### PR TITLE
Bug 473545 - Add Welcome Page for the Gradle project creation wizard

### DIFF
--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectImportWizardUiTest.java
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/ProjectImportWizardUiTest.java
@@ -26,7 +26,7 @@ public class ProjectImportWizardUiTest extends BaseSWTBotTest {
 
         // if the wizard was opened the label is available, otherwise a WidgetNotFoundException is
         // thrown
-        bot.styledText(ProjectWizardMessages.InfoMessage_GradleWelcomeWizardPageContext);
+        bot.styledText(ProjectWizardMessages.InfoMessage_GradleWelcomeWizardPageImportContext);
 
         // cancel the wizard
         bot.button("Cancel").click();

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/AbstractProjectWizard.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/AbstractProjectWizard.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz <simon.scholz@vogella.com> - Bug 473545
+ */
+
+package org.eclipse.buildship.ui.wizard.project;
+
+import org.eclipse.buildship.core.GradlePluginsRuntimeException;
+import org.eclipse.buildship.ui.UiPlugin;
+import org.eclipse.core.runtime.preferences.ConfigurationScope;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.jface.wizard.Wizard;
+import org.osgi.service.prefs.BackingStoreException;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Abstract Wizard implementation, which provides common behavior for project
+ * wizards.
+ */
+public abstract class AbstractProjectWizard extends Wizard implements HelpContextIdProvider {
+
+    private final String welcomePageEnabledPreferenceKey;
+    // state bit storing that the wizard is blocked to finish globally
+    private boolean finishGloballyEnabled;
+
+    public AbstractProjectWizard(String welcomePageEnabledPreferenceKey) {
+        this.welcomePageEnabledPreferenceKey = Preconditions.checkNotNull(welcomePageEnabledPreferenceKey);
+        // the wizard must not be finishable unless this global flag is enabled
+        this.finishGloballyEnabled = true;
+    }
+
+    @Override
+    public boolean canFinish() {
+        // the wizard can finish if all pages are complete and the finish is
+        // globally enabled
+        return super.canFinish() && this.finishGloballyEnabled;
+    }
+
+    public void setFinishGloballyEnabled(boolean finishGloballyEnabled) {
+        this.finishGloballyEnabled = finishGloballyEnabled;
+    }
+
+    public void setWelcomePageEnabled(boolean enabled) {
+        @SuppressWarnings("deprecation")
+        ConfigurationScope configurationScope = new ConfigurationScope();
+        IEclipsePreferences node = configurationScope.getNode(UiPlugin.PLUGIN_ID);
+        node.putBoolean(this.welcomePageEnabledPreferenceKey, enabled);
+        try {
+            node.flush();
+        } catch (BackingStoreException e) {
+            throw new GradlePluginsRuntimeException(e);
+        }
+    }
+
+    public boolean isShowWelcomePage() {
+        // store the in the configuration scope to have the same settings for
+        // all workspaces
+        @SuppressWarnings("deprecation")
+        ConfigurationScope configurationScope = new ConfigurationScope();
+        IEclipsePreferences node = configurationScope.getNode(UiPlugin.PLUGIN_ID);
+        return node.getBoolean(this.welcomePageEnabledPreferenceKey, true);
+    }
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.java
@@ -42,11 +42,14 @@ public final class ProjectWizardMessages extends NLS {
     public static String Label_ProjectName;
     public static String Group_Label_ProjectLocation;
     public static String Button_UseDefaultLocation;
+
+    public static String CheckButton_Show_Welcomepage_Next_Time;
     public static String Label_CustomLocation;
     public static String Group_Label_WorkingSets;
     public static String Message_TargetProjectDirectory;
 
-    public static String InfoMessage_GradleWelcomeWizardPageDefault;
+    public static String InfoMessage_GradleWelcomeWizardPageImport;
+    public static String InfoMessage_GradleWelcomeWizardPageCreation;
     public static String InfoMessage_GradleProjectWizardPageDefault;
     public static String InfoMessage_GradleOptionsWizardPageDefault;
     public static String InfoMessage_PreviewImportWizardPageDefault;
@@ -54,7 +57,8 @@ public final class ProjectWizardMessages extends NLS {
     public static String InfoMessage_NewGradleProjectWizardPageDefault;
     public static String InfoMessage_NewGradleProjectPreviewWizardPageDefault;
 
-    public static String InfoMessage_GradleWelcomeWizardPageContext;
+    public static String InfoMessage_GradleWelcomeWizardPageImportContext;
+    public static String InfoMessage_GradleWelcomeWizardPageCreationContext;
     public static String InfoMessage_GradleProjectWizardPageContext;
     public static String InfoMessage_GradleOptionsWizardPageContext;
     public static String InfoMessage_GradlePreviewWizardPageContext;
@@ -65,6 +69,24 @@ public final class ProjectWizardMessages extends NLS {
     public static String Title_Dialog_Limitations;
     public static String Limitations_Tooltip;
     public static String Limitations_Details_0_1;
+
+    public static String Import_Wizard_Welcome_Page_Name;
+    public static String Import_Wizard_Paragraph_Main_Title;
+    public static String Import_Wizard_Paragraph_Title_Smart_Project_Import;
+    public static String Import_Wizard_Paragraph_Content_Smart_Project_Import;
+    public static String Import_Wizard_Paragraph_Title_Gradle_Wrapper;
+    public static String Import_Wizard_Paragraph_Content_Gradle_Wrapper;
+    public static String Import_Wizard_Paragraph_Title_Advanced_Options;
+    public static String Import_Wizard_Paragraph_Content_Advanced_Options;
+
+    public static String Creation_Wizard_Welcome_Page_Name;
+    public static String Creation_Wizard_Paragraph_Main_Title;
+    public static String Creation_Wizard_Paragraph_Title_Smart_Project_Creation;
+    public static String Creation_Wizard_Paragraph_Content_Smart_Project_Creation;
+    public static String Creation_Wizard_Paragraph_Title_Gradle_Wrapper;
+    public static String Creation_Wizard_Paragraph_Content_Gradle_Wrapper;
+    public static String Creation_Wizard_Paragraph_Title_Advanced_Options;
+    public static String Creation_Wizard_Paragraph_Content_Advanced_Options;
 
     static {
         // initialize resource bundle

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/WelcomePageContent.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/WelcomePageContent.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz <simon.scholz@vogella.com> - Bug 473545
+ */
+
+package org.eclipse.buildship.ui.wizard.project;
+
+import java.util.List;
+
+import org.eclipse.jface.wizard.WizardPage;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * This interface is used to configure the {@link GradleWelcomeWizardPage}.
+ *
+ * @see GradleWelcomeWizardPage
+ */
+public interface WelcomePageContent {
+
+    /**
+     * This is the name of the {@link WizardPage}.
+     *
+     * @return the name of the {@link WizardPage}
+     */
+    String getName();
+
+    /**
+     * This is the title, which is shown in the title area of the
+     * {@link WizardPage}.
+     *
+     * @return title for the {@link WizardPage}
+     */
+    String getTitle();
+
+    /**
+     * This is the message, which is shown below the title in the title area of
+     * the {@link WizardPage}.
+     *
+     * @return message of the title area in the {@link WizardPage}
+     */
+    String getMessage();
+
+    /**
+     * {@link AbstractWizardPage} objects provide to show page context
+     * information in the bottom of a {@link WizardPage}.
+     *
+     * @return the page context information content
+     */
+    String getPageContextInformation();
+
+    /**
+     * The title for the content area of a {@link GradleWelcomeWizardPage}
+     *
+     * @return content area's title
+     */
+    String getWelcomePageParagraphTitle();
+
+    /**
+     * A list of {@link WelcomePageParagraph} objects, which should be shown in
+     * the content of the {@link GradleWelcomeWizardPage}.
+     *
+     * @return paragraphs for the {@link GradleWelcomeWizardPage}
+     */
+    List<WelcomePageParagraph> getWelcomePageParagraphs();
+
+    /**
+     * Specifies a paragraph, which is shown on the GradleWelcomeWizardPage.
+     */
+    public final class WelcomePageParagraph {
+
+        private String title;
+        private String content;
+
+        public WelcomePageParagraph(String title, String content) {
+            this.title = Preconditions.checkNotNull(title);
+            this.content = Preconditions.checkNotNull(content);
+        }
+
+        public String getTitle() {
+            return this.title;
+        }
+
+        public String getContent() {
+            return this.content;
+        }
+
+    }
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/WelcomePageContentFactory.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/WelcomePageContentFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz <simon.scholz@vogella.com> - Bug 473545
+ */
+
+package org.eclipse.buildship.ui.wizard.project;
+
+import org.eclipse.buildship.ui.wizard.project.WelcomePageContent.WelcomePageParagraph;
+import org.eclipse.buildship.ui.wizard.project.internal.DefaultWelcomePageContent;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+
+/**
+ * Factory for creating {@link WelcomePageContent} instances for the
+ * {@link GradleWelcomeWizardPage}.
+ */
+public class WelcomePageContentFactory {
+
+    private WelcomePageContentFactory() {
+    }
+
+    public static WelcomePageContent createImportWizardWelcomePageConfigurator() {
+        Builder<WelcomePageParagraph> paragraphs = ImmutableList.builder();
+        paragraphs
+                .add(new WelcomePageParagraph(ProjectWizardMessages.Import_Wizard_Paragraph_Title_Smart_Project_Import,
+                        ProjectWizardMessages.Import_Wizard_Paragraph_Content_Smart_Project_Import));
+        paragraphs.add(new WelcomePageParagraph(ProjectWizardMessages.Import_Wizard_Paragraph_Title_Gradle_Wrapper,
+                ProjectWizardMessages.Import_Wizard_Paragraph_Content_Gradle_Wrapper));
+        paragraphs.add(new WelcomePageParagraph(ProjectWizardMessages.Import_Wizard_Paragraph_Title_Advanced_Options,
+                ProjectWizardMessages.Import_Wizard_Paragraph_Content_Advanced_Options));
+        WelcomePageContent welcomePageConfigurator = new DefaultWelcomePageContent(
+                ProjectWizardMessages.Import_Wizard_Welcome_Page_Name,
+                ProjectWizardMessages.Title_GradleWelcomeWizardPage,
+                ProjectWizardMessages.InfoMessage_GradleWelcomeWizardPageImport,
+                ProjectWizardMessages.InfoMessage_GradleWelcomeWizardPageImportContext,
+                ProjectWizardMessages.Import_Wizard_Paragraph_Main_Title, paragraphs.build());
+
+        return welcomePageConfigurator;
+    }
+
+    public static WelcomePageContent createCreationWizardWelcomePageConfigurator() {
+        Builder<WelcomePageParagraph> paragraphs = ImmutableList.builder();
+        paragraphs.add(
+                new WelcomePageParagraph(ProjectWizardMessages.Creation_Wizard_Paragraph_Title_Smart_Project_Creation,
+                        ProjectWizardMessages.Creation_Wizard_Paragraph_Content_Smart_Project_Creation));
+        paragraphs.add(new WelcomePageParagraph(ProjectWizardMessages.Creation_Wizard_Paragraph_Title_Gradle_Wrapper,
+                ProjectWizardMessages.Creation_Wizard_Paragraph_Content_Gradle_Wrapper));
+        paragraphs.add(new WelcomePageParagraph(ProjectWizardMessages.Creation_Wizard_Paragraph_Title_Advanced_Options,
+                ProjectWizardMessages.Creation_Wizard_Paragraph_Content_Advanced_Options));
+        WelcomePageContent welcomePageConfigurator = new DefaultWelcomePageContent(
+                ProjectWizardMessages.Creation_Wizard_Welcome_Page_Name,
+                ProjectWizardMessages.Title_GradleWelcomeWizardPage,
+                ProjectWizardMessages.InfoMessage_GradleWelcomeWizardPageCreation,
+                ProjectWizardMessages.InfoMessage_GradleWelcomeWizardPageCreationContext,
+                ProjectWizardMessages.Creation_Wizard_Paragraph_Main_Title, paragraphs.build());
+
+        return welcomePageConfigurator;
+    }
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/internal/DefaultWelcomePageContent.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/internal/DefaultWelcomePageContent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz <simon.scholz@vogella.com> - Bug 473545
+ */
+
+package org.eclipse.buildship.ui.wizard.project.internal;
+
+import java.util.List;
+
+import org.eclipse.buildship.ui.wizard.project.WelcomePageContent;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Default implementation of a {@link WelcomePageContent}.
+ */
+public final class DefaultWelcomePageContent implements WelcomePageContent {
+
+    private String name;
+    private String title;
+    private String message;
+    private String pageContextInformation;
+    private String welcomePageParagraphtitle;
+    private List<WelcomePageParagraph> welcomePageParagraphs;
+
+    public DefaultWelcomePageContent(String name, String title, String message, String pageContextInformation,
+            String welcomePageParagraphtitle, List<WelcomePageParagraph> welcomePageParagraphs) {
+        this.name = Preconditions.checkNotNull(name);
+        this.title = Preconditions.checkNotNull(title);
+        this.message = Preconditions.checkNotNull(message);
+        this.pageContextInformation = Preconditions.checkNotNull(pageContextInformation);
+        this.welcomePageParagraphtitle = Preconditions.checkNotNull(welcomePageParagraphtitle);
+        this.welcomePageParagraphs = Preconditions.checkNotNull(welcomePageParagraphs);
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public String getTitle() {
+        return this.title;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public String getPageContextInformation() {
+        return this.pageContextInformation;
+    }
+
+    @Override
+    public String getWelcomePageParagraphTitle() {
+        return this.welcomePageParagraphtitle;
+    }
+
+    @Override
+    public List<WelcomePageParagraph> getWelcomePageParagraphs() {
+        return this.welcomePageParagraphs;
+    }
+
+}

--- a/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.properties
+++ b/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.properties
@@ -31,11 +31,13 @@ Label_ProjectStructure=Gradle project structure
 Label_ProjectName=Project name
 Group_Label_ProjectLocation=Project location
 Button_UseDefaultLocation=Use default location
+CheckButton_Show_Welcomepage_Next_Time=Show welcome page next time the wizard appears
 Label_CustomLocation=Location
 Group_Label_WorkingSets=Working sets
 Message_TargetProjectDirectory=Target project directory
 
-InfoMessage_GradleWelcomeWizardPageDefault=Learn how to make best use of the Gradle project import wizard.
+InfoMessage_GradleWelcomeWizardPageImport=Learn how to make best use of the Gradle project import wizard.
+InfoMessage_GradleWelcomeWizardPageCreation=Learn how to make best use of the Gradle project creation wizard.
 InfoMessage_GradleProjectWizardPageDefault=Specify the root directory of the Gradle project to import.
 InfoMessage_GradleOptionsWizardPageDefault=Specify optional import options to apply when importing and interacting with the Gradle project.
 InfoMessage_PreviewImportWizardPageDefault=Review the import configuration before starting the import of the Gradle project.
@@ -43,7 +45,8 @@ InfoMessage_PreviewImportWizardPageDefault=Review the import configuration befor
 InfoMessage_NewGradleProjectWizardPageDefault=Specify the name of the Gradle project to create.
 InfoMessage_NewGradleProjectPreviewWizardPageDefault=Review the configuration before starting the creation of the Gradle project.
 
-InfoMessage_GradleWelcomeWizardPageContext=Click the Next button to start the wizard and configure the import.
+InfoMessage_GradleWelcomeWizardPageImportContext=Click the Next button to start the wizard and configure the import.
+InfoMessage_GradleWelcomeWizardPageCreationContext=Click the Next button to start the wizard and configure the project creation.
 InfoMessage_GradleProjectWizardPageContext=Click the Finish button to finish the wizard and start the import. Click the Next button to select optional import options.
 InfoMessage_GradleOptionsWizardPageContext=Click the Finish button to finish the wizard and start the import. Click the Next button to see a summary of the import configuration.
 InfoMessage_GradlePreviewWizardPageContext=Click the Finish button to finish the wizard and start the import. Click the Back button to adjust the import configuration.
@@ -54,3 +57,21 @@ InfoMessage_NewGradleProjectPreviewWizardPageContext=Click the Finish button to 
 Title_Dialog_Limitations=Limitations
 Limitations_Tooltip=Click on the warning icon to see more details about the limitations of Buildship when using this Gradle version.
 Limitations_Details_0_1=Buildship runs with all Gradle versions >=1.0. But, some Buildship functionality is not available when using Gradle version {0}:\n\n{1}
+
+Import_Wizard_Welcome_Page_Name=GradleWelcome
+Import_Wizard_Paragraph_Main_Title=How to experience the best Gradle integration to quickly try different settings and see their impact on the import.
+Import_Wizard_Paragraph_Title_Smart_Project_Import=Smart project import
+Import_Wizard_Paragraph_Content_Smart_Project_Import=\nPoint the wizard to the root location of the Gradle project to import. Buildship will take care of importing all the belonging projects. All imported projects that already contain an Eclipse .project file will be left alone, aside from being added the Gradle nature.
+Import_Wizard_Paragraph_Title_Gradle_Wrapper=Gradle Wrapper
+Import_Wizard_Paragraph_Content_Gradle_Wrapper=\nYou will experience the best Gradle integration if you make use of the Gradle wrapper in your Gradle build and configure it to use the latest released version of Gradle. Using the Gradle wrapper also makes the build most sharable between multiple users.
+Import_Wizard_Paragraph_Title_Advanced_Options=Advanced options
+Import_Wizard_Paragraph_Content_Advanced_Options=\nUnless you have a very specific reason, leave the advanced options at their default values. The advanced options can be useful to quickly try different settings and see their impact on the import.
+
+Creation_Wizard_Welcome_Page_Name=GradleWelcome
+Creation_Wizard_Paragraph_Main_Title=How to experience the best Gradle integration to quickly try different settings and see their impact on the project creation.
+Creation_Wizard_Paragraph_Title_Smart_Project_Creation=Smart project creation
+Creation_Wizard_Paragraph_Content_Smart_Project_Creation=\nPoint the wizard to the root location of the Gradle project to import. Buildship will take care of importing all the belonging projects. All imported projects that already contain an Eclipse .project file will be left alone, aside from being added the Gradle nature.
+Creation_Wizard_Paragraph_Title_Gradle_Wrapper=Gradle Wrapper
+Creation_Wizard_Paragraph_Content_Gradle_Wrapper=\nYou will experience the best Gradle integration if you make use of the Gradle wrapper in your Gradle build and configure it to use the latest released version of Gradle. Using the Gradle wrapper also makes the build most sharable between multiple users.
+Creation_Wizard_Paragraph_Title_Advanced_Options=Advanced options
+Creation_Wizard_Paragraph_Content_Advanced_Options=\nUnless you have a very specific reason, leave the advanced options at their default values. The advanced options can be useful to quickly try different settings and see their impact on the creation.


### PR DESCRIPTION
Added an abstract WelcomePage, which can be configured by a WelcomePageConfigurator.

@etiennestuder
There is a WelcomePageConfiguratorFactory, where you can add your desired text to the project creation  welcome page.
See the // TODO in 
org.eclipse.buildship.ui.wizard.welcome.WelcomePageConfiguratorFactory.createCreationWizardWelcomePageConfigurator(String)