### PR TITLE
Build script download progress

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'de.undercouch:gradle-download-task:1.2'
     compile 'nu.studer:java-ordered-properties:1.0.1'
     compile 'org.apache.maven:maven-ant-tasks:2.1.3'
     compile 'bcel:bcel:5.1'


### PR DESCRIPTION
When the info logging level is enabled then the eclipse sdk download status is visible.
This PR depends on https://github.com/eclipse/buildship/pull/8
