### PR TITLE
Bug 470070 - Importing multi-module project with linked src folders does not create links

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerInitializer.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerInitializer.java
@@ -13,7 +13,6 @@ package org.eclipse.buildship.core.workspace.internal;
 
 import java.util.List;
 
-import org.eclipse.core.runtime.SubProgressMonitor;
 import org.gradle.tooling.CancellationToken;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProgressListener;
@@ -31,14 +30,15 @@ import com.gradleware.tooling.toolingmodel.repository.TransientRequestAttributes
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.ClasspathContainerInitializer;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.JavaModelException;
 
 import org.eclipse.buildship.core.CorePlugin;
 import org.eclipse.buildship.core.GradlePluginsRuntimeException;
@@ -53,7 +53,8 @@ import org.eclipse.buildship.core.util.progress.ToolingApiWorkspaceJob;
  * <p/>
  * When this initializer is invoked, it looks up the {@link OmniEclipseProject} for the given
  * Eclipse workspace project, takes all the found sources, project dependencies and external
- * dependencies, and assigns them to the {@link org.eclipse.buildship.core.workspace.GradleClasspathContainer#CONTAINER_ID} classpath
+ * dependencies, and assigns them to the
+ * {@link org.eclipse.buildship.core.workspace.GradleClasspathContainer#CONTAINER_ID} classpath
  * container.
  * <p/>
  * This initializer is assigned to the projects via the
@@ -78,7 +79,7 @@ public final class GradleClasspathContainerInitializer extends ClasspathContaine
 
             @Override
             protected void runToolingApiJobInWorkspace(IProgressMonitor monitor) throws Exception {
-                monitor.beginTask("Initializing classpath", 100);
+                monitor.beginTask("Initializing classpath", 150);
 
                 // use the same rule as the ProjectImportJob to do the initialization
                 IJobManager manager = Job.getJobManager();
@@ -93,9 +94,12 @@ public final class GradleClasspathContainerInitializer extends ClasspathContaine
         }.schedule();
     }
 
-    private void internalInitialize(IPath containerPath, IJavaProject project, FetchStrategy fetchStrategy, IProgressMonitor monitor) throws JavaModelException {
+    private void internalInitialize(IPath containerPath, IJavaProject project, FetchStrategy fetchStrategy, IProgressMonitor monitor) throws CoreException {
         Optional<OmniEclipseProject> eclipseProject = findEclipseProject(project.getProject(), fetchStrategy);
         if (eclipseProject.isPresent()) {
+            // update linked resources
+            LinkedResourcesUpdater.update(project.getProject(), eclipseProject.get().getLinkedResources(), new SubProgressMonitor(monitor, 50));
+
             // update source folders
             SourceFolderUpdater.update(project, eclipseProject.get().getSourceDirectories(), new SubProgressMonitor(monitor, 50));
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/LinkedResourcesUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/LinkedResourcesUpdater.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Etienne Studer & Donát Csikós (Gradle Inc.) - initial API and implementation and initial documentation
+ */
+
+package org.eclipse.buildship.core.workspace.internal;
+
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.base.Function;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+
+import com.gradleware.tooling.toolingmodel.OmniEclipseLinkedResource;
+
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
+
+/**
+ * Updates the linked sources the target project.
+ *
+ * TODO (donat) Right now this class is called only on Java projects. But the concept of linked
+ * resources is defined on all projects (~ on the IProject interface). Therefore the project update
+ * functionality should be refactored such that all this class is executed on all projects, not just
+ * on Java projects. Needs PR#140 to be merged before because it contains a
+ * RefreshGradleClasspathContainerJob class where this class should be called.
+ */
+public final class LinkedResourcesUpdater {
+
+    // string enum constant to select folders when checking OmniEclipseLinkedResource#getType()
+    private static final String LINKED_RESOURCE_TYPE_FOLDER = "2";
+
+    private final IProject project;
+    private final List<OmniEclipseLinkedResource> linkedResources;
+
+    private LinkedResourcesUpdater(IProject project, List<OmniEclipseLinkedResource> sourceFolders) {
+        this.project = Preconditions.checkNotNull(project);
+        this.linkedResources = Preconditions.checkNotNull(sourceFolders);
+    }
+
+    private void updateLinkedResources(IProgressMonitor monitor) throws CoreException {
+        monitor.beginTask("Update linked resources", IProgressMonitor.UNKNOWN);
+        try {
+            // TODO (donat) delete linked resources which were but are no longer part of the model
+            Set<File> existingLinkedLocations = findLinkedLocationsUnderProject();
+            List<OmniEclipseLinkedResource> newLinkedResources = filterNewLinkedResources(existingLinkedLocations);
+            createLinkedResources(newLinkedResources);
+        } finally {
+            monitor.done();
+        }
+    }
+
+    private Set<File> findLinkedLocationsUnderProject() throws CoreException {
+        return FluentIterable.of(this.project.members()).filter(new Predicate<IResource>() {
+
+            @Override
+            public boolean apply(IResource folder) {
+                return folder.isLinked();
+            }
+        }).transform(new Function<IResource, File>() {
+
+            @Override
+            public File apply(IResource folder) {
+                return folder.getLocation().toFile();
+            }
+        }).toSet();
+    }
+
+    private List<OmniEclipseLinkedResource> filterNewLinkedResources(final Set<File> existingLocations) {
+        return FluentIterable.from(this.linkedResources).filter(new Predicate<OmniEclipseLinkedResource>() {
+
+            @Override
+            public boolean apply(OmniEclipseLinkedResource resource) {
+                // TODO (donat) deal with files and virtual resources (~urls)
+                return resource.getLocation() != null && resource.getType().equals(LINKED_RESOURCE_TYPE_FOLDER) && !existingLocations.contains(new File(resource.getLocation()));
+            }
+        }).toList();
+    }
+
+    private void createLinkedResources(List<OmniEclipseLinkedResource> linkedResources) throws CoreException {
+        for (OmniEclipseLinkedResource linkedResource : linkedResources) {
+            IPath resourcePath = new Path(linkedResource.getLocation());
+            IFolder folder = getNewProjectFolder(new File(linkedResource.getLocation()).getName());
+            folder.createLink(resourcePath, IResource.NONE, null);
+        }
+    }
+
+    private IFolder getNewProjectFolder(String baseName) throws CoreException {
+        // if a folder with the same name already exists then create the location with a '_'
+        // appended to the name
+        IFolder folder = this.project.getFolder(baseName);
+        if (folder.exists()) {
+            return getNewProjectFolder(baseName + "_");
+        } else {
+            return folder;
+        }
+    }
+
+    public static void update(IProject project, List<OmniEclipseLinkedResource> linkedResources, IProgressMonitor monitor) throws CoreException {
+        LinkedResourcesUpdater updater = new LinkedResourcesUpdater(project, linkedResources);
+        updater.updateLinkedResources(monitor);
+    }
+
+}


### PR DESCRIPTION
Create linked sources if the model contains it
Create linked resource only if it doesn't exist
Use linked resources as source folders if specified
Filter linked resources to work with folders only
Refactor source code updater in order to have better exception handling