### PR TITLE
Dependency version mapping

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,27 @@ eclipseBuild {
             "org.eclipse.swtbot.eclipse.feature.group",
             "org.eclipse.swtbot.ide.feature.group"
         ]
+        versionMapping = [
+            'org.eclipse.core.runtime' : '3.6.0.v20100505',
+            'org.eclipse.core.resources' : '3.6.1.R36x_v20110131-1630',
+            'org.eclipse.core.variables' : '3.2.400.v20100505',
+            'org.eclipse.core.filesystem' : '1.3.1.R36x_v20100727-0745',
+            'org.eclipse.jdt.core' : '3.6.2.v_A76_R36x',
+            'org.eclipse.jdt.junit.core' : '3.6.1.r361_v20100825-0800',
+            'org.eclipse.jdt.launching' : '3.5.200.v20110105_r362',
+            'org.eclipse.debug.core' : '3.6.0.v20100519',
+            'org.eclipse.help' : '3.5.0.v20100524',
+            'org.eclipse.ui' : '3.6.2.M20110203-1100',
+            'org.eclipse.ui.ide' : '3.6.2.M20101201-0800',
+            'org.eclipse.ui.console' : '3.5.0.v20100526',
+            'org.eclipse.ui.editors' : '3.6.1.r361_v20100825-0800',
+            'org.eclipse.ui.views' : '3.5.1.M20110202-0800',
+            'org.eclipse.debug.ui' : '3.6.3.v20101201_r362',
+            'org.eclipse.jdt.ui' : '3.6.2.r362_v20110203',
+            "org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}" : '3.7.2.v3740f',
+            'org.eclipse.swtbot.eclipse.finder' : '2.2.1.201402241301',
+            'org.eclipse.swtbot.junit4_x' : '2.2.1.201402241301'
+        ]
     }
 
     targetPlatform {
@@ -35,6 +56,27 @@ eclipseBuild {
             "org.junit",
             "org.eclipse.swtbot.eclipse.feature.group",
             "org.eclipse.swtbot.ide.feature.group"
+        ]
+        versionMapping = [
+            'org.eclipse.core.runtime' : '3.7.0.v20110110',
+            'org.eclipse.core.resources' : '3.7.101.v20120125-1505',
+            'org.eclipse.core.variables' : '3.2.500.v20110928-1503',
+            'org.eclipse.core.filesystem' : '1.3.100.v20110423-0524',
+            'org.eclipse.jdt.core' : '3.7.3.v20120119-1537',
+            'org.eclipse.jdt.junit.core' : '3.7.0.v20110928-1453',
+            'org.eclipse.jdt.launching' : '3.6.1.v20111006_r372',
+            'org.eclipse.debug.core' : '3.7.1.v20111129-2031',
+            'org.eclipse.help' : '3.5.100.v20110426',
+            'org.eclipse.ui' : '3.7.0.v20110928-1505',
+            'org.eclipse.ui.ide' : '3.7.0.v20110928-1505',
+            'org.eclipse.ui.console' : '3.5.100.v20111007_r372',
+            'org.eclipse.ui.editors' : '3.7.0.v20110928-1504',
+            'org.eclipse.ui.views' : '3.6.0.v20110928-1505',
+            'org.eclipse.debug.ui' : '3.7.102.v20111129-1423_r372',
+            'org.eclipse.jdt.ui' : '3.7.2.v20120109-1427',
+            "org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}" : '3.7.2.v3740f',
+            'org.eclipse.swtbot.eclipse.finder' : '2.2.1.201402241301',
+            'org.eclipse.swtbot.junit4_x' : '2.2.1.201402241301'
         ]
     }
 
@@ -51,6 +93,27 @@ eclipseBuild {
             "org.eclipse.swtbot.eclipse.feature.group",
             "org.eclipse.swtbot.ide.feature.group"
         ]
