### PR TITLE
Bug 472191 - UI tests hang when run from Eclipse

### DIFF
--- a/docs/development/Setup.md
+++ b/docs/development/Setup.md
@@ -123,8 +123,11 @@ on the package _org.eclipse.buildship.core.test_ and choose _Run As >> JUnit Plu
 (not as a _JUnit Test_!). Individual tests can be run the same way.
 
 To run the complete set of ui tests from inside Eclipse, right-click
-on the package _org.eclipse.buildship.ui.test_ and choose _Run As >> JUnit Plug-In-Test_
-(not as a _JUnit Test_!). Individual tests can be run the same way.
+on the package _org.eclipse.buildship.ui.test_ and choose _Run As >> Run Configurations_. Choose _JUnit Plug-In-Test_. 
+In the _Test_ tab, ensure that the _Run in UI thread_ checkbox is unchecked, and click _Run_. Buildship uses 
+SWTBot tests, which must be run in a non-UI thread. When running the UI tests in the future, click on the 
+package _org.eclipse.buildship.ui.test_ and choose _Run As >> JUnit Plug-In-Test_ (not as a _JUnit Test_!). The run 
+configurations should be saved. Individual tests can be run the same way.
 
 ## Enabling Tracing
 
@@ -180,3 +183,4 @@ The following workflow is applied to all Buildship issues tracked in Bugzilla:
 * [Eclipse Testing](http://wiki.eclipse.org/Eclipse/Testing)
 * [PDE Test Automation](http://www.eclipse.org/articles/article.php?file=Article-PDEJUnitAntAutomation/index.html)
 * [Enabling Tracing](http://help.eclipse.org/luna/index.jsp?topic=%2Forg.eclipse.pde.doc.user%2Fguide%2Ftools%2Flaunchers%2Ftracing.htm)
+* [SWTBot Testing](https://wiki.eclipse.org/SWTBot/UsersGuide)


### PR DESCRIPTION
SWTBot tests simply need to be run on a non-UI thread, this is not a fault of Buildship. I believe that the best solution to this problem is to simply inform the developer.