### PR TITLE
Bug 472223 - Show a warning in case the project root location is inside

### DIFF
--- a/org.eclipse.buildship.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.core/META-INF/MANIFEST.MF
@@ -35,4 +35,5 @@ Export-Package: org.eclipse.buildship.core,
  org.eclipse.buildship.core.util.progress,
  org.eclipse.buildship.core.util.string,
  org.eclipse.buildship.core.util.variable,
+ org.eclipse.buildship.core.util.workspace,
  org.eclipse.buildship.core.workspace

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/workspace/WorkspaceUtils.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/workspace/WorkspaceUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz <simon.scholz@vogella.com> - Bug 472223
+ */
+
+package org.eclipse.buildship.core.util.workspace;
+
+import java.io.File;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+
+/**
+ * These utility methods can be used to check certain workspace specific
+ * settings.
+ */
+public class WorkspaceUtils {
+
+    public static boolean isInWorkspaceFolder(File file) {
+        return isInWorkspaceFolder(new Path(file.getAbsolutePath()));
+    }
+
+    public static boolean isInWorkspaceFolder(IPath path) {
+        IPath workspaceLocation = ResourcesPlugin.getWorkspace().getRoot().getLocation();
+        return workspaceLocation.isPrefixOf(path);
+    }
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/GradleProjectWizardPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/GradleProjectWizardPage.java
@@ -14,8 +14,16 @@ package org.eclipse.buildship.ui.wizard.project;
 import java.io.File;
 import java.util.List;
 
-import com.google.common.collect.ImmutableList;
-
+import org.eclipse.buildship.core.projectimport.ProjectImportConfiguration;
+import org.eclipse.buildship.core.util.file.FileUtils;
+import org.eclipse.buildship.core.util.workspace.WorkspaceUtils;
+import org.eclipse.buildship.ui.UiPlugin;
+import org.eclipse.buildship.ui.UiPluginConstants;
+import org.eclipse.buildship.ui.i18n.UiMessages;
+import org.eclipse.buildship.ui.util.file.DirectoryDialogSelectionListener;
+import org.eclipse.buildship.ui.util.layout.LayoutUtils;
+import org.eclipse.buildship.ui.util.widget.UiBuilder;
+import org.eclipse.buildship.ui.util.workbench.WorkingSetUtils;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.swt.SWT;
@@ -29,15 +37,7 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkingSet;
 
-import org.eclipse.buildship.core.projectimport.ProjectImportConfiguration;
-import org.eclipse.buildship.core.util.file.FileUtils;
-import org.eclipse.buildship.ui.UiPlugin;
-import org.eclipse.buildship.ui.UiPluginConstants;
-import org.eclipse.buildship.ui.i18n.UiMessages;
-import org.eclipse.buildship.ui.util.file.DirectoryDialogSelectionListener;
-import org.eclipse.buildship.ui.util.layout.LayoutUtils;
-import org.eclipse.buildship.ui.util.widget.UiBuilder;
-import org.eclipse.buildship.ui.util.workbench.WorkingSetUtils;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Page in the {@link ProjectImportWizard} specifying the Gradle root project folder to import.
@@ -99,6 +99,19 @@ public final class GradleProjectWizardPage extends AbstractWizardPage {
             public void modifyText(ModifyEvent e) {
                 File projectDir = FileUtils.getAbsoluteFile(GradleProjectWizardPage.this.projectDirText.getText()).orNull();
                 getConfiguration().setProjectDir(projectDir);
+                // TODO currently a
+                // com.gradleware.tooling.toolingutils.binding.ValidationListener
+                // only receives error messages, therefore the warning message
+                // is implemented here, but it should also be done by a
+                // com.gradleware.tooling.toolingutils.binding.Validator<T>
+                if (NONE == getMessageType()) {
+                    // in case the current message type is NONE, a warning may
+                    // be shown
+                    if (WorkspaceUtils.isInWorkspaceFolder(projectDir)) {
+                        setMessage(ProjectWizardMessages.GradleProjectWizardPage_project_workspace_location_warning,
+                                WARNING);
+                    }
+                }
             }
         });
         this.workingSetConfigurationWidget.addWorkingSetChangeListener(new WorkingSetChangedListener() {

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPage.java
@@ -11,18 +11,11 @@
 
 package org.eclipse.buildship.ui.wizard.project;
 
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.FutureCallback;
-import com.gradleware.tooling.toolingmodel.OmniBuildEnvironment;
-import com.gradleware.tooling.toolingmodel.OmniGradleBuildStructure;
-import com.gradleware.tooling.toolingmodel.OmniGradleProjectStructure;
-import com.gradleware.tooling.toolingmodel.util.Pair;
-import com.gradleware.tooling.toolingutils.binding.Property;
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import org.eclipse.buildship.core.GradlePluginsRuntimeException;
 import org.eclipse.buildship.core.gradle.Limitations;
 import org.eclipse.buildship.core.i18n.CoreMessages;
@@ -30,6 +23,7 @@ import org.eclipse.buildship.core.projectimport.ProjectImportConfiguration;
 import org.eclipse.buildship.core.util.gradle.GradleDistributionFormatter;
 import org.eclipse.buildship.core.util.gradle.GradleDistributionWrapper;
 import org.eclipse.buildship.core.util.progress.DelegatingProgressListener;
+import org.eclipse.buildship.core.util.workspace.WorkspaceUtils;
 import org.eclipse.buildship.ui.UiPlugin;
 import org.eclipse.buildship.ui.util.font.FontUtils;
 import org.eclipse.buildship.ui.util.layout.LayoutUtils;
@@ -47,16 +41,28 @@ import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.*;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Layout;
+import org.eclipse.swt.widgets.Tree;
+import org.eclipse.swt.widgets.TreeItem;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
 import org.gradle.tooling.ProgressListener;
 import org.gradle.util.GradleVersion;
 
-import java.io.File;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.FutureCallback;
+import com.gradleware.tooling.toolingmodel.OmniBuildEnvironment;
+import com.gradleware.tooling.toolingmodel.OmniGradleBuildStructure;
+import com.gradleware.tooling.toolingmodel.OmniGradleProjectStructure;
+import com.gradleware.tooling.toolingmodel.util.Pair;
+import com.gradleware.tooling.toolingutils.binding.Property;
 
 /**
  * Page in the {@link ProjectImportWizard} showing a preview about the project about to be
@@ -336,8 +342,29 @@ public final class ProjectPreviewWizardPage extends AbstractWizardPage {
             // the job has already taken care of logging the success
             this.latch.countDown();
 
+            OmniGradleBuildStructure gradleBuildStructure = result.getSecond();
             updateSummary(result.getFirst());
-            populateTree(result.getSecond());
+            populateTree(gradleBuildStructure);
+
+            showProjectRootNameChangeWarning(gradleBuildStructure);
+        }
+
+        private void showProjectRootNameChangeWarning(OmniGradleBuildStructure gradleBuildStructure) {
+
+            final Property<File> projectDir = getConfiguration().getProjectDir();
+            final String rootProjectName = gradleBuildStructure.getRootProject().getName();
+            if (WorkspaceUtils.isInWorkspaceFolder(projectDir.getValue())
+                    && !(projectDir.getValue().getName().equals(rootProjectName))) {
+                PlatformUI.getWorkbench().getDisplay().asyncExec(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        setMessage("The root project folder will be renamed to " + rootProjectName, WARNING);
+                        ProjectPreviewWizardPage.this.projectDirLabel.setText(
+                                new File(projectDir.getValue().getParentFile(), rootProjectName).getAbsolutePath());
+                    }
+                });
+            }
         }
 
         @Override

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.java
@@ -40,7 +40,11 @@ public final class ProjectWizardMessages extends NLS {
     public static String Label_ProjectStructure;
 
     public static String Label_ProjectName;
+    public static String GradleProjectWizardPage_project_workspace_location_warning;
+
     public static String Group_Label_ProjectLocation;
+    public static String Button_Label_Browse;
+
     public static String Button_UseDefaultLocation;
     public static String Label_CustomLocation;
     public static String Group_Label_WorkingSets;

--- a/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.properties
+++ b/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.properties
@@ -29,7 +29,9 @@ Label_GradleVersion=Gradle version
 Label_ProjectStructure=Gradle project structure
 
 Label_ProjectName=Project name
+GradleProjectWizardPage_project_workspace_location_warning=It is recommended to locate your Gradle projects outside the workspace location, otherwise it might be moved during the import
 Group_Label_ProjectLocation=Project location
+Button_Label_Browse=
 Button_UseDefaultLocation=Use default location
 Label_CustomLocation=Location
 Group_Label_WorkingSets=Working sets


### PR DESCRIPTION
the workspace

Change-Id: Id84690c3368ce170a9c19f903055ea659b37b9b6
Signed-off-by: Simon Scholz <simon.scholz@vogella.com>

Bug 472223 - Show a warning that the root location inside the workspace
will be changed

Change-Id: I4070d25898701ae432e5420dcc01554c60806d67
Signed-off-by: Simon Scholz <simon.scholz@vogella.com>

Bug 472223 - Rename root folder in workspace if necessary

Change-Id: Ia0dc9c39ed102f2f273075d1a4b4af4d24c66798
Signed-off-by: Simon Scholz <simon.scholz@vogella.com>

Bug 472223 - Added spock integration test for Bug 472223

Change-Id: Iaec9be5d83b5820ddbe43485a5edef849e613fc8
Signed-off-by: Simon Scholz <simon.scholz@vogella.com>

Bug 472223 - Externalized warning and removed whitespace

Change-Id: If17d65f370827af2214e2daa5f70c81cd75fad8d
Signed-off-by: Simon Scholz <simon.scholz@vogella.com>

Add settings to Oomph model to ignore warnings on the unused @SuppressWarnings arguments

Signed-off-by: Donat Csikos <csdonat@gmail.com>

Bug 473389 - NPEs during UI integration tests in the UIPlugin Activator

Change-Id: Ic35a73404b11b9ebb8a8e551fc4f0f285bbbb9d4
Signed-off-by: Simon Scholz <simon.scholz@vogella.com>

Review

Bug 470071 - Includes and excludes are not applied to source folders

Signed-off-by: Ian Stewart-Binks <istewart@redhat.com>

Bug 470071: Make code more compact, clean up.

Signed-off-by: Ian Stewart-Binks <istewart@redhat.com>

Minor code formatting

Signed-off-by: Donat Csikos <csdonat@gmail.com>

Format and organize imports in class ProjectImportJob

Signed-off-by: Donat Csikos <csdonat@gmail.com>

Replace FixedRequestAttributes field with method argument

Signed-off-by: Donat Csikos <csdonat@gmail.com>

Move things around a little

Signed-off-by: Donat Csikos <csdonat@gmail.com>