### PR TITLE
Change color of run configuration arguments shown in the Gradle Console

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/console/ProcessStreams.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/console/ProcessStreams.java
@@ -20,6 +20,13 @@ import java.io.OutputStream;
 public interface ProcessStreams {
 
     /**
+     * Returns a stream dedicated for displaying configuration information.
+     *
+     * @return output stream for configuration
+     */
+    OutputStream getConfiguration();
+
+    /**
      * Returns the default output stream.
      *
      * @return the default output stream

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/console/internal/StdProcessStreamsProvider.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/console/internal/StdProcessStreamsProvider.java
@@ -29,6 +29,11 @@ public final class StdProcessStreamsProvider implements ProcessStreamsProvider {
     private final ProcessStreams stdStreams = new ProcessStreams() {
 
         @Override
+        public OutputStream getConfiguration() {
+            return System.err;
+        }
+
+        @Override
         public InputStream getInput() {
             return System.in;
         }
@@ -47,7 +52,6 @@ public final class StdProcessStreamsProvider implements ProcessStreamsProvider {
         public void close() {
             // do nothing since we never want to close the std streams
         }
-
     };
 
     @Override

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleConfigurationDelegateJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleConfigurationDelegateJob.java
@@ -133,7 +133,7 @@ public final class RunGradleConfigurationDelegateJob extends ToolingApiJob {
         request.cancellationToken(getToken());
 
         // print the applied run configuration settings at the beginning of the console output
-        writeRunConfigurationDescription(configurationAttributes, processStreams.getOutput());
+        writeRunConfigurationDescription(configurationAttributes, processStreams.getConfiguration());
 
         // attach a test progress listener if the run configuration has the test progress
         // visualization enabled


### PR DESCRIPTION
Create dedicated output stream in GradleConsole where configuration information is printed