### PR TITLE
Bug 468928 - Expose info logging only if tracing is enabled in the platform configuration

### DIFF
--- a/docs/development/Setup.md
+++ b/docs/development/Setup.md
@@ -126,6 +126,9 @@ To run the complete set of ui tests from inside Eclipse, right-click
 on the package _org.eclipse.buildship.ui.test_ and choose _Run As >> JUnit Plug-In-Test_
 (not as a _JUnit Test_!). Individual tests can be run the same way.
 
+## Enabling Tracing
+
+Tracing can be enabled in the _Tracing_ tab of the _Run Configurations..._ dialog.
 
 ## Running the Build
 
@@ -175,3 +178,4 @@ The following workflow is applied to all Buildship issues tracked in Bugzilla:
 
 * [Eclipse Testing](http://wiki.eclipse.org/Eclipse/Testing)
 * [PDE Test Automation](http://www.eclipse.org/articles/article.php?file=Article-PDEJUnitAntAutomation/index.html)
+* [Enabling Tracing](http://help.eclipse.org/luna/index.jsp?topic=%2Forg.eclipse.pde.doc.user%2Fguide%2Ftools%2Flaunchers%2Ftracing.htm)

--- a/org.eclipse.buildship.core/.options
+++ b/org.eclipse.buildship.core/.options
@@ -1,0 +1,1 @@
+org.eclipse.buildship.core/debug = true

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/CorePlugin.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/CorePlugin.java
@@ -144,7 +144,7 @@ public final class CorePlugin extends Plugin {
     }
 
     private EclipseLogger createLogger() {
-        return new EclipseLogger(getLog(), PLUGIN_ID);
+        return new EclipseLogger(getLog(), PLUGIN_ID, isDebugging());
     }
 
     private PublishedGradleVersionsWrapper createPublishedGradleVersions() {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/logging/EclipseLogger.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/logging/EclipseLogger.java
@@ -17,26 +17,35 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 
 /**
- * Logs to the Eclipse logging infrastructure.
+ * Logs to the Eclipse logging infrastructure. The EclipseLogger only logs information if tracing is
+ * enabled.
+ *
+ * Tracing can be enabled in Eclipse's 'Tracing' tab in the 'Run Configurations...' dialog.
  */
 public final class EclipseLogger implements Logger {
 
     private final ILog log;
     private final String pluginId;
+    private final boolean isDebugging;
 
-    public EclipseLogger(ILog log, String pluginId) {
+    public EclipseLogger(ILog log, String pluginId, boolean isDebugging) {
         this.log = log;
         this.pluginId = pluginId;
+        this.isDebugging = isDebugging;
     }
 
     @Override
     public void info(String message) {
-        this.log.log(new Status(IStatus.INFO, this.pluginId, message));
+        if (this.isDebugging) {
+            this.log.log(new Status(IStatus.INFO, this.pluginId, message));
+        }
     }
 
     @Override
     public void info(String message, Throwable t) {
-        this.log.log(new Status(IStatus.INFO, this.pluginId, message, t));
+        if (this.isDebugging) {
+            this.log.log(new Status(IStatus.INFO, this.pluginId, message, t));
+        }
     }
 
     @Override

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
@@ -97,7 +97,7 @@ public final class UiPlugin extends AbstractUIPlugin {
     }
 
     private EclipseLogger createLogger() {
-        return new EclipseLogger(getLog(), PLUGIN_ID);
+        return new EclipseLogger(getLog(), PLUGIN_ID, isDebugging());
     }
 
     private ProcessStreamsProvider createConsoleProcessStreamsProvider() {


### PR DESCRIPTION
*Expose info logging only if tracing is enabled in the platform configuration*

Tracing can be enabled in two ways:

* In the _Run Configurations..._ > _Tracing_ tab

* On the command line, by using the `-debug` flag. A _.options_ file must be located in the _eclipse_ directory, or a _.options_ file must be specified after the `-debug` flag.
