### PR TITLE
Bug 472193 - UI Tests Crash When Run From Eclipse

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
@@ -22,6 +22,7 @@ import org.osgi.framework.ServiceRegistration;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.ui.ISelectionService;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.eclipse.swt.widgets.Display;
 
@@ -128,31 +129,36 @@ public final class UiPlugin extends AbstractUIPlugin {
         CorePlugin.listenerRegistry().addEventListener(this.workingSetsAddingProjectCreatedListener);
 
         this.contextActivatingSelectionListener = new ContextActivatingSelectionListener(UiPluginConstants.GRADLE_NATURE_CONTEXT_ID, Predicates.hasGradleNature(), getWorkbench());
-        Display.getDefault().asyncExec(new Runnable() {
+        Display display = PlatformUI.getWorkbench().getDisplay();
+        if (display != null && !display.isDisposed()) {
+            display.asyncExec(new Runnable() {
 
-            @Override
-            public void run() {
-                ((ISelectionService) getWorkbench().getActiveWorkbenchWindow().getService(ISelectionService.class))
-                .addSelectionListener(UiPlugin.this.contextActivatingSelectionListener);
-            
-            }
-        });
+                @Override
+                public void run() {
+                    ((ISelectionService) getWorkbench().getActiveWorkbenchWindow().getService(ISelectionService.class))
+                    .addSelectionListener(UiPlugin.this.contextActivatingSelectionListener);
+                }
+            });
+        }
     }
 
     @SuppressWarnings({"cast", "RedundantCast"})
     private void unregisterListeners() {
-        Display.getDefault().asyncExec(new Runnable() {
+        Display display = PlatformUI.getWorkbench().getDisplay();
+        if (display != null && !display.isDisposed()) {
+            display.asyncExec(new Runnable() {
 
-            @Override
-            public void run() {
-                // if the selection service is disposed, then the listeners are already removed
-                // (see the javadoc on ISelectionService.addSelectionListener(ISelectionListener listener))
-                ISelectionService selectionService = ((ISelectionService) getWorkbench().getService(ISelectionService.class));
-                if (selectionService != null) {
-                    selectionService.removeSelectionListener(UiPlugin.this.contextActivatingSelectionListener);
+                @Override
+                public void run() {
+                     // if the selection service is disposed, then the listeners are already removed
+                    // (see the javadoc on ISelectionService.addSelectionListener(ISelectionListener listener))
+                    ISelectionService selectionService = ((ISelectionService) getWorkbench().getService(ISelectionService.class));
+                    if (selectionService != null) {
+                        selectionService.removeSelectionListener(UiPlugin.this.contextActivatingSelectionListener);
+                    }
                 }
-            }
-        });
+            });
+        }
         CorePlugin.listenerRegistry().removeEventListener(this.workingSetsAddingProjectCreatedListener);
         CorePlugin.listenerRegistry().removeEventListener(this.executionShowingBuildLaunchRequestListener);
         DebugPlugin.getDefault().getLaunchManager().removeLaunchListener(this.consoleShowingLaunchListener);

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
@@ -23,6 +23,7 @@ import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.ui.ISelectionService;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.swt.widgets.Display;
 
 import org.eclipse.buildship.core.CorePlugin;
 import org.eclipse.buildship.core.Logger;
@@ -127,17 +128,31 @@ public final class UiPlugin extends AbstractUIPlugin {
         CorePlugin.listenerRegistry().addEventListener(this.workingSetsAddingProjectCreatedListener);
 
         this.contextActivatingSelectionListener = new ContextActivatingSelectionListener(UiPluginConstants.GRADLE_NATURE_CONTEXT_ID, Predicates.hasGradleNature(), getWorkbench());
-        ((ISelectionService) getWorkbench().getActiveWorkbenchWindow().getService(ISelectionService.class)).addSelectionListener(this.contextActivatingSelectionListener);
+        Display.getDefault().asyncExec(new Runnable() {
+
+            @Override
+            public void run() {
+                ((ISelectionService) getWorkbench().getActiveWorkbenchWindow().getService(ISelectionService.class))
+                .addSelectionListener(UiPlugin.this.contextActivatingSelectionListener);
+            
+            }
+        });
     }
 
     @SuppressWarnings({"cast", "RedundantCast"})
     private void unregisterListeners() {
-        // if the selection service is disposed, then the listeners are already removed
-        // (see the javadoc on ISelectionService.addSelectionListener(ISelectionListener listener))
-        ISelectionService selectionService = ((ISelectionService) getWorkbench().getService(ISelectionService.class));
-        if (selectionService != null) {
-            selectionService.removeSelectionListener(this.contextActivatingSelectionListener);
-        }
+        Display.getDefault().asyncExec(new Runnable() {
+
+            @Override
+            public void run() {
+                // if the selection service is disposed, then the listeners are already removed
+                // (see the javadoc on ISelectionService.addSelectionListener(ISelectionListener listener))
+                ISelectionService selectionService = ((ISelectionService) getWorkbench().getService(ISelectionService.class));
+                if (selectionService != null) {
+                    selectionService.removeSelectionListener(UiPlugin.this.contextActivatingSelectionListener);
+                }
+            }
+        });
         CorePlugin.listenerRegistry().removeEventListener(this.workingSetsAddingProjectCreatedListener);
         CorePlugin.listenerRegistry().removeEventListener(this.executionShowingBuildLaunchRequestListener);
         DebugPlugin.getDefault().getLaunchManager().removeLaunchListener(this.consoleShowingLaunchListener);


### PR DESCRIPTION
The SWTBot tests crash. Certain code in the  `UiPlugin`'s `start` and `stop` methods needs to be run on the UI thread, which is something that is [not guaranteed](http://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fapi%2Forg%2Feclipse%2Fui%2Fplugin%2FAbstractUIPlugin.html) for those methods (note the `startup` method in the reference).

This PR runs the code that requires the UI thread in `start`/`stop` on the UI thread.