### PR TITLE
Creation wizard help

### DIFF
--- a/org.eclipse.buildship.ui/help/help-contexts.xml
+++ b/org.eclipse.buildship.ui/help/help-contexts.xml
@@ -3,4 +3,8 @@
     <description>The Gradle Project Import Wizard allows you to import existing Gradle projects into the Eclipse workspace.</description>
     <topic href="help/html/project-import.html" label="Importing a Gradle Project" />
   </context>
+  <context id="projectcreation">
+     <description>The Gradle Project Creation Wizard allows you to create new Gradle projects in your Eclipse workspace.</description>
+     <topic href="help/html/project-creation.html" label="Creating a Gradle Project"/>
+  </context>
 </contexts>

--- a/org.eclipse.buildship.ui/help/html/project-creation.html
+++ b/org.eclipse.buildship.ui/help/html/project-creation.html
@@ -1,0 +1,9 @@
+<h1>Create a Gradle Project</h1>
+
+<p>Specify a name for the Gradle Project, which should be created.</p>
+<p>
+Optional<br>
+<ul>
+    <li> Define an alternative project location
+    <li> Assign the newly created project to a workingset
+</ul>

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/HelpContext.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/HelpContext.java
@@ -21,6 +21,8 @@ public final class HelpContext {
     // the context id is defined in the external (xml) file specified in the plugin.xml
     public static final String PROJECT_IMPORT = UiPlugin.PLUGIN_ID + ".projectimport"; //$NON-NLS-1$
 
+    public static final String PROJECT_CREATION = UiPlugin.PLUGIN_ID + ".projectcreation"; //$NON-NLS-1$
+
     private HelpContext() {
     }
 

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/generic/HelpContextIdProvider.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/generic/HelpContextIdProvider.java
@@ -1,0 +1,6 @@
+package org.eclipse.buildship.ui.generic;
+
+
+public interface HelpContextIdProvider {
+    String getHelpContextId();
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/AbstractWizardPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/AbstractWizardPage.java
@@ -34,7 +34,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.PlatformUI;
 
 import org.eclipse.buildship.core.projectimport.ProjectImportConfiguration;
-import org.eclipse.buildship.ui.HelpContext;
+import org.eclipse.buildship.ui.generic.HelpContextIdProvider;
 import org.eclipse.buildship.ui.util.font.FontUtils;
 import org.eclipse.buildship.ui.util.widget.UiBuilder;
 
@@ -216,7 +216,9 @@ public abstract class AbstractWizardPage extends WizardPage {
         // the user could navigate back to the initial Eclipse import page which sets another help
         // context
         if (visible) {
-            PlatformUI.getWorkbench().getHelpSystem().setHelp(getControl(), HelpContext.PROJECT_IMPORT);
+            if (getWizard() instanceof HelpContextIdProvider) {
+                PlatformUI.getWorkbench().getHelpSystem().setHelp(getControl(), ((HelpContextIdProvider) getWizard()).getHelpContextId());
+            }
         }
     }
 

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/NewGradleProjectWizardPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/NewGradleProjectWizardPage.java
@@ -11,17 +11,13 @@
 
 package org.eclipse.buildship.ui.wizard.project;
 
+import java.util.Queue;
+
+import com.gradleware.tooling.toolingutils.binding.Property;
+
 import com.google.common.collect.EvictingQueue;
 import com.google.common.collect.ImmutableList;
-import com.gradleware.tooling.toolingutils.binding.Property;
-import org.eclipse.buildship.core.projectimport.ProjectImportConfiguration;
-import org.eclipse.buildship.ui.UiPlugin;
-import org.eclipse.buildship.ui.UiPluginConstants;
-import org.eclipse.buildship.ui.util.databinding.conversion.BooleanInvert;
-import org.eclipse.buildship.ui.util.databinding.dialog.MessageRestoringValidationMessageProvider;
-import org.eclipse.buildship.ui.util.databinding.observable.ProjectLocationComputedValue;
-import org.eclipse.buildship.ui.util.file.DirectoryDialogSelectionListener;
-import org.eclipse.buildship.ui.util.widget.UiBuilder;
+
 import org.eclipse.core.databinding.AggregateValidationStatus;
 import org.eclipse.core.databinding.Binding;
 import org.eclipse.core.databinding.DataBindingContext;
@@ -45,11 +41,23 @@ import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.widgets.*;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.dialogs.WorkingSetConfigurationBlock;
 
-import java.util.Queue;
+import org.eclipse.buildship.core.projectimport.ProjectImportConfiguration;
+import org.eclipse.buildship.ui.UiPlugin;
+import org.eclipse.buildship.ui.UiPluginConstants;
+import org.eclipse.buildship.ui.util.databinding.conversion.BooleanInvert;
+import org.eclipse.buildship.ui.util.databinding.dialog.MessageRestoringValidationMessageProvider;
+import org.eclipse.buildship.ui.util.databinding.observable.ProjectLocationComputedValue;
+import org.eclipse.buildship.ui.util.file.DirectoryDialogSelectionListener;
+import org.eclipse.buildship.ui.util.widget.UiBuilder;
 
 /**
  * First Wizard page for the new Gradle project wizard.
@@ -93,6 +101,8 @@ public final class NewGradleProjectWizardPage extends AbstractWizardPage {
         // Text to specify a project name
         this.projectNameText = new Text(root, SWT.BORDER);
         GridDataFactory.fillDefaults().grab(true, false).span(2, SWT.DEFAULT).applyTo(this.projectNameText);
+        // initially set focus so that the user can directly type a project name
+        this.projectNameText.setFocus();
 
         Group locationGroup = new Group(root, SWT.NONE);
         locationGroup.setText(ProjectWizardMessages.Label_ProjectLocation);

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectCreationWizard.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectCreationWizard.java
@@ -35,12 +35,14 @@ import org.eclipse.ui.IWorkingSet;
 import org.eclipse.buildship.core.launch.RunGradleTasksJob;
 import org.eclipse.buildship.core.projectimport.ProjectImportConfiguration;
 import org.eclipse.buildship.core.util.file.FileUtils;
+import org.eclipse.buildship.ui.HelpContext;
 import org.eclipse.buildship.ui.UiPlugin;
+import org.eclipse.buildship.ui.generic.HelpContextIdProvider;
 
 /**
  * Page in the {@link ProjectCreationWizard} specifying the name of the Gradle project folder to create.
  */
-public final class ProjectCreationWizard extends Wizard implements INewWizard {
+public final class ProjectCreationWizard extends Wizard implements INewWizard, HelpContextIdProvider {
 
     /**
      * The section name declaration for {@link org.eclipse.jface.dialogs.DialogSettings} where the
@@ -230,6 +232,11 @@ public final class ProjectCreationWizard extends Wizard implements INewWizard {
             }
         }
         return true;
+    }
+
+    @Override
+    public String getHelpContextId() {
+        return HelpContext.PROJECT_CREATION;
     }
 
 }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectImportWizard.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectImportWizard.java
@@ -11,27 +11,28 @@
 
 package org.eclipse.buildship.ui.wizard.project;
 
-import org.eclipse.ui.IImportWizard;
-import org.osgi.service.prefs.BackingStoreException;
-
 import com.gradleware.tooling.toolingutils.distribution.PublishedGradleVersions;
+import org.osgi.service.prefs.BackingStoreException;
 
 import org.eclipse.core.runtime.preferences.ConfigurationScope;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.Wizard;
+import org.eclipse.ui.IImportWizard;
 import org.eclipse.ui.IWorkbench;
 
 import org.eclipse.buildship.core.CorePlugin;
 import org.eclipse.buildship.core.GradlePluginsRuntimeException;
 import org.eclipse.buildship.core.projectimport.ProjectImportConfiguration;
+import org.eclipse.buildship.ui.HelpContext;
 import org.eclipse.buildship.ui.UiPlugin;
+import org.eclipse.buildship.ui.generic.HelpContextIdProvider;
 
 /**
  * Eclipse wizard for importing Gradle projects into the workspace.
  */
-public final class ProjectImportWizard extends Wizard implements IImportWizard {
+public final class ProjectImportWizard extends Wizard implements IImportWizard, HelpContextIdProvider {
 
     /**
      * The section name declaration for {@link org.eclipse.jface.dialogs.DialogSettings} where the import wizard stores its
@@ -162,6 +163,11 @@ public final class ProjectImportWizard extends Wizard implements IImportWizard {
             section = dialogSettings.addNewSection(PROJECT_IMPORT_DIALOG_SETTINGS);
         }
         return section;
+    }
+
+    @Override
+    public String getHelpContextId() {
+        return HelpContext.PROJECT_IMPORT;
     }
 
 }


### PR DESCRIPTION
In the AbstractWizardPage the help context was hardcoded to the project import and is now defined by the wizard(HelpContextIdProvider) itself, since some wizards reuse the same pages.