### PR TITLE
Implement changes proposed in the 'Revisit current Task View' story

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/FilterPrivateTasksAction.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/FilterPrivateTasksAction.java
@@ -31,7 +31,7 @@ public final class FilterPrivateTasksAction extends Action {
         super(null, AS_CHECK_BOX);
         this.taskViewer = Preconditions.checkNotNull(taskViewer);
 
-        setToolTipText(TaskViewMessages.Action_FilterPrivateTasks_Tooltip);
+        setText(TaskViewMessages.Action_FilterPrivateTasks_Text);
         setImageDescriptor(PluginImages.TASK.withState(PluginImage.ImageState.ENABLED).getOverlayImageDescriptor(
                 ImmutableList.of(PluginImages.OVERLAY_PRIVATE_TASK.withState(PluginImage.ImageState.ENABLED))));
         setChecked(taskViewer.getState().isPrivateTasksVisible());

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/FilterProjectTasksAction.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/FilterProjectTasksAction.java
@@ -31,7 +31,7 @@ public final class FilterProjectTasksAction extends Action {
         super(null, AS_CHECK_BOX);
         this.taskViewer = Preconditions.checkNotNull(taskViewer);
 
-        setToolTipText(TaskViewMessages.Action_FilterProjectTasks_Tooltip);
+        setText(TaskViewMessages.Action_FilterProjectTasks_Text);
         setImageDescriptor(PluginImages.TASK.withState(PluginImage.ImageState.ENABLED).getOverlayImageDescriptor(
                 ImmutableList.of(PluginImages.OVERLAY_PROJECT_TASK.withState(PluginImage.ImageState.ENABLED))));
         setChecked(taskViewer.getState().isProjectTasksVisible());

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/FilterTaskSelectorsAction.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/FilterTaskSelectorsAction.java
@@ -31,7 +31,7 @@ public final class FilterTaskSelectorsAction extends Action {
         super(null, AS_CHECK_BOX);
         this.taskViewer = Preconditions.checkNotNull(taskViewer);
 
-        setToolTipText(TaskViewMessages.Action_FilterTaskSelectors_Tooltip);
+        setText(TaskViewMessages.Action_FilterTaskSelectors_Text);
         setImageDescriptor(PluginImages.TASK.withState(ImageState.ENABLED).getOverlayImageDescriptor(
                 ImmutableList.of(PluginImages.OVERLAY_TASK_SELECTOR.withState(ImageState.ENABLED))));
         setChecked(taskViewer.getState().isTaskSelectorsVisible());

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/SortTasksByTypeAction.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/SortTasksByTypeAction.java
@@ -32,7 +32,7 @@ public final class SortTasksByTypeAction extends Action {
         super(null, IAction.AS_CHECK_BOX);
         this.taskView = Preconditions.checkNotNull(taskView);
 
-        setToolTipText(TaskViewMessages.Action_SortByType_Tooltip);
+        setText(TaskViewMessages.Action_SortByType_Text);
         setImageDescriptor(PluginImages.SORT_BY_TYPE.withState(PluginImage.ImageState.ENABLED).getImageDescriptor());
         setChecked(taskView.getState().isSortByType());
     }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/SortTasksByVisibilityAction.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/SortTasksByVisibilityAction.java
@@ -33,7 +33,7 @@ public final class SortTasksByVisibilityAction extends Action {
         super(null, IAction.AS_CHECK_BOX);
         this.taskView = Preconditions.checkNotNull(taskView);
 
-        setToolTipText(TaskViewMessages.Action_SortByVisibility_Tooltip);
+        setText(TaskViewMessages.Action_SortByVisibility_Text);
         setImageDescriptor(PluginImages.SORT_BY_VISIBILITY.withState(PluginImage.ImageState.ENABLED).getImageDescriptor());
         setChecked(taskView.getState().isSortByVisibility());
     }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/TaskViewMessages.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/TaskViewMessages.java
@@ -26,6 +26,11 @@ public final class TaskViewMessages extends NLS {
     public static String Tree_Column_Name_Text;
     public static String Tree_Column_Description_Text;
 
+    public static String Action_FilterProjectTasks_Text;
+    public static String Action_FilterTaskSelectors_Text;
+    public static String Action_FilterPrivateTasks_Text;
+    public static String Action_SortByType_Text;
+    public static String Action_SortByVisibility_Text;
     public static String Action_RunTasks_Text;
     public static String Action_RunDefaultTasks_Text;
     public static String Action_OpenRunConfiguration_Text;
@@ -33,11 +38,6 @@ public final class TaskViewMessages extends NLS {
     public static String Action_Refresh_Text;
     public static String Action_ShowTreeHeader_Text;
 
-    public static String Action_FilterProjectTasks_Tooltip;
-    public static String Action_FilterTaskSelectors_Tooltip;
-    public static String Action_FilterPrivateTasks_Tooltip;
-    public static String Action_SortByType_Tooltip;
-    public static String Action_SortByVisibility_Tooltip;
     public static String Action_RunTasks_Tooltip;
     public static String Action_RunDefaultTasks_Tooltip;
     public static String Action_OpenRunConfiguration_Tooltip;

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/TaskViewState.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/TaskViewState.java
@@ -44,7 +44,7 @@ public final class TaskViewState {
         // in Eclipse 3.6 the method InstanceScope.INSTANCE does not exist
         @SuppressWarnings("deprecation")
         IEclipsePreferences prefs = new InstanceScope().getNode(UiPlugin.PLUGIN_ID);
-        this.projectTasksVisible = prefs.getBoolean(this.PREF_PROJECT_TASKS_VISIBLE, true);
+        this.projectTasksVisible = prefs.getBoolean(this.PREF_PROJECT_TASKS_VISIBLE, false);
         this.taskSelectorsVisible = prefs.getBoolean(this.PREF_TASK_SELECTORS_VISIBLE, true);
         this.privateTasksVisible = prefs.getBoolean(this.PREF_PRIVATE_TASKS_VISIBLE, false);
         this.sortByType = prefs.getBoolean(this.PREF_SORT_BY_TYPE, true);

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/UiContributionManager.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/taskview/UiContributionManager.java
@@ -34,9 +34,10 @@ import org.eclipse.buildship.ui.generic.SelectionSpecificAction;
  */
 public final class UiContributionManager {
 
-    private static final String TASK_MISC_GROUP = "taskMiscGroup";
-    private static final String TASK_FILTERING_GROUP = "taskFilteringGroup";
-    private static final String TASK_SORTING_GROUP = "taskSortingGroup";
+    private static final String TOOLBAR_MISC_GROUP = "toolbarMiscGroup";
+    private static final String MENU_SORTING_GROUP = "toolbarSortingGroup";
+    private static final String MENU_FILTERING_GROUP = "menuFilteringGroup";
+    private static final String MENU_MISC_GROUP = "menuMiscGroup";
 
     private final TaskView taskView;
     private final ImmutableList<SelectionSpecificAction> managedActions;
@@ -55,7 +56,7 @@ public final class UiContributionManager {
         RunDefaultTasksAction runDefaultTasksAction = new RunDefaultTasksAction(UiPluginConstants.RUN_DEFAULT_TASKS_COMMAND_ID);
         OpenRunConfigurationAction openRunConfigurationAction = new OpenRunConfigurationAction(UiPluginConstants.OPEN_RUN_CONFIGURATION_COMMAND_ID);
         OpenBuildScriptAction openBuildScriptAction = new OpenBuildScriptAction(UiPluginConstants.OPEN_BUILD_SCRIPT_COMMAND_ID);
-        this.managedActions = ImmutableList.<SelectionSpecificAction>of(runTasksAction, runDefaultTasksAction, openRunConfigurationAction, openBuildScriptAction);
+        this.managedActions = ImmutableList.<SelectionSpecificAction> of(runTasksAction, runDefaultTasksAction, openRunConfigurationAction, openBuildScriptAction);
 
         this.managedActionsSelectionChangedListener = new ActionEnablingSelectionChangedListener(taskView.getTreeViewer(), this.managedActions);
         this.treeViewerSelectionChangeListener = new TreeViewerSelectionChangeListener(taskView);
@@ -77,22 +78,22 @@ public final class UiContributionManager {
 
     private void fillToolbar() {
         IToolBarManager manager = this.taskView.getViewSite().getActionBars().getToolBarManager();
-
-        manager.add(new GroupMarker(TASK_MISC_GROUP));
-        manager.appendToGroup(TASK_MISC_GROUP, new RefreshViewAction(UiPluginConstants.REFRESH_TASKVIEW_COMMAND_ID));
-        manager.appendToGroup(TASK_MISC_GROUP, new ToggleLinkToSelectionAction(this.taskView));
-        manager.add(new Separator(TASK_FILTERING_GROUP));
-        manager.appendToGroup(TASK_FILTERING_GROUP, new FilterTaskSelectorsAction(this.taskView));
-        manager.appendToGroup(TASK_FILTERING_GROUP, new FilterProjectTasksAction(this.taskView));
-        manager.appendToGroup(TASK_FILTERING_GROUP, new FilterPrivateTasksAction(this.taskView));
-        manager.add(new Separator(TASK_SORTING_GROUP));
-        manager.appendToGroup(TASK_SORTING_GROUP, new SortTasksByTypeAction(this.taskView));
-        manager.appendToGroup(TASK_SORTING_GROUP, new SortTasksByVisibilityAction(this.taskView));
+        manager.add(new GroupMarker(TOOLBAR_MISC_GROUP));
+        manager.appendToGroup(TOOLBAR_MISC_GROUP, new RefreshViewAction(UiPluginConstants.REFRESH_TASKVIEW_COMMAND_ID));
+        manager.appendToGroup(TOOLBAR_MISC_GROUP, new ToggleLinkToSelectionAction(this.taskView));
     }
 
     private void fillMenu() {
         IMenuManager manager = this.taskView.getViewSite().getActionBars().getMenuManager();
-        manager.add(new ToggleShowTreeHeaderAction(this.taskView));
+        manager.add(new Separator(MENU_FILTERING_GROUP));
+        manager.appendToGroup(MENU_FILTERING_GROUP, new FilterTaskSelectorsAction(this.taskView));
+        manager.appendToGroup(MENU_FILTERING_GROUP, new FilterProjectTasksAction(this.taskView));
+        manager.appendToGroup(MENU_FILTERING_GROUP, new FilterPrivateTasksAction(this.taskView));
+        manager.add(new Separator(MENU_SORTING_GROUP));
+        manager.appendToGroup(MENU_SORTING_GROUP, new SortTasksByTypeAction(this.taskView));
+        manager.appendToGroup(MENU_SORTING_GROUP, new SortTasksByVisibilityAction(this.taskView));
+        manager.add(new Separator(MENU_MISC_GROUP));
+        manager.appendToGroup(MENU_MISC_GROUP, new ToggleShowTreeHeaderAction(this.taskView));
     }
 
     private void fillContextMenu() {

--- a/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/taskview/TaskViewMessages.properties
+++ b/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/taskview/TaskViewMessages.properties
@@ -15,6 +15,11 @@ Label_Reload_Problem=There was a problem loading the content of the task view. C
 Tree_Column_Name_Text=Name
 Tree_Column_Description_Text=Description
 
+Action_FilterProjectTasks_Text=Show Project Tasks
+Action_FilterTaskSelectors_Text=Show Task Selectors
+Action_FilterPrivateTasks_Text=Show All Tasks
+Action_SortByType_Text=Order Tasks by Type
+Action_SortByVisibility_Text=Order Tasks by Visibility
 Action_RunTasks_Text=Run Gradle Tasks
 Action_RunDefaultTasks_Text=Run Default Gradle Tasks
 Action_OpenRunConfiguration_Text=Open Gradle Run Configuration...
@@ -22,11 +27,6 @@ Action_OpenBuildScript_Text=Open Gradle Build Script
 Action_Refresh_Text=Refresh
 Action_ShowTreeHeader_Text=Show Header
 
-Action_FilterProjectTasks_Tooltip=Show the project tasks
-Action_FilterTaskSelectors_Tooltip=Show the task selectors
-Action_FilterPrivateTasks_Tooltip=Show the private tasks
-Action_SortByType_Tooltip=Order the tasks by type
-Action_SortByVisibility_Tooltip=Order the tasks by visibility
 Action_RunTasks_Tooltip=Run the selected tasks
 Action_RunDefaultTasks_Tooltip=Run the default tasks of the selected project
 Action_OpenRunConfiguration_Tooltip=Open the Run Configuration for the selected tasks


### PR DESCRIPTION
Don't show project tasks by default
Move filter actions to the task view's menu
Rename 'Include private tasks' to 'Show All Tasks'
Cleanup i18n resources