### PR TITLE
Bug 471005 - Importing existing project results in Java Model Exception

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerInitializer.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerInitializer.java
@@ -24,6 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
 import com.gradleware.tooling.toolingmodel.OmniEclipseGradleBuild;
@@ -153,7 +154,7 @@ public final class GradleClasspathContainerInitializer extends ClasspathContaine
     }
 
     private List<IClasspathEntry> collectSourceFolders(OmniEclipseProject gradleProject, final IJavaProject workspaceProject) {
-        return FluentIterable.from(gradleProject.getSourceDirectories()).transform(new Function<OmniEclipseSourceDirectory, IClasspathEntry>() {
+        List<IClasspathEntry> sourceFolders = FluentIterable.from(gradleProject.getSourceDirectories()).transform(new Function<OmniEclipseSourceDirectory, IClasspathEntry>() {
 
             @Override
             public IClasspathEntry apply(OmniEclipseSourceDirectory directory) {
@@ -171,6 +172,12 @@ public final class GradleClasspathContainerInitializer extends ClasspathContaine
                 // @formatter:on
             }
         }).toList();
+
+        return removeDuplicatesFromSourceFolders(sourceFolders);
+    }
+
+    private List<IClasspathEntry> removeDuplicatesFromSourceFolders(List<IClasspathEntry> sourceFolders) {
+        return ImmutableSet.copyOf(sourceFolders).asList();
     }
 
     private void updateSourceFoldersInClasspath(List<IClasspathEntry> gradleModelSourceFolders, IJavaProject project, IProgressMonitor monitor) throws JavaModelException {


### PR DESCRIPTION
When the build.gradle file of a project contains multiple source sets that specify overlapping source directories, each specified source directory is added to that projects source directories, regardless of whether or not it's a duplicate.

When the project is imported, these source directories are each added to the classpath. This happens in `GradleClasspathContainerInitializer#updateSourceFoldersInClasspath()`. If there are duplicate source folders, then this bit of code tries to add duplicate entries to the classpath.

The list of source folders passed to `IJavaProject#setRawClasspath()` can't contain any duplicates, and as such, this is where the error lies.

The fix is to remove duplicates when the source folders are collected in buildship. I am hesitant to not add duplicate entries into a projects source folders in the first place, because I am unfamiliar with the other uses of source folders.