+        versionMapping = [
+            'org.eclipse.core.runtime' : '3.8.0.v20120912-155025',
+            'org.eclipse.core.resources' : '3.8.1.v20121114-124432',
+            'org.eclipse.core.variables' : '3.2.600.v20120521-2012',
+            'org.eclipse.core.filesystem' : '1.3.200.v20130115-145044',
+            'org.eclipse.jdt.core' : '3.8.3.v20130121-145325',
+            'org.eclipse.jdt.junit.core' : '3.7.100.v20120523-1257',
+            'org.eclipse.jdt.launching' : '3.6.101.v20130111-183046',
+            'org.eclipse.debug.core' : 'org.eclipse.debug.core',
+            'org.eclipse.help' : '3.6.0.v20120912-134126',
+            'org.eclipse.ui' : '3.104.0.v20121024-145224',
+            'org.eclipse.ui.ide' : '3.8.2.v20121106-165923',
+            'org.eclipse.ui.console' : '3.5.100.v20120521-2012',
+            'org.eclipse.ui.editors' : '3.8.0.v20120523-1540',
+            'org.eclipse.ui.views' : '3.6.100.v20120705-114010',
+            'org.eclipse.debug.ui' : '3.8.2.v20130130-171415',
+            'org.eclipse.jdt.ui' : '3.8.2.v20130107-165834',
+            "org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}" : '3.102.1.v20140206-1358',
+            'org.eclipse.swtbot.eclipse.finder' : '2.2.1.201402241301',
+            'org.eclipse.swtbot.junit4_x' : '2.2.1.201402241301'
+        ]
     }
 
     targetPlatform {
@@ -65,6 +128,28 @@ eclipseBuild {
             "org.junit",
             "org.eclipse.swtbot.eclipse.feature.group",
             "org.eclipse.swtbot.ide.feature.group"
+        ]
+        
+        versionMapping = [
+            'org.eclipse.core.runtime' : '3.9.100.v20131218-1515',
+            'org.eclipse.core.resources' : '3.8.101.v20130717-0806',
+            'org.eclipse.core.variables' : '3.2.700.v20130402-1741',
+            'org.eclipse.core.filesystem' : '1.4.0.v20130514-1240',
+            'org.eclipse.jdt.core' : '3.9.2.v20140114-1555',
+            'org.eclipse.jdt.junit.core' : '3.7.200.v20130514-1154',
+            'org.eclipse.jdt.launching' : '3.7.1.v20131218-1102',
+            'org.eclipse.debug.core' : '3.8.0.v20130514-0954',
+            'org.eclipse.help' : '3.6.0.v20130326-1254',
+            'org.eclipse.ui' : '3.105.0.v20130522-1122',
+            'org.eclipse.ui.ide' : '3.9.2.v20131004-0923',
+            'org.eclipse.ui.console' : '3.5.200.v20130514-0954',
+            'org.eclipse.ui.editors' : '3.8.100.v20130513-1637',
+            'org.eclipse.ui.views' : '3.6.100.v20130326-1250',
+            'org.eclipse.debug.ui' : '3.9.0.v20130516-1713',
+            'org.eclipse.jdt.ui' : '3.9.2.v20131106-1600',
+            "org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}" : '3.102.1.v20140206-1358',
+            'org.eclipse.swtbot.eclipse.finder' : '2.2.1.201402241301',
+            'org.eclipse.swtbot.junit4_x' : '2.2.1.201402241301'
         ]
     }
 
@@ -81,6 +166,27 @@ eclipseBuild {
             "org.eclipse.swtbot.eclipse.feature.group",
             "org.eclipse.swtbot.ide.feature.group"
         ]
