### PR TITLE
Bug 471095 - Close project preview before job finishes results in SWTException

### DIFF
--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/SWTBotTestHelper.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/SWTBotTestHelper.groovy
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Ian Stewart-Binks (Red Hat, Inc.) - Bug 471095
+ */
+
 package org.eclipse.buildship.ui
 
 import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/SWTBotTestHelper.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/SWTBotTestHelper.groovy
@@ -1,0 +1,94 @@
+package org.eclipse.buildship.ui
+
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell
+import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable
+import org.eclipse.swtbot.swt.finder.results.VoidResult
+import org.eclipse.swtbot.swt.finder.results.BoolResult
+import org.eclipse.ui.PlatformUI
+import org.eclipse.core.runtime.jobs.Job
+import org.eclipse.swt.widgets.Display
+
+class SWTBotTestHelper {
+    static SWTWorkbenchBot swtBot;
+
+    public static SWTWorkbenchBot getBot() {
+        if (swtBot == null) {
+            return new SWTWorkbenchBot()
+        }
+        return swtBot
+    }
+
+    private static void closeWelcomePageIfAny() throws Exception {
+        try {
+            SWTBotView view = getBot().activeView()
+            if (view.getTitle().equals("Welcome")) {
+                view.close()
+            }
+        } catch (WidgetNotFoundException e) {
+            UiPlugin.logger().error("Failed to initialize SWTBot test.", e)
+        }
+    }
+
+    public static void closeAllShellsExceptTheApplicationShellAndForceShellActivation() {
+        SWTWorkbenchBot bot = getBot()
+
+        // in case a UI test fails some shells might not be closed properly, therefore we close
+        // these here and log it
+        SWTBotShell[] shells = bot.shells()
+        for (SWTBotShell swtBotShell : shells) {
+            if (swtBotShell.isOpen() && !isEclipseApplicationShell(swtBotShell)) {
+                bot.captureScreenshot(swtBotShell.getText() + " NotClosed.jpg")
+                UiPlugin.logger().warn(swtBotShell.getText() + " was not closed properly.")
+                swtBotShell.close()
+            }
+        }
+
+        // http://wiki.eclipse.org/SWTBot/Troubleshooting#No_active_Shell_when_running_SWTBot_tests_in_Xvfb
+        UIThreadRunnable.syncExec(new VoidResult() {
+
+                    @Override
+                    public void run() {
+                        PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell().forceActive()
+                    }
+                })
+    }
+
+    public static boolean isEclipseApplicationShell(final SWTBotShell swtBotShell) {
+        return UIThreadRunnable.syncExec(new BoolResult() {
+
+                    @Override
+                    public Boolean run() {
+                        return PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell().equals(swtBotShell.widget)
+                    }
+                })
+    }
+
+    protected static void waitForJobsToFinish() {
+        while (!Job.getJobManager().isIdle()) {
+            delay(500)
+        }
+    }
+
+    private static void delay(long waitTimeMillis) {
+        Display display = Display.getCurrent()
+        if (display != null) {
+            long endTimeMillis = System.currentTimeMillis() + waitTimeMillis
+            while (System.currentTimeMillis() < endTimeMillis) {
+                if (!display.readAndDispatch()) {
+                    display.sleep()
+                }
+            }
+            display.update()
+        } else {
+            try {
+                Thread.sleep(waitTimeMillis)
+            } catch (InterruptedException e) {
+                // ignore
+            }
+        }
+    }
+
+}

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPageUiTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPageUiTest.groovy
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Ian Stewart-Binks (Red Hat, Inc.) - Bug 471095
+ */
+
 package org.eclipse.buildship.ui.wizard.project
 
 import org.eclipse.swtbot.eclipse.finder.waits.Conditions

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPageUiTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPageUiTest.groovy
@@ -1,0 +1,76 @@
+package org.eclipse.buildship.ui.wizard.project
+
+import org.eclipse.swtbot.eclipse.finder.waits.Conditions
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.buildship.core.CorePlugin
+import org.eclipse.buildship.core.Logger
+import org.eclipse.buildship.ui.SWTBotTestHelper
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+import org.eclipse.buildship.ui.test.fixtures.TestEnvironment
+import org.eclipse.core.runtime.jobs.Job
+
+
+class ProjectPreviewWizardPageUiTest extends Specification {
+    SWTWorkbenchBot bot = SWTBotTestHelper.getBot()
+
+    @Rule
+    TemporaryFolder tempFolder
+    File location
+
+    def setup() {
+        SWTBotTestHelper.closeAllShellsExceptTheApplicationShellAndForceShellActivation()
+    }
+
+    def setupSpec() {
+        SWTBotTestHelper.closeWelcomePageIfAny()
+    }
+
+    def "Stop preview and close import wizard before import job finishes"() {
+        given:
+        Logger logger = Mock()
+        TestEnvironment.registerService(Logger, logger)
+        location = tempFolder.newFolder("new-folder")
+
+        new File(location.toString() + "/build.gradle").withWriter('utf-8') { writer ->
+            writer.writeLine "Thread.sleep(5000)"
+            writer.writeLine "task takesLongTimeToLoad {"
+            writer.writeLine "    Thread.sleep(5000)"
+            writer.writeLine "    doLast {"
+            writer.writeLine "        Thread.sleep(5000)"
+            writer.writeLine "    }"
+            writer.writeLine "}"
+        }
+
+        CorePlugin.workspaceOperations().createProject('project-name', location, [], [], new NullProgressMonitor())
+
+        when:
+        startImportPreviewAndCancelWizard()
+        SWTBotTestHelper.waitForJobsToFinish()
+
+        then:
+        0 * logger.error(_, _)
+
+        cleanup:
+        TestEnvironment.cleanup()
+    }
+
+    private void startImportPreviewAndCancelWizard() {
+        bot.menu("File").menu("Import...").click()
+        SWTBotShell shell = bot.shell("Import")
+        shell.activate()
+        bot.waitUntil(Conditions.shellIsActive("Import"))
+        bot.tree().expandNode("Gradle").select("Gradle Project")
+        bot.button("Next >").click()
+        bot.button("Next >").click()
+        bot.textWithLabel("Project root directory").setText(location.toString())
+        bot.button("Next >").click()
+        bot.button("Next >").click()
+        bot.toolbarButtonWithTooltip("Cancel Operation").click()
+        bot.button("Cancel").click()
+    }
+
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPage.java
@@ -23,6 +23,8 @@ import com.gradleware.tooling.toolingmodel.OmniGradleBuildStructure;
 import com.gradleware.tooling.toolingmodel.OmniGradleProjectStructure;
 import com.gradleware.tooling.toolingmodel.util.Pair;
 import com.gradleware.tooling.toolingutils.binding.Property;
+
+import org.eclipse.buildship.core.CorePlugin;
 import org.eclipse.buildship.core.GradlePluginsRuntimeException;
 import org.eclipse.buildship.core.gradle.Limitations;
 import org.eclipse.buildship.core.i18n.CoreMessages;
@@ -42,6 +44,7 @@ import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Font;
@@ -353,20 +356,32 @@ public final class ProjectPreviewWizardPage extends AbstractWizardPage {
 
                 @Override
                 public void run() {
-                    // update Gradle user home
-                    if (buildEnvironment.getGradle().getGradleUserHome().isPresent()) {
-                        String gradleUserHome = buildEnvironment.getGradle().getGradleUserHome().get().getAbsolutePath();
-                        ProjectPreviewWizardPage.this.gradleUserHomeLabel.setText(gradleUserHome);
+                    try {
+                        if (!ProjectPreviewWizardPage.this.gradleUserHomeLabel.isDisposed()) {
+                            // update Gradle user home
+                            if (buildEnvironment.getGradle().getGradleUserHome().isPresent()) {
+                                String gradleUserHome = buildEnvironment.getGradle().getGradleUserHome().get().getAbsolutePath();
+                                ProjectPreviewWizardPage.this.gradleUserHomeLabel.setText(gradleUserHome);
+                            }
+                        }
+
+                        if (!ProjectPreviewWizardPage.this.gradleVersionLabel.isDisposed()) {
+                            // update Gradle version
+                            String gradleVersion = buildEnvironment.getGradle().getGradleVersion();
+                            ProjectPreviewWizardPage.this.gradleVersionLabel.setText(gradleVersion);
+                            updateGradleVersionWarningLabel();
+                        }
+
+
+                        if (!ProjectPreviewWizardPage.this.javaHomeLabel.isDisposed()) {
+                            // update Java home
+                            String javaHome = buildEnvironment.getJava().getJavaHome().getAbsolutePath();
+                            ProjectPreviewWizardPage.this.javaHomeLabel.setText(javaHome);
+                        }
+                    } catch (SWTException e) {
+                        String message = String.format("Failed to properly close ProjectPreviewWizardPage.");
+                        CorePlugin.logger().error(message, e);
                     }
-
-                    // update Gradle version
-                    String gradleVersion = buildEnvironment.getGradle().getGradleVersion();
-                    ProjectPreviewWizardPage.this.gradleVersionLabel.setText(gradleVersion);
-                    updateGradleVersionWarningLabel();
-
-                    // update Java home
-                    String javaHome = buildEnvironment.getJava().getJavaHome().getAbsolutePath();
-                    ProjectPreviewWizardPage.this.javaHomeLabel.setText(javaHome);
                 }
             });
         }
