### PR TITLE
Bug 470071 - Includes and excludes are not applied to source folders

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/SourceFolderUpdaterTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/SourceFolderUpdaterTest.groovy
@@ -29,7 +29,7 @@ class SourceFolderUpdaterTest extends Specification {
 
     def "Model source folders are added"() {
         given:
-        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': [], 'inclusion-pattern': new IPath[0], 'exclusion-pattern': new IPath[0])
+        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': [])
         def newModelSourceFolders = gradleSourceFolders(['src'])
 
         expect:
@@ -49,7 +49,7 @@ class SourceFolderUpdaterTest extends Specification {
 
     def "Duplicate model source folders are merged into one source entry"() {
         given:
-        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': [], 'inclusion-pattern': new IPath[0], 'exclusion-pattern': new IPath[0])
+        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': [])
         def newModelSourceFolders = gradleSourceFolders(['src', 'src'])
 
         when:
@@ -65,7 +65,7 @@ class SourceFolderUpdaterTest extends Specification {
 
     def "Previous model source folders are removed if they no longer exist in the Gradle model"() {
         given:
-        def project = javaProject('name': 'project-name', 'model-source-folders': ['src-old'], 'manual-source-folders': [], 'inclusion-pattern': new IPath[0], 'exclusion-pattern': new IPath[0])
+        def project = javaProject('name': 'project-name', 'model-source-folders': ['src-old'], 'manual-source-folders': [])
         def newModelSourceFolders = gradleSourceFolders(['src-new'])
 
         when:
@@ -81,7 +81,7 @@ class SourceFolderUpdaterTest extends Specification {
 
     def "Non-model source folders are preserved even if they are not part of the Gradle model"() {
         given:
-        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': ['src'], 'inclusion-pattern': new IPath[0], 'exclusion-pattern': new IPath[0])
+        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': ['src'])
         def newModelSourceFolders = gradleSourceFolders(['src-gradle'])
 
         expect:
@@ -103,7 +103,7 @@ class SourceFolderUpdaterTest extends Specification {
 
     def "Model source folders that were previously defined manually are transformed to model source folders"() {
         given:
-        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': ['src'], 'inclusion-pattern': new IPath[0], 'exclusion-pattern': new IPath[0])
+        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': ['src'])
         def newModelSourceFolders = gradleSourceFolders(['src'])
 
         expect:
@@ -121,7 +121,7 @@ class SourceFolderUpdaterTest extends Specification {
         project.rawClasspath[0].extraAttributes.length == 1
         project.rawClasspath[0].extraAttributes[0].name == SourceFolderUpdater.CLASSPATH_ATTRIBUTE_FROM_GRADLE_MODEL
     }
-    
+
     def "Classpath inclusion/exclusion patterns on Gradle source folders are preserved"() {
         given:
         def project = javaProject('name': 'project-name', 'model-source-folders': ['src'], 'manual-source-folders': [], 'inclusion-pattern': (IPath[])[new Path("manual-inclusion-pattern")], 'exclusion-pattern': (IPath[])[new Path("manual-exclusion-pattern")])
@@ -129,7 +129,7 @@ class SourceFolderUpdaterTest extends Specification {
 
         when:
         SourceFolderUpdater.update(project, newModelSourceFolders, null)
-        
+
         then:
         project.rawClasspath[0].getInclusionPatterns()[0].toString() == "manual-inclusion-pattern"
         project.rawClasspath[0].getExclusionPatterns()[0].toString() == "manual-exclusion-pattern"
@@ -147,8 +147,8 @@ class SourceFolderUpdaterTest extends Specification {
         def projectName = arguments['name']
         def modelSourceFolders = arguments['model-source-folders']
         def manualSourceFolders = arguments['manual-source-folders']
-        def inclusionPattern = arguments['inclusion-pattern']
-        def exclusionPattern = arguments['exclusion-pattern']
+        def inclusionPattern = arguments['inclusion-pattern']?:new IPath[0]
+        def exclusionPattern = arguments['exclusion-pattern']?:new IPath[0]
 
         // create project folder
         def location = tempFolder.newFolder(projectName)

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/SourceFolderUpdaterTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/SourceFolderUpdaterTest.groovy
@@ -13,6 +13,7 @@ import org.eclipse.jdt.core.IClasspathAttribute
 import org.eclipse.jdt.core.IClasspathEntry
 import org.eclipse.jdt.core.IJavaProject
 import org.eclipse.jdt.core.JavaCore
+import org.eclipse.core.runtime.Path
 
 import org.eclipse.buildship.core.CorePlugin
 import org.eclipse.buildship.core.util.file.FileUtils
@@ -28,7 +29,7 @@ class SourceFolderUpdaterTest extends Specification {
 
     def "Model source folders are added"() {
         given:
-        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': [])
+        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': [], 'inclusion-pattern': new IPath[0], 'exclusion-pattern': new IPath[0])
         def newModelSourceFolders = gradleSourceFolders(['src'])
 
         expect:
@@ -48,7 +49,7 @@ class SourceFolderUpdaterTest extends Specification {
 
     def "Duplicate model source folders are merged into one source entry"() {
         given:
-        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': [])
+        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': [], 'inclusion-pattern': new IPath[0], 'exclusion-pattern': new IPath[0])
         def newModelSourceFolders = gradleSourceFolders(['src', 'src'])
 
         when:
@@ -64,7 +65,7 @@ class SourceFolderUpdaterTest extends Specification {
 
     def "Previous model source folders are removed if they no longer exist in the Gradle model"() {
         given:
-        def project = javaProject('name': 'project-name', 'model-source-folders': ['src-old'], 'manual-source-folders': [])
+        def project = javaProject('name': 'project-name', 'model-source-folders': ['src-old'], 'manual-source-folders': [], 'inclusion-pattern': new IPath[0], 'exclusion-pattern': new IPath[0])
         def newModelSourceFolders = gradleSourceFolders(['src-new'])
 
         when:
@@ -80,7 +81,7 @@ class SourceFolderUpdaterTest extends Specification {
 
     def "Non-model source folders are preserved even if they are not part of the Gradle model"() {
         given:
-        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': ['src'])
+        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': ['src'], 'inclusion-pattern': new IPath[0], 'exclusion-pattern': new IPath[0])
         def newModelSourceFolders = gradleSourceFolders(['src-gradle'])
 
         expect:
@@ -102,7 +103,7 @@ class SourceFolderUpdaterTest extends Specification {
 
     def "Model source folders that were previously defined manually are transformed to model source folders"() {
         given:
-        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': ['src'])
+        def project = javaProject('name': 'project-name', 'model-source-folders': [], 'manual-source-folders': ['src'], 'inclusion-pattern': new IPath[0], 'exclusion-pattern': new IPath[0])
         def newModelSourceFolders = gradleSourceFolders(['src'])
 
         expect:
@@ -120,6 +121,19 @@ class SourceFolderUpdaterTest extends Specification {
         project.rawClasspath[0].extraAttributes.length == 1
         project.rawClasspath[0].extraAttributes[0].name == SourceFolderUpdater.CLASSPATH_ATTRIBUTE_FROM_GRADLE_MODEL
     }
+    
+    def "Classpath inclusion/exclusion patterns on Gradle source folders are preserved"() {
+        given:
+        def project = javaProject('name': 'project-name', 'model-source-folders': ['src'], 'manual-source-folders': [], 'inclusion-pattern': (IPath[])[new Path("manual-inclusion-pattern")], 'exclusion-pattern': (IPath[])[new Path("manual-exclusion-pattern")])
+        def newModelSourceFolders = gradleSourceFolders(['src'])
+
+        when:
+        SourceFolderUpdater.update(project, newModelSourceFolders, null)
+        
+        then:
+        project.rawClasspath[0].getInclusionPatterns()[0].toString() == "manual-inclusion-pattern"
+        project.rawClasspath[0].getExclusionPatterns()[0].toString() == "manual-exclusion-pattern"
+    }
 
     private List<OmniEclipseSourceDirectory> gradleSourceFolders(List<String> folderPaths) {
         folderPaths.collect { String folderPath ->
@@ -133,6 +147,8 @@ class SourceFolderUpdaterTest extends Specification {
         def projectName = arguments['name']
         def modelSourceFolders = arguments['model-source-folders']
         def manualSourceFolders = arguments['manual-source-folders']
+        def inclusionPattern = arguments['inclusion-pattern']
+        def exclusionPattern = arguments['exclusion-pattern']
 
         // create project folder
         def location = tempFolder.newFolder(projectName)
@@ -161,7 +177,7 @@ class SourceFolderUpdaterTest extends Specification {
             FileUtils.ensureFolderHierarchyExists(folder)
             def root = javaProject.getPackageFragmentRoot(folder)
             def attribute = JavaCore.newClasspathAttribute(SourceFolderUpdater.CLASSPATH_ATTRIBUTE_FROM_GRADLE_MODEL, "true")
-            JavaCore.newSourceEntry(root.path, new IPath[0], new IPath[0], null, [attribute] as IClasspathAttribute[])
+            JavaCore.newSourceEntry(root.path, inclusionPattern, exclusionPattern, null, [attribute] as IClasspathAttribute[])
         }
         javaProject.setRawClasspath(manualSourceEntries + modelSourceEntries as IClasspathEntry[], new NullProgressMonitor())
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SourceFolderUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SourceFolderUpdater.java
@@ -79,26 +79,21 @@ public final class SourceFolderUpdater {
                 FileUtils.ensureFolderHierarchyExists(sourceDirectory);
                 final IPackageFragmentRoot root = SourceFolderUpdater.this.project.getPackageFragmentRoot(sourceDirectory);
                 IClasspathAttribute fromGradleModel = JavaCore.newClasspathAttribute(CLASSPATH_ATTRIBUTE_FROM_GRADLE_MODEL, "true");
-                
-                IPath[] includes = new IPath[] {};
-                IPath[] excludes = new IPath[] {};
 
-                // preserve the includes/excludes defined by the user. 
+                // preserve the includes/excludes defined by the user.
                 // this should eventually be provided by the Tooling API,
                 // see Bug 470071
                 Optional<IClasspathEntry> userDefinedClasspathEntry = FluentIterable.from(rawClasspath).firstMatch(new Predicate<IClasspathEntry>() {
-                    
+
                     @Override
                     public boolean apply(IClasspathEntry entry) {
-                        return root.getPath().toString().equals(entry.getPath().toString());
+                        return root.getPath().equals(entry.getPath());
                     }
                 });
 
-                if (userDefinedClasspathEntry.isPresent()) {
-                    includes = userDefinedClasspathEntry.get().getInclusionPatterns();
-                    excludes = userDefinedClasspathEntry.get().getExclusionPatterns();
-                }
-                
+                IPath[] includes = userDefinedClasspathEntry.isPresent() ? userDefinedClasspathEntry.get().getInclusionPatterns() : new IPath[] {};
+                IPath[] excludes = userDefinedClasspathEntry.isPresent() ? userDefinedClasspathEntry.get().getExclusionPatterns() : new IPath[] {};
+
                 // @formatter:off
                 return JavaCore.newSourceEntry(root.getPath(),
                         includes,                                    // use manually defined inclusion patterns, include all if none exist

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SourceFolderUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SourceFolderUpdater.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
@@ -68,19 +69,40 @@ public final class SourceFolderUpdater {
         updateClasspath(newClasspathEntries, monitor);
     }
 
-    private List<IClasspathEntry> collectGradleSourceFolders() {
+    private List<IClasspathEntry> collectGradleSourceFolders() throws JavaModelException {
+        final List<IClasspathEntry> rawClasspath = ImmutableList.copyOf(this.project.getRawClasspath());
         List<IClasspathEntry> sourceFolders = FluentIterable.from(this.sourceFolders).transform(new Function<OmniEclipseSourceDirectory, IClasspathEntry>() {
 
             @Override
             public IClasspathEntry apply(OmniEclipseSourceDirectory directory) {
                 IFolder sourceDirectory = SourceFolderUpdater.this.project.getProject().getFolder(Path.fromOSString(directory.getPath()));
                 FileUtils.ensureFolderHierarchyExists(sourceDirectory);
-                IPackageFragmentRoot root = SourceFolderUpdater.this.project.getPackageFragmentRoot(sourceDirectory);
+                final IPackageFragmentRoot root = SourceFolderUpdater.this.project.getPackageFragmentRoot(sourceDirectory);
                 IClasspathAttribute fromGradleModel = JavaCore.newClasspathAttribute(CLASSPATH_ATTRIBUTE_FROM_GRADLE_MODEL, "true");
+                
+                IPath[] includes = new IPath[] {};
+                IPath[] excludes = new IPath[] {};
+
+                // preserve the includes/excludes defined by the user. 
+                // this should eventually be provided by the Tooling API,
+                // see Bug 470071
+                Optional<IClasspathEntry> userDefinedClasspathEntry = FluentIterable.from(rawClasspath).firstMatch(new Predicate<IClasspathEntry>() {
+                    
+                    @Override
+                    public boolean apply(IClasspathEntry entry) {
+                        return root.getPath().toString().equals(entry.getPath().toString());
+                    }
+                });
+
+                if (userDefinedClasspathEntry.isPresent()) {
+                    includes = userDefinedClasspathEntry.get().getInclusionPatterns();
+                    excludes = userDefinedClasspathEntry.get().getExclusionPatterns();
+                }
+                
                 // @formatter:off
                 return JavaCore.newSourceEntry(root.getPath(),
-                        new IPath[]{},                               // include all files
-                        new IPath[]{},                               // don't exclude anything
+                        includes,                                    // use manually defined inclusion patterns, include all if none exist
+                        excludes,                                    // use manually defined exclusion patterns, exclude none if none exist
                         null,                                        // use the same output folder as defined on the project
                         new IClasspathAttribute[]{fromGradleModel}   // the source folder is loaded from the current Gradle model
                 );


### PR DESCRIPTION
Temporary fix for [Bug 470071](https://bugs.eclipse.org/bugs/show_bug.cgi?id=470071)

If the user modifies the entries of the _.classpath_ file that correspond to source folders in the Gradle model, those modifications are ignored when the project's classpath is updated by Buildship (e.g., via `Gradle > Refresh Gradle Project`).

(I noted that this is a temporary fix, as it has been noted that the Tooling API will expose source folder filters.)