### PR TITLE
Bug472223

### DIFF
--- a/org.eclipse.buildship.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.core/META-INF/MANIFEST.MF
@@ -35,4 +35,5 @@ Export-Package: org.eclipse.buildship.core,
  org.eclipse.buildship.core.util.progress,
  org.eclipse.buildship.core.util.string,
  org.eclipse.buildship.core.util.variable,
+ org.eclipse.buildship.core.util.workspace,
  org.eclipse.buildship.core.workspace

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/projectimport/ProjectImportJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/projectimport/ProjectImportJob.java
@@ -7,40 +7,13 @@
  *
  * Contributors:
  *     Etienne Studer & Donát Csikós (Gradle Inc.) - initial API and implementation and initial documentation
+ *     Simon Scholz <simon.scholz@vogella.com> - Bug 472223
  */
 
 package org.eclipse.buildship.core.projectimport;
 
 import java.io.File;
 import java.util.List;
-
-import org.gradle.tooling.ProgressListener;
-
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
-
-import com.gradleware.tooling.toolingmodel.OmniEclipseGradleBuild;
-import com.gradleware.tooling.toolingmodel.OmniEclipseProject;
-import com.gradleware.tooling.toolingmodel.OmniGradleProject;
-import com.gradleware.tooling.toolingmodel.repository.FetchStrategy;
-import com.gradleware.tooling.toolingmodel.repository.FixedRequestAttributes;
-import com.gradleware.tooling.toolingmodel.repository.ModelRepository;
-import com.gradleware.tooling.toolingmodel.repository.TransientRequestAttributes;
-import com.gradleware.tooling.toolingmodel.util.Maybe;
-
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IProjectDescription;
-import org.eclipse.core.resources.IWorkspaceRoot;
-import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.SubProgressMonitor;
-import org.eclipse.core.runtime.jobs.IJobManager;
-import org.eclipse.core.runtime.jobs.Job;
-import org.eclipse.jdt.launching.JavaRuntime;
 
 import org.eclipse.buildship.core.CorePlugin;
 import org.eclipse.buildship.core.configuration.GradleProjectNature;
@@ -51,7 +24,35 @@ import org.eclipse.buildship.core.projectimport.internal.DefaultProjectCreatedEv
 import org.eclipse.buildship.core.util.progress.AsyncHandler;
 import org.eclipse.buildship.core.util.progress.DelegatingProgressListener;
 import org.eclipse.buildship.core.util.progress.ToolingApiWorkspaceJob;
+import org.eclipse.buildship.core.util.workspace.WorkspaceUtils;
 import org.eclipse.buildship.core.workspace.WorkspaceOperations;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubProgressMonitor;
+import org.eclipse.core.runtime.jobs.IJobManager;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.gradle.tooling.ProgressListener;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.gradleware.tooling.toolingmodel.OmniEclipseGradleBuild;
+import com.gradleware.tooling.toolingmodel.OmniEclipseProject;
+import com.gradleware.tooling.toolingmodel.OmniGradleBuildStructure;
+import com.gradleware.tooling.toolingmodel.OmniGradleProject;
+import com.gradleware.tooling.toolingmodel.OmniGradleProjectStructure;
+import com.gradleware.tooling.toolingmodel.repository.FetchStrategy;
+import com.gradleware.tooling.toolingmodel.repository.FixedRequestAttributes;
+import com.gradleware.tooling.toolingmodel.repository.ModelRepository;
+import com.gradleware.tooling.toolingmodel.repository.TransientRequestAttributes;
+import com.gradleware.tooling.toolingmodel.util.Maybe;
 
 /**
  * Imports a Gradle project into Eclipse using the project import coordinates given by a
@@ -59,7 +60,7 @@ import org.eclipse.buildship.core.workspace.WorkspaceOperations;
  */
 public final class ProjectImportJob extends ToolingApiWorkspaceJob {
 
-    private final FixedRequestAttributes fixedAttributes;
+    private FixedRequestAttributes fixedAttributes;
     private final ImmutableList<String> workingSets;
     private final AsyncHandler initializer;
 
@@ -89,6 +90,13 @@ public final class ProjectImportJob extends ToolingApiWorkspaceJob {
         IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
         manager.beginRule(workspaceRoot, monitor);
         try {
+            // in case the project dir is in the workspace folder the root
+            // folder name has to be change to the "rootProject.name", which is
+            // defined in the settings.gradle file. See Bug 472223
+            if (WorkspaceUtils.isInWorkspaceFolder(this.fixedAttributes.getProjectDir())) {
+                changeProjectRootFolderName(monitor);
+            }
+
             OmniEclipseGradleBuild eclipseGradleBuild = fetchEclipseGradleBuild(new SubProgressMonitor(monitor, 50));
             OmniEclipseProject rootProject = eclipseGradleBuild.getRootEclipseProject();
             List<OmniEclipseProject> allProjects = rootProject.getAll();
@@ -102,6 +110,21 @@ public final class ProjectImportJob extends ToolingApiWorkspaceJob {
         // monitor is closed by caller in super class
     }
 
+    public void changeProjectRootFolderName(IProgressMonitor monitor) {
+        File projectDir = this.fixedAttributes.getProjectDir();
+            OmniGradleBuildStructure gradleBuildStructure = fetchGradleBuildStructure(monitor);
+            OmniGradleProjectStructure rootProject = gradleBuildStructure.getRootProject();
+            if (!(projectDir.getName().equals(rootProject.getName()))) {
+                File newProjectDir = new File(projectDir.getParentFile(), rootProject.getName());
+                projectDir.renameTo(newProjectDir);
+                // override fixedAttributes with newProjectDir
+                this.fixedAttributes = new FixedRequestAttributes(newProjectDir,
+                        this.fixedAttributes.getGradleUserHome(),
+                        this.fixedAttributes.getGradleDistribution(), this.fixedAttributes.getJavaHome(),
+                        this.fixedAttributes.getJvmArguments(), this.fixedAttributes.getArguments());
+            }
+    }
+
     private OmniEclipseGradleBuild fetchEclipseGradleBuild(IProgressMonitor monitor) {
         monitor.beginTask("Load Eclipse Gradle project", IProgressMonitor.UNKNOWN);
         try {
@@ -111,6 +134,20 @@ public final class ProjectImportJob extends ToolingApiWorkspaceJob {
                     ImmutableList.<org.gradle.tooling.events.ProgressListener> of(), getToken());
             ModelRepository repository = CorePlugin.modelRepositoryProvider().getModelRepository(this.fixedAttributes);
             return repository.fetchEclipseGradleBuild(transientAttributes, FetchStrategy.FORCE_RELOAD);
+        } finally {
+            monitor.done();
+        }
+    }
+
+    private OmniGradleBuildStructure fetchGradleBuildStructure(IProgressMonitor monitor) {
+        monitor.beginTask("Load Gradle Project Structure", IProgressMonitor.UNKNOWN);
+        try {
+            ProcessStreams stream = CorePlugin.processStreamsProvider().getBackgroundJobProcessStreams();
+            TransientRequestAttributes transientAttributes = new TransientRequestAttributes(false, stream.getOutput(),
+                    stream.getError(), null, ImmutableList.<ProgressListener> of(),
+                    ImmutableList.<org.gradle.tooling.events.ProgressListener> of(), getToken());
+            ModelRepository repository = CorePlugin.modelRepositoryProvider().getModelRepository(this.fixedAttributes);
+            return repository.fetchGradleBuildStructure(transientAttributes, FetchStrategy.FORCE_RELOAD);
         } finally {
             monitor.done();
         }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/workspace/WorkspaceUtils.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/workspace/WorkspaceUtils.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz <simon.scholz@vogella.com> - Bug 472223
+ */
+
 package org.eclipse.buildship.core.util.workspace;
 
 import java.io.File;
@@ -6,6 +17,10 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 
+/**
+ * These utility methods can be used to check certain workspace specific
+ * settings.
+ */
 public class WorkspaceUtils {
 
     public static boolean isInWorkspaceFolder(File file) {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/workspace/WorkspaceUtils.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/workspace/WorkspaceUtils.java
@@ -1,0 +1,19 @@
+package org.eclipse.buildship.core.util.workspace;
+
+import java.io.File;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+
+public class WorkspaceUtils {
+
+    public static boolean isInWorkspaceFolder(File file) {
+        return isInWorkspaceFolder(new Path(file.getAbsolutePath()));
+    }
+
+    public static boolean isInWorkspaceFolder(IPath path) {
+        IPath workspaceLocation = ResourcesPlugin.getWorkspace().getRoot().getLocation();
+        return workspaceLocation.isPrefixOf(path);
+    }
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/GradleProjectWizardPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/GradleProjectWizardPage.java
@@ -108,7 +108,7 @@ public final class GradleProjectWizardPage extends AbstractWizardPage {
                     // in case the current message type is NONE, a warning may
                     // be shown
                     if (WorkspaceUtils.isInWorkspaceFolder(projectDir)) {
-                        setMessage("It is recommended to locate your Gradle projects outside the workspace location",
+                        setMessage(ProjectWizardMessages.GradleProjectWizardPage_project_workspace_location_warning,
                                 WARNING);
                     }
                 }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/GradleProjectWizardPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/GradleProjectWizardPage.java
@@ -14,8 +14,16 @@ package org.eclipse.buildship.ui.wizard.project;
 import java.io.File;
 import java.util.List;
 
-import com.google.common.collect.ImmutableList;
-
+import org.eclipse.buildship.core.projectimport.ProjectImportConfiguration;
+import org.eclipse.buildship.core.util.file.FileUtils;
+import org.eclipse.buildship.core.util.workspace.WorkspaceUtils;
+import org.eclipse.buildship.ui.UiPlugin;
+import org.eclipse.buildship.ui.UiPluginConstants;
+import org.eclipse.buildship.ui.i18n.UiMessages;
+import org.eclipse.buildship.ui.util.file.DirectoryDialogSelectionListener;
+import org.eclipse.buildship.ui.util.layout.LayoutUtils;
+import org.eclipse.buildship.ui.util.widget.UiBuilder;
+import org.eclipse.buildship.ui.util.workbench.WorkingSetUtils;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
@@ -29,15 +37,7 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkingSet;
 
-import org.eclipse.buildship.core.projectimport.ProjectImportConfiguration;
-import org.eclipse.buildship.core.util.file.FileUtils;
-import org.eclipse.buildship.ui.UiPlugin;
-import org.eclipse.buildship.ui.UiPluginConstants;
-import org.eclipse.buildship.ui.i18n.UiMessages;
-import org.eclipse.buildship.ui.util.file.DirectoryDialogSelectionListener;
-import org.eclipse.buildship.ui.util.layout.LayoutUtils;
-import org.eclipse.buildship.ui.util.widget.UiBuilder;
-import org.eclipse.buildship.ui.util.workbench.WorkingSetUtils;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Page in the {@link ProjectImportWizard} specifying the Gradle root project folder to import.
@@ -99,6 +99,19 @@ public final class GradleProjectWizardPage extends AbstractWizardPage {
             public void modifyText(ModifyEvent e) {
                 File projectDir = FileUtils.getAbsoluteFile(GradleProjectWizardPage.this.projectDirText.getText()).orNull();
                 getConfiguration().setProjectDir(projectDir);
+                // TODO currently a
+                // com.gradleware.tooling.toolingutils.binding.ValidationListener
+                // only receives error messages, therefore the warning message
+                // is implemented here, but it should also be done by a
+                // com.gradleware.tooling.toolingutils.binding.Validator<T>
+                if (NONE == getMessageType()) {
+                    // in case the current message type is NONE, a warning may
+                    // be shown
+                    if (WorkspaceUtils.isInWorkspaceFolder(projectDir)) {
+                        setMessage("It is recommended to locate your Gradle projects outside the workspace location",
+                                WARNING);
+                    }
+                }
             }
         });
         this.workingSetConfigurationWidget.addWorkingSetChangeListener(new WorkingSetChangedListener() {

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPage.java
@@ -345,7 +345,7 @@ public final class ProjectPreviewWizardPage extends AbstractWizardPage {
             OmniGradleBuildStructure gradleBuildStructure = result.getSecond();
             updateSummary(result.getFirst());
             populateTree(gradleBuildStructure);
-            
+
             showProjectRootNameChangeWarning(gradleBuildStructure);
         }
 

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.java
@@ -40,7 +40,11 @@ public final class ProjectWizardMessages extends NLS {
     public static String Label_ProjectStructure;
 
     public static String Label_ProjectName;
+    public static String GradleProjectWizardPage_project_workspace_location_warning;
+
     public static String Group_Label_ProjectLocation;
+    public static String Button_Label_Browse;
+
     public static String Button_UseDefaultLocation;
     public static String Label_CustomLocation;
     public static String Group_Label_WorkingSets;

--- a/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.properties
+++ b/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.properties
@@ -29,7 +29,9 @@ Label_GradleVersion=Gradle version
 Label_ProjectStructure=Gradle project structure
 
 Label_ProjectName=Project name
+GradleProjectWizardPage_project_workspace_location_warning=It is recommended to locate your Gradle projects outside the workspace location, otherwise it might be moved during the import
 Group_Label_ProjectLocation=Project location
+Button_Label_Browse=
 Button_UseDefaultLocation=Use default location
 Label_CustomLocation=Location
 Group_Label_WorkingSets=Working sets


### PR DESCRIPTION
* Added a warning in case the import project location is inside the workspace location
* In case the rootProject.name property of the settings.gradle file is different to the folder name, the folder name will now be changed to the rootProject.name in case the folder is inside the workspace location