+        versionMapping = [
+            'org.eclipse.core.runtime' : '3.10.0.v20140318-2214',
+            'org.eclipse.core.resources' : '3.9.1.v20140825-1431',
+            'org.eclipse.core.variables' : '3.2.800.v20130819-1716',
+            'org.eclipse.core.filesystem' : '1.4.100.v20140514-1614',
+            'org.eclipse.jdt.core' : '3.10.2.v20150120-1634',
+            'org.eclipse.jdt.junit.core' : '3.7.300.v20140409-1618',
+            'org.eclipse.jdt.launching' : '3.7.102.v20141111-0953',
+            'org.eclipse.debug.core' : '3.9.1.v20140805-1629',
+            'org.eclipse.help' : '3.6.0.v20130326-1254',
+            'org.eclipse.ui' : '3.106.1.v20141002-1150',
+            'org.eclipse.ui.ide' : '3.10.2.v20141118-1227',
+            'org.eclipse.ui.console' : '3.5.300.v20140424-1437',
+            'org.eclipse.ui.editors' : '3.8.200.v20140401-1310',
+            'org.eclipse.ui.views' : '3.7.0.v20140408-0703',
+            'org.eclipse.debug.ui' : '3.10.2.v20141014-1039',
+            'org.eclipse.jdt.ui' : '3.10.2.v20141014-1419',
+            "org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}" : '3.103.2.v20150203-1351',
+            'org.eclipse.swtbot.eclipse.finder' : '2.2.1.201402241301',
+            'org.eclipse.swtbot.junit4_x' : '2.2.1.201402241301'
+        ]
     }
 
     targetPlatform {
@@ -95,6 +201,27 @@ eclipseBuild {
             "org.junit",
             "org.eclipse.swtbot.eclipse.feature.group",
             "org.eclipse.swtbot.ide.feature.group"
+        ]       
+        versionMapping = [
+            "org.eclipse.core.runtime" : "3.10.0.v20150112-1422",
+            "org.eclipse.core.resources" : "3.9.100.v20150114-1351",
+            "org.eclipse.core.variables" : "3.2.800.v20130819-1716",
+            "org.eclipse.core.filesystem" : "1.4.200.v20150115-1924",
+            "org.eclipse.jdt.core" : "3.11.0.v20150126-2015",
+            "org.eclipse.jdt.junit.core" : "3.7.300.v20141114-1947",
+            "org.eclipse.jdt.launching" : "3.7.200.v20150116-1130",
+            "org.eclipse.debug.core" : "3.10.0.v20141009-1205",
+            "org.eclipse.help" : "3.6.0.v20130326-1254",
+            "org.eclipse.ui" : "3.107.0.v20150107-0903",
+            "org.eclipse.ui.ide" : "3.10.100.v20150126-1117",
+            "org.eclipse.ui.console" : "3.6.0.v20141210-1834",
+            "org.eclipse.ui.editors" : "3.9.0.v20141118-1526",
+            "org.eclipse.ui.views" : "3.7.100.v20141003-0011",
+            "org.eclipse.debug.ui" : "3.11.0.v20150116-1131",
+            "org.eclipse.jdt.ui" : "3.10.100.v20150116-1347",
+            "org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}" : "3.7.2.v3740f",
+            "org.eclipse.swtbot.eclipse.finder" : "2.2.1.201402241301",
+            "org.eclipse.swtbot.junit4_x" : "2.2.1.201402241301"
         ]
     }
 }

--- a/buildSrc/src/main/groovy/eclipsebuild/BundlePlugin.groovy
+++ b/buildSrc/src/main/groovy/eclipsebuild/BundlePlugin.groovy
@@ -25,7 +25,12 @@ import org.gradle.api.tasks.Copy
  * It makes OSGi-related variables like os, ws and arch available for the project (via project.ext)
  * for building against platform-dependent dependencies. An example dependency on SWT:
  * <pre>
- * compile "eclipse:org.eclipse.swt.${project.ext.ws}.${project.ext.os}.${project.ext.arch}:+"
+ * compile "eclipse:org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}:+"
+ * </pre>
+ * A {@code withDependency} method is declared to use the target platform's version mapping and fix
+ * the dependency version to a concrete value. For example:
+ * <pre>
+ * compile withDependencies("org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}")
  * </pre>
  * To construct the output jar the plugin loads the contents of the <code>build.properties</code>
  * file and sync it with the jar's content.
@@ -55,10 +60,7 @@ class BundlePlugin implements Plugin<Project> {
         project.plugins.apply(JavaPlugin)
 
         // make new variables for the build.gradle file e.g. for platform-dependent dependencies
-        project.ext.ECLIPSE_OS = Constants.os
-        project.ext.ECLIPSE_WS = Constants.ws
-        project.ext.ECLIPSE_ARCH = Constants.arch
-        project.ext.ECLIPSE_VERSION = Config.on(project).eclipseVersion
+        Constants.exposePublicConstantsFor(project)
 
         // add new configuration scope
         project.configurations.create('bundled')
@@ -183,7 +185,10 @@ class BundlePlugin implements Plugin<Project> {
     }
 
     static void addTaskUpdateLibs(Project project) {
-        project.task(TASK_NAME_UPDATE_LIBS, dependsOn: [TASK_NAME_COPY_LIBS, TASK_NAME_UPDATE_MANIFEST]) {
+        project.task(TASK_NAME_UPDATE_LIBS, dependsOn: [
+            TASK_NAME_COPY_LIBS,
+            TASK_NAME_UPDATE_MANIFEST
+        ]) {
             group = Constants.gradleTaskGroupName
             description = 'Copies the bundled dependencies into the lib folder and updates the manifest file.'
         }

--- a/buildSrc/src/main/groovy/eclipsebuild/Constants.groovy
+++ b/buildSrc/src/main/groovy/eclipsebuild/Constants.groovy
@@ -11,6 +11,8 @@
 
 package eclipsebuild
 
+import org.gradle.api.Project;
+
 import org.gradle.internal.os.OperatingSystem
 
 /**
@@ -97,6 +99,15 @@ class Constants {
         } else {
             return new URL("http://www.eclipse.org/downloads/download.php?file=/eclipse/downloads/drops4/R-4.4.2-201502041700/eclipse-SDK-4.4.2-${getOs()}-${getWs()}${archInUrl}.tar.gz&r=1");
         }
+    }
+
+    /**
+     * Enable variables in the target project's build script.
+     */
+    static exposePublicConstantsFor(Project project) {
+        project.ext.ECLIPSE_OS = os
+        project.ext.ECLIPSE_WS = ws
+        project.ext.ECLIPSE_ARCH = arch
     }
 
 }

--- a/docs/pluginbuild/Usage.md
+++ b/docs/pluginbuild/Usage.md
@@ -21,10 +21,10 @@ the build and makes all Eclipse plugins available for dependency resolution. The
 The set of supported target platforms are declared in the root _build.gradle_ file. For example:
 
     apply plugin: eclipsebuild.BuildDefinitionPlugin
-
+    
     eclipseBuild {
         defaultEclipseVersion = '44'
-
+    
         targetPlatform {
             eclipseVersion = '44'
             sdkVersion = "4.4.2.M20150204-1700"
@@ -36,8 +36,11 @@ The set of supported target platforms are declared in the root _build.gradle_ fi
                "org.eclipse.swtbot.eclipse.feature.group",
                "org.eclipse.swtbot.ide.feature.group"
             ]
+            versionMapping = [
+                'org.eclipse.core.runtime' : '3.10.0.v20140318-2214'
+            ]
         }
-
+    
         targetPlatform {
              eclipseVersion = '43'
              ...
@@ -66,6 +69,13 @@ customized by specifying the `targetPlatformsDir` Gradle project property:
     gradle installTargetPlatform -PtargetPlatformsDir=/path/to/target/platform
 
 
+The `versionMapping` can be used to define exact plugin dependency versions per target platform. A bundle can define a dependency 
+through the {@code withDependency()} method like
+
+    compile withDependency("org.eclipse.core.runtime")
+
+If active target platform has a version mapped for the dependency then that version is used, otherwise an unbound version range (+) is applied.
+
 ### BundlePlugin
 
 The `BundlePlugin` Gradle plugin knows how to build Eclipse plugins and needs to be applied on the plugin project(s). The plugin creates
@@ -84,7 +94,6 @@ achieved by declaring `bundled` dependencies. For example:
 
 The dependencies of the `bundled` configuration are used by the `updateLibs` task. This task downloads the transitive
 dependencies into the _lib_ folder, updates the manifest file to reference these dependencies and updates the _.classpath_ file.
-
 
 ### TestBundlePlugin
 

--- a/org.eclipse.buildship.core/build.gradle
+++ b/org.eclipse.buildship.core/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: eclipsebuild.BundlePlugin
 
 dependencies {
-    compile "eclipse:org.eclipse.core.runtime:+"
-    compile "eclipse:org.eclipse.core.resources:+"
-    compile "eclipse:org.eclipse.core.variables:+"
-    compile "eclipse:org.eclipse.core.filesystem:+"
-    compile "eclipse:org.eclipse.jdt.core:+"
-    compile "eclipse:org.eclipse.jdt.junit.core:+"
-    compile "eclipse:org.eclipse.jdt.launching:+"
-    compile "eclipse:org.eclipse.debug.core:+"
+    compile withDependency("org.eclipse.core.runtime")
+    compile withDependency("org.eclipse.core.resources")
+    compile withDependency("org.eclipse.core.variables")
+    compile withDependency("org.eclipse.core.filesystem")
+    compile withDependency("org.eclipse.jdt.core")
+    compile withDependency("org.eclipse.jdt.junit.core")
+    compile withDependency("org.eclipse.jdt.launching")
+    compile withDependency("org.eclipse.debug.core")
 
     bundled "com.gradleware.tooling:toolingmodel:$commonsLibVersion"
     bundled "org.slf4j:slf4j-simple:$slf4jLibVersion"

--- a/org.eclipse.buildship.ui.test/build.gradle
+++ b/org.eclipse.buildship.ui.test/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'groovy'
 dependencies {
     compile project(':org.eclipse.buildship.core')
     compile project(':org.eclipse.buildship.ui')
-    compile "eclipse:org.eclipse.swtbot.eclipse.finder:+"
-    compile "eclipse:org.eclipse.swtbot.junit4_x:+"
+    compile withDependency("org.eclipse.swtbot.eclipse.finder")
+    compile withDependency("org.eclipse.swtbot.junit4_x")
 
     bundled "org.spockframework:spock-core:$spockLibVersion"
     bundled "cglib:cglib-nodep:$cglibLibVersion"

--- a/org.eclipse.buildship.ui/build.gradle
+++ b/org.eclipse.buildship.ui/build.gradle
@@ -2,14 +2,14 @@ apply plugin: eclipsebuild.BundlePlugin
 
 dependencies {
     compile project(':org.eclipse.buildship.core')
-    compile "eclipse:org.eclipse.help:+"
-    compile "eclipse:org.eclipse.ui:+"
-    compile "eclipse:org.eclipse.ui.ide:+"
-    compile "eclipse:org.eclipse.ui.console:+"
-    compile "eclipse:org.eclipse.ui.editors:+"
-    compile "eclipse:org.eclipse.ui.views:+"
-    compile "eclipse:org.eclipse.debug.ui:+"
-    compile "eclipse:org.eclipse.jdt.ui:+"
-    compile "eclipse:org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}:+"
+    compile withDependency("org.eclipse.help")
+    compile withDependency("org.eclipse.ui")
+    compile withDependency("org.eclipse.ui.ide")
+    compile withDependency("org.eclipse.ui.console")
+    compile withDependency("org.eclipse.ui.editors")
+    compile withDependency("org.eclipse.ui.views")
+    compile withDependency("org.eclipse.debug.ui")
+    compile withDependency("org.eclipse.jdt.ui")
+    compile withDependency("org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}")
 }
 


### PR DESCRIPTION
Initialize versionMapping field with empty map
Use withDependency() to define plugin dependences in the build scripts
Add version mapping for all target platforms
Debug logging for version mapping
Enable variable substitution for project specific dependencies
Document the changes

Signed-off-by: Donat Csikos <csdonat@gmail.com>