### PR TITLE
Creation wizard default location

### DIFF
--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectCreationWizardUiTest.java
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectCreationWizardUiTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ */
+
+package org.eclipse.buildship.ui.wizard.project;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotCheckBox;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
+
+import org.eclipse.buildship.ui.AbstractSwtbotTest;
+
+/**
+ * SWTBot tests for the {@link ProjectCreationWizard}.
+ *
+ */
+public class ProjectCreationWizardUiTest extends AbstractSwtbotTest {
+
+    @Test
+    public void canOpenNewWizardFromMenuBar() throws Exception {
+        // open the import wizard
+        bot.menu("File").menu("New").menu("Other...").click();
+        SWTBotShell shell = bot.shell("New");
+        shell.activate();
+        bot.tree().expandNode("Gradle").select("Gradle Project");
+        bot.button("Next >").click();
+
+        // if the wizard was opened the label is available, otherwise a WidgetNotFoundException is
+        // thrown
+        bot.text(ProjectWizardMessages.InfoMessage_NewGradleProjectWizardPageDefault);
+
+        // cancel the wizard
+        bot.button("Cancel").click();
+    }
+
+    @Test
+    public void defaultLocationButtonInitiallyChecked() throws Exception {
+        // open the import wizard
+        bot.menu("File").menu("New").menu("Other...").click();
+        SWTBotShell shell = bot.shell("New");
+        shell.activate();
+        bot.tree().expandNode("Gradle").select("Gradle Project");
+        bot.button("Next >").click();
+
+        // check whether the checkbox is initially checked
+        SWTBotCheckBox useDefaultLocationCheckBox = bot.checkBox(ProjectWizardMessages.Button_UseDefaultLocation, 0);
+        assertTrue(useDefaultLocationCheckBox.isChecked());
+
+        // cancel the wizard
+        bot.button("Cancel").click();
+    }
+
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectCreationWizardController.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectCreationWizardController.java
@@ -11,15 +11,18 @@
 
 package org.eclipse.buildship.ui.wizard.project;
 
-import com.google.common.base.Optional;
+import java.io.File;
+
 import com.gradleware.tooling.toolingutils.binding.Property;
 import com.gradleware.tooling.toolingutils.binding.ValidationListener;
-import org.eclipse.buildship.core.util.binding.Validators;
-import org.eclipse.buildship.core.util.file.FileUtils;
+
+import com.google.common.base.Optional;
+
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.ui.INewWizard;
 
-import java.io.File;
+import org.eclipse.buildship.core.util.binding.Validators;
+import org.eclipse.buildship.core.util.file.FileUtils;
 
 /**
  * Controller class for the {@link org.eclipse.buildship.ui.wizard.project.ProjectImportWizard}. Contains all non-UI related calculations
@@ -44,10 +47,10 @@ public final class ProjectCreationWizardController {
 
         // initialize values from the persisted dialog settings
         IDialogSettings dialogSettings = projectCreationWizard.getDialogSettings();
-        Optional<Boolean> useDefaultLocation = Optional.fromNullable(dialogSettings.getBoolean(SETTINGS_KEY_LOCATION_USE_DEFAULT));
+        boolean useDefaultLocation = dialogSettings.get(SETTINGS_KEY_LOCATION_USE_DEFAULT) != null ? dialogSettings.getBoolean(SETTINGS_KEY_LOCATION_USE_DEFAULT) : true;
         Optional<File> customLocation = FileUtils.getAbsoluteFile(dialogSettings.get(SETTINGS_KEY_CUSTOM_LOCATION));
 
-        this.configuration.setUseDefaultLocation(useDefaultLocation.or(Boolean.TRUE));
+        this.configuration.setUseDefaultLocation(useDefaultLocation);
         this.configuration.setCustomLocation(customLocation.orNull());
 
         // store the values every time they change


### PR DESCRIPTION
Initially the dialogsettings for the default location are not set and therefore cause that the default location is not correct in the creation dialog.

This PR fixes this and also provides an SWTBot test for it.