### PR TITLE
UI Tests now wait for Wizards to be shown and closes all shells before tests

### DIFF
--- a/org.eclipse.buildship.ui.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.ui.test/META-INF/MANIFEST.MF
@@ -9,7 +9,8 @@ Fragment-Host: org.eclipse.buildship.ui
 Comment: junit has to be a required bundle, otherwise the tests won't launch for headless builds
 Require-Bundle: org.eclipse.swtbot.eclipse.finder,
  org.eclipse.swtbot.junit4_x,
- org.junit
+ org.junit,
+ org.apache.log4j
 Bundle-ClassPath: .,
  lib/cglib-nodep-3.1.jar,
  lib/groovy-all-2.0.5.jar,

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectCreationWizardUiTest.java
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectCreationWizardUiTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotCheckBox;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 
@@ -24,12 +25,7 @@ public class ProjectCreationWizardUiTest extends AbstractSwtbotTest {
 
     @Test
     public void canOpenNewWizardFromMenuBar() throws Exception {
-        // open the import wizard
-        bot.menu("File").menu("New").menu("Other...").click();
-        SWTBotShell shell = bot.shell("New");
-        shell.activate();
-        bot.tree().expandNode("Gradle").select("Gradle Project");
-        bot.button("Next >").click();
+        openGradleNewWizard();
 
         // if the wizard was opened the label is available, otherwise a WidgetNotFoundException is
         // thrown
@@ -41,12 +37,7 @@ public class ProjectCreationWizardUiTest extends AbstractSwtbotTest {
 
     @Test
     public void defaultLocationButtonInitiallyChecked() throws Exception {
-        // open the import wizard
-        bot.menu("File").menu("New").menu("Other...").click();
-        SWTBotShell shell = bot.shell("New");
-        shell.activate();
-        bot.tree().expandNode("Gradle").select("Gradle Project");
-        bot.button("Next >").click();
+        openGradleNewWizard();
 
         // check whether the checkbox is initially checked
         SWTBotCheckBox useDefaultLocationCheckBox = bot.checkBox(ProjectWizardMessages.Button_UseDefaultLocation, 0);
@@ -54,6 +45,15 @@ public class ProjectCreationWizardUiTest extends AbstractSwtbotTest {
 
         // cancel the wizard
         bot.button("Cancel").click();
+    }
+
+    private void openGradleNewWizard() {
+        bot.menu("File").menu("New").menu("Other...").click();
+        bot.waitUntil(Conditions.shellIsActive("New"));
+        SWTBotShell shell = bot.shell("New");
+        shell.activate();
+        bot.tree().expandNode("Gradle").select("Gradle Project");
+        bot.button("Next >").click();
     }
 
 }

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectImportWizardUiTest.java
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectImportWizardUiTest.java
@@ -11,10 +11,12 @@
 
 package org.eclipse.buildship.ui.wizard.project;
 
-import org.eclipse.buildship.ui.AbstractSwtbotTest;
+import org.junit.Test;
+
+import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 
-import org.junit.Test;
+import org.eclipse.buildship.ui.AbstractSwtbotTest;
 
 public class ProjectImportWizardUiTest extends AbstractSwtbotTest {
 
@@ -22,6 +24,7 @@ public class ProjectImportWizardUiTest extends AbstractSwtbotTest {
     public void canOpenImportWizardFromMenuBar() throws Exception {
         // open the import wizard
         bot.menu("File").menu("Import...").click();
+        bot.waitUntil(Conditions.shellIsActive("Import"));
         SWTBotShell shell = bot.shell("Import");
         shell.activate();
         bot.tree().expandNode("Gradle").select("Gradle Project");


### PR DESCRIPTION
* Added bot.waitUntil(Conditions.shellIsActive("{WizardTitle}")); so that it is ensured that the wizard is opened (Might have caused that the Tree is not found)
* Enhanced the @Before method so that all shells are closed properly before running the next test
* Log4j had to be added here due to SWTBot dependencies for it