### PR TITLE
Adds a first version of a help story

### DIFF
--- a/docs/stories/Help.md
+++ b/docs/stories/Help.md
@@ -1,0 +1,11 @@
+# General
+
+## Provide help content
+
+### Requested Change
+
+Eclipse has an integrated help system which is also available online via http://help.eclipse.org. Buildship should also provide (at least) minimal help content to avoid that functionality is documented within the application, like currently for in the import wizard Gradle task.
+
+### Motivation
+
+Eclipse provides an integrated context sensitive help system which the users are used to. Buildship should follow the same convention.

--- a/docs/stories/README.md
+++ b/docs/stories/README.md
@@ -15,6 +15,7 @@ We capture our ideas for features of Buildship in _stories_. The following stori
 1. [Tooling API](ToolingAPI.md)
 1. [Editor](Editor.md)
 1. [Build](Build.md)
+1. [Help](Help.md)
 
 Note that all stories that have been implemented already do have a strike-through title. They will be archived
 from the stories documents at some point.


### PR DESCRIPTION
Follow up on https://bugs.eclipse.org/bugs/show_bug.cgi?id=468022#c5 

I think Buildship should have a story for Eclipse help content.