### PR TITLE
Don't recreate project descriptors if they already exist

### DIFF
--- a/.project
+++ b/.project
@@ -28,15 +28,6 @@
 			</matcher>
 		</filter>
 		<filter>
-			<id>1429025690220</id>
-			<name></name>
-			<type>10</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-.settings</arguments>
-			</matcher>
-		</filter>
-		<filter>
 			<id>1429025690244</id>
 			<name></name>
 			<type>10</type>

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/projectimport/ProjectImportJobTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/projectimport/ProjectImportJobTest.groovy
@@ -1,0 +1,111 @@
+package org.eclipse.buildship.core.projectimport
+
+import spock.lang.Unroll;
+
+import com.gradleware.tooling.toolingmodel.repository.ModelRepository;
+import com.gradleware.tooling.toolingmodel.repository.ModelRepositoryProvider;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+
+import org.eclipse.buildship.core.CorePlugin;
+import org.eclipse.buildship.core.configuration.GradleProjectBuilder;
+import org.eclipse.buildship.core.configuration.GradleProjectNature;
+import org.eclipse.buildship.core.gradle.GradleDistributionWrapper;
+import org.eclipse.buildship.core.gradle.GradleDistributionWrapper.DistributionType;
+import org.eclipse.buildship.core.workspace.WorkspaceOperations;
+
+import org.junit.rules.TemporaryFolder;
+import org.junit.Rule;
+import spock.lang.Specification
+
+class ProjectImportJobTest extends Specification {
+
+    @Rule
+    TemporaryFolder tempFolder
+
+    def cleanup() {
+        CorePlugin.workspaceOperations().deleteAllProjects(null)
+    }
+
+    def "Project import job creates a new project in the workspace"(boolean projectDescriptorExists) {
+        setup:
+        File rootProject = newProject(false, projectDescriptorExists)
+        ProjectImportJob job = newProjectImportJob(rootProject)
+
+        when:
+        job.schedule()
+        job.join()
+
+        then:
+        CorePlugin.workspaceOperations().findProjectByName(rootProject.name).present
+
+        where:
+        projectDescriptorExists << [false, true]
+    }
+
+    def "Project descriptors should be created if and only if they don't exist"(boolean applyJavaPlugin, boolean projectDescriptorExists, String descriptorComment) {
+        setup:
+        File rootProject = newProject(applyJavaPlugin, projectDescriptorExists)
+        ProjectImportJob job = newProjectImportJob(rootProject)
+
+        when:
+        job.schedule()
+        job.join()
+
+        then:
+        new File(rootProject, '.project').exists()
+        new File(rootProject, '.classpath').exists() == applyJavaPlugin
+        CorePlugin.workspaceOperations().findEclipseProject(rootProject).get().getComment() == descriptorComment
+
+        where:
+        applyJavaPlugin | projectDescriptorExists | descriptorComment
+        false           | false                   | ''         // the comment from the generated descriptor
+        false           | true                    | 'original' // the comment from the original descriptor
+        true            | false                   | ''
+        true            | true                    | 'original'
+    }
+
+    def "Imported projects always have Gradle builder and nature"(boolean projectDescriptorExists) {
+        setup:
+        File rootProject = newProject(false, projectDescriptorExists)
+        ProjectImportJob job = newProjectImportJob(rootProject)
+
+        when:
+        job.schedule()
+        job.join()
+        def project = CorePlugin.workspaceOperations().findProjectByName(rootProject.name).get()
+
+        then:
+        GradleProjectNature.INSTANCE.isPresentOn(project)
+        project.description.buildSpec.find { it.getBuilderName().equals(GradleProjectBuilder.INSTANCE.ID) }
+
+        where:
+        projectDescriptorExists << [false, true]
+    }
+
+    def newProject(boolean applyJavaPlugin, boolean projectDescriptorExists) {
+        def root = tempFolder.newFolder("simple-project")
+        def buildGradle = new File(root, "build.gradle")
+        def sourceFile = new File(root, 'src/main/java/')
+        sourceFile.mkdirs()
+        buildGradle.text = applyJavaPlugin ? "apply plugin: 'java'" : " "
+        if (projectDescriptorExists) {
+            def dotProject = new File(root, '.project')
+            dotProject.text = '''<?xml version="1.0" encoding="UTF-8"?><projectDescription><name>simple-project</name><comment>original</comment><projects>
+               </projects><buildSpec></buildSpec><natures></natures></projectDescription>'''
+            if (applyJavaPlugin) {
+                def dotClasspath = new File(root, '.classpath')
+                dotClasspath.text = '''<?xml version="1.0" encoding="UTF-8"?><classpath><classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+                    <classpathentry kind="src" path="src/main/java"/><classpathentry kind="output" path="bin"/></classpath>'''
+            }
+        }
+        root
+    }
+
+    def newProjectImportJob(File location) {
+        ProjectImportConfiguration configuration = new ProjectImportConfiguration()
+        configuration.setGradleDistribution(GradleDistributionWrapper.from(DistributionType.WRAPPER, ""))
+        configuration.setProjectDir(location)
+        new ProjectImportJob(configuration)
+    }
+}

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/WorkspaceOperations.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/WorkspaceOperations.java
@@ -18,6 +18,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IJavaProject;
 
@@ -52,6 +53,17 @@ public interface WorkspaceOperations {
     void deleteAllProjects(IProgressMonitor monitor);
 
     /**
+     * Checks if a target folder contains a valid Eclipse project. If it finds a project descriptor
+     * it parses it and returns the corresponding {@link IProjectDescription} object. If no
+     * .project file is present or the the descriptor file contains invalid data then an absent
+     * value is returned.
+     *
+     * @param location the location to search for existing projects
+     * @return the project description object
+     */
+    Optional<IProjectDescription> findEclipseProject(File location);
+
+    /**
      * Creates a new {@link IProject} in the workspace using the specified name and location. The
      * location must exist and no project with the specified name must currently exist in the
      * workspace. The new project gets the specified natures applied. Those child projects whose
@@ -67,6 +79,18 @@ public interface WorkspaceOperations {
      * @throws org.eclipse.buildship.core.GradlePluginsRuntimeException thrown if the project creation fails
      */
     IProject createProject(String name, File location, List<File> childProjectLocations, List<String> natureIds, IProgressMonitor monitor);
+
+    /**
+     * Loads an existing Eclipse project to the workspace. After the project is opened it is
+     * associated with the specified list of natures.
+     *
+     * @param description the description specifying the project to open
+     * @param extraNatureIds the list of natures to be associated to the project after it is opened
+     * @param monitor the monitor to report the progress on
+     * @return the opened project's reference
+     * @throws org.eclipse.buildship.core.GradlePluginsRuntimeException thrown if the project opening fails
+     */
+    IProject openProject(IProjectDescription description, ImmutableList<String> extraNatureIds, IProgressMonitor monitor);
 
     /**
      * Configures an existing {@link IProject} to be a {@link IJavaProject}.


### PR DESCRIPTION
If they exist we only add the project nature
This makes it possible to import Buildship into Buildship