@@ -376,14 +391,21 @@ public final class ProjectPreviewWizardPage extends AbstractWizardPage {
 
                 @Override
                 public void run() {
-                    ProjectPreviewWizardPage.this.projectPreviewTree.removeAll();
+                    try {
+                        if (!ProjectPreviewWizardPage.this.projectPreviewTree.isDisposed()) {
+                              ProjectPreviewWizardPage.this.projectPreviewTree.removeAll();
 
-                    // populate the tree from the build structure
-                    OmniGradleProjectStructure rootProject = buildStructure.getRootProject();
-                    TreeItem rootTreeItem = new TreeItem(ProjectPreviewWizardPage.this.projectPreviewTree, SWT.NONE);
-                    rootTreeItem.setExpanded(true);
-                    rootTreeItem.setText(rootProject.getName());
-                    populateRecursively(rootProject, rootTreeItem);
+                              // populate the tree from the build structure
+                              OmniGradleProjectStructure rootProject = buildStructure.getRootProject();
+                              TreeItem rootTreeItem = new TreeItem(ProjectPreviewWizardPage.this.projectPreviewTree, SWT.NONE);
+                              rootTreeItem.setExpanded(true);
+                              rootTreeItem.setText(rootProject.getName());
+                              populateRecursively(rootProject, rootTreeItem);
+                        }
+                    } catch (SWTException e) {
+                        String message = String.format("Failed to properly close ProjectPreviewWizardPage.");
+                        CorePlugin.logger().error(message, e);
+                    }
                 }
             });
         }
@@ -393,7 +415,14 @@ public final class ProjectPreviewWizardPage extends AbstractWizardPage {
 
                 @Override
                 public void run() {
-                    ProjectPreviewWizardPage.this.projectPreviewTree.removeAll();
+                    try {
+                        if (!ProjectPreviewWizardPage.this.projectPreviewTree.isDisposed()) {
+                            ProjectPreviewWizardPage.this.projectPreviewTree.removeAll();
+                        }
+                    } catch (SWTException e) {
+                        String message = String.format("Failed to properly close ProjectPreviewWizardPage.");
+                        CorePlugin.logger().error(message, e);
+                    }
                 }
             });
         }


### PR DESCRIPTION
This pull request brings many issues into the light:

-- Edit: The proposed fix for 1 has been merged in.

1. **The first set of SWTExceptions**
  When a project preview is started, a `ProjectPreviewJob` is triggered with a `DelegatingProgressListener`. The method `DelegatingProgressListener.statusChanged()` is called periodically as the project preview is initialized. When this method is called, the `DelegatingProgressListener` updates the corresponding monitor by calling `monitor.subtask...` When the user cancels the request to view the project preview, and closes the project import wizard, the `ProjectPreviewJob.fetchGradleBuildStructure()` method continues, and the `DelegatingProgressListener` continues to listen for events. The `ProjectPreviewJob.fetchGradleBuildStructure()` continually updates the `DelegatingProgressListener`, which then tries to call `monitor.subtask...`, however, the monitor has already been canceled at this point, at which time an `SWTException` is thrown.
  * The point at which the first `SWTException` is thrown is [here](https://github.com/gradle/tooling-commons/blob/master/toolingmodel/src/main/java/com/gradleware/tooling/toolingmodel/repository/internal/DefaultModelRepository.java#L370), which throws a `UncheckedExecutionException`. I'm assuming that the listeners are notified at some point here.
  * In `DelegatingProgressListener`, the events that the monitor is being updated with oscillate between "Compile script into cache", "Configure project".
  * The solution is to check whether the monitor is canceled in `DelegatingProgressListener`. A better solution would be to remove the listener from the `ProjectPreviewJob`, and let the job die silently. I've looked into unregistering/cancelling listeners/transient request attributes right when the job is canceled, but with no success.
  * Current solution _may_ still be flawed, should monitor be canceled in between when the `DelegatingProgressListener` checks if it's canceled, and when it calls `monitor.subtask...`.

2. **The second set of SWTExceptions**
  When that same job is canceled, the `JobChangeListener` that's listening for `done` in `ProjectPreviewJob` will call `resultHandler.onFailure...` which then subsequently calls `ProjectPreviewWizardPage.clearTree()`. The tree is disposed at this point, and naturally results in an `SWTException`.
  * The solution is to just check if the tree is disposed before trying to access it.
  * This PR does *not* introduce a test case for this solution. I am uncertain as to how to go about testing this.

3. **Induction of SWT tests within Spock tests**
  This PR uses SWTBot tests inside Spock tests, which appears to be unorthodox for Buildship. In the event that this PR is accepted, it would be wise to create an issue to further the conquest of Spock in the testing of Buildship. Spock uses the Sputnik test runner, and SWTBotTests use the SWTBotJunit4ClassRunner. This means that the SWTBot tests can be run in Spock, but we lose the ability to take screenshots. I've looked into how we can add this functionality back in, and it should be doable, but I have so far been unsuccessful. I think it would be a good idea to open another issue on this topic, or at least merge it in with the SWTBot -> Spock issue. I'm very interested in looking into this!
  * Note that this PR essentially ports over the `BaseSWTBotTest` class into the `SWTBotTestHelper` class. Not much of the functionality has changed, however `waitForJobs` has. I have implemented it such that it no longer checks to see if all jobs from the `JobManager` are null, but rather checks to see if the `JobManager` is idle. With the latter approach, the tests would not close properly, because `waitForJobs` would not wait for the long running `ProjectPreviewJob`  (interestingly, the job would still run, but the `JobManager` would return null for `currentJob` inside of _ProjectPreviewWizardPageUiTest_, but not null inside of _ProjectPreviewWizardPage_. It turns out that they're being run on different threads, but `currentJob` only works for the same thread that it's called from.
  * In _SWTBotTestHelper_, access modifiers have been preserved.

4. **A note on the logging that this PR introduces**
  Logging has been added for the sole purpose of being able to properly test. 
  * Not all instances where widgets in the `ProjectPreviewWizardPage` are accessed are tested. You will notice that methods that are called in `onSuccess`, such as `populateTree` have had the same fix as `clearTree` applied to them. This is meant for consistency, and for a potential race condition when a job successfully completes, but the user simoultaneously disposes the wizard before these methods are called. This may be _too_ precautious.