### PR TITLE
Bug 473862 - F5 key shortcut doesn't refresh project folder contents

### DIFF
--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/BaseSWTBotTest.java
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/BaseSWTBotTest.java
@@ -25,6 +25,7 @@ import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
 import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
 import org.eclipse.swtbot.swt.finder.results.BoolResult;
 import org.eclipse.swtbot.swt.finder.results.VoidResult;
+import org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.ui.PlatformUI;
 
@@ -32,6 +33,11 @@ import org.eclipse.ui.PlatformUI;
 public abstract class BaseSWTBotTest {
 
     protected static SWTWorkbenchBot bot;
+
+    @BeforeClass
+    public static void setKeyboardPreferences() {
+        SWTBotPreferences.KEYBOARD_LAYOUT = "EN_US";
+    }
 
     @BeforeClass
     public static void closeWelcomePageIfAny() throws Exception {
@@ -85,12 +91,12 @@ public abstract class BaseSWTBotTest {
     }
 
     protected void waitForJobsToFinish() {
-        while (Job.getJobManager().currentJob() != null) {
+        while (!Job.getJobManager().isIdle()) {
             delay(500);
         }
     }
 
-    private void delay(long waitTimeMillis) {
+    protected void delay(long waitTimeMillis) {
         Display display = Display.getCurrent();
         if (display != null) {
             long endTimeMillis = System.currentTimeMillis() + waitTimeMillis;

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/BaseSWTBotTest.java
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/BaseSWTBotTest.java
@@ -96,7 +96,7 @@ public abstract class BaseSWTBotTest {
         }
     }
 
-    protected void delay(long waitTimeMillis) {
+    private void delay(long waitTimeMillis) {
         Display display = Display.getCurrent();
         if (display != null) {
             long endTimeMillis = System.currentTimeMillis() + waitTimeMillis;

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/RefreshUiTest.java
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/wizard/project/RefreshUiTest.java
@@ -1,0 +1,77 @@
+/*
+* Copyright (c) 2015 the original author or authors.
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Ian Stewart-Binks (Red Hat Inc.) - Bug 473862 - F5 key shortcut doesn't refresh project folder contents
+*/
+package org.eclipse.buildship.ui.wizard.project;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.Test;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.swt.SWT;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.eclipse.buildship.core.CorePlugin;
+import org.eclipse.buildship.ui.BaseSWTBotTest;
+
+public class RefreshUiTest extends BaseSWTBotTest {
+
+    private static final String NATURE_ID = CorePlugin.PLUGIN_ID + ".gradleprojectnature";
+    private static final String TEST_FILENAME = "newFile";
+    private static final String TEST_PROJECTNAME = "newProject";
+    private NullProgressMonitor monitor = new NullProgressMonitor();
+
+    @Test
+    public void defaultEclipseBehaviourIsNotHindered() throws Exception {
+        IProject project = createProject();
+        createFileUnderProject(project);
+        performDefaultEclipseRefresh();
+        assertTrue(project.getFile(TEST_FILENAME).exists());
+        project.delete(true, this.monitor);
+    }
+
+    private void performDefaultEclipseRefresh() {
+        waitForJobsToFinish();
+
+        SWTBotView packageExplorer = bot.viewByTitle("Package Explorer");
+        packageExplorer.show();
+        SWTBotTree tree = packageExplorer.bot().tree();
+        SWTBotTreeItem treeItem = tree.getTreeItem(TEST_PROJECTNAME);
+        treeItem.select().pressShortcut(0, SWT.F5, (char) 0);
+
+        waitForJobsToFinish();
+    }
+
+    private IProject createProject() throws CoreException {
+        IWorkspace workspace = ResourcesPlugin.getWorkspace();
+        IProject project = workspace.getRoot().getProject("newProject");
+        IProjectDescription projectDescription = workspace.newProjectDescription(project.getName());
+
+        projectDescription.setNatureIds(new String[] {NATURE_ID});
+        project.create(projectDescription, this.monitor);
+        project.open(IResource.NONE, this.monitor);
+
+        return project;
+    }
+
+    private void createFileUnderProject(IProject project) throws IOException {
+        File file = new File(project.getLocation().toFile(), TEST_FILENAME);
+        file.createNewFile();
+    }
+
+}

--- a/org.eclipse.buildship.ui/plugin.xml
+++ b/org.eclipse.buildship.ui/plugin.xml
@@ -196,12 +196,6 @@
              schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
              sequence="F5">
        </key>
-       <key
-             commandId="org.eclipse.buildship.ui.commands.refreshproject"
-             contextId="org.eclipse.buildship.ui.contexts.gradlenature"
-             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-             sequence="F5">
-       </key>
    </extension>
 
     <!-- integration of Gradle command images -->

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
@@ -65,7 +65,7 @@ public final class UiPlugin extends AbstractUIPlugin {
     private ContextActivatingSelectionListener contextActivatingSelectionListener;
     private ContextActivatingWindowListener contextActivatingWindowListener;
     private RefreshListener refreshListener;
-    
+
     @Override
     public void start(BundleContext context) throws Exception {
         super.start(context);
@@ -142,9 +142,9 @@ public final class UiPlugin extends AbstractUIPlugin {
 
         this.contextActivatingWindowListener = new ContextActivatingWindowListener(this.contextActivatingSelectionListener);
         getWorkbench().addWindowListener(this.contextActivatingWindowListener);
-        
-        refreshListener = new RefreshListener();
-        getWorkbench().getService(ICommandService.class).addExecutionListener(refreshListener);
+
+        this.refreshListener = new RefreshListener();
+        ((ICommandService) getWorkbench().getService(ICommandService.class)).addExecutionListener(this.refreshListener);
     }
 
     @SuppressWarnings({"cast", "RedundantCast"})
@@ -160,7 +160,7 @@ public final class UiPlugin extends AbstractUIPlugin {
         CorePlugin.listenerRegistry().removeEventListener(this.workingSetsAddingProjectCreatedListener);
         CorePlugin.listenerRegistry().removeEventListener(this.executionShowingBuildLaunchRequestListener);
         DebugPlugin.getDefault().getLaunchManager().removeLaunchListener(this.consoleShowingLaunchListener);
-        getWorkbench().getService(ICommandService.class).removeExecutionListener(refreshListener);
+        ((ICommandService) getWorkbench().getService(ICommandService.class)).removeExecutionListener(this.refreshListener);
     }
 
     public static UiPlugin getInstance() {

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
@@ -28,10 +28,12 @@ import org.eclipse.buildship.ui.util.selection.ContextActivatingSelectionListene
 import org.eclipse.buildship.ui.util.selection.ContextActivatingWindowListener;
 import org.eclipse.buildship.ui.view.execution.ExecutionShowingBuildLaunchRequestListener;
 import org.eclipse.buildship.ui.wizard.project.WorkingSetsAddingProjectCreatedListener;
+import org.eclipse.buildship.ui.workspace.RefreshListener;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.ui.ISelectionService;
 import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.commands.ICommandService;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -62,7 +64,8 @@ public final class UiPlugin extends AbstractUIPlugin {
     private WorkingSetsAddingProjectCreatedListener workingSetsAddingProjectCreatedListener;
     private ContextActivatingSelectionListener contextActivatingSelectionListener;
     private ContextActivatingWindowListener contextActivatingWindowListener;
-
+    private RefreshListener refreshListener;
+    
     @Override
     public void start(BundleContext context) throws Exception {
         super.start(context);
@@ -139,6 +142,9 @@ public final class UiPlugin extends AbstractUIPlugin {
 
         this.contextActivatingWindowListener = new ContextActivatingWindowListener(this.contextActivatingSelectionListener);
         getWorkbench().addWindowListener(this.contextActivatingWindowListener);
+        
+        refreshListener = new RefreshListener();
+        getWorkbench().getService(ICommandService.class).addExecutionListener(refreshListener);
     }
 
     @SuppressWarnings({"cast", "RedundantCast"})
@@ -154,6 +160,7 @@ public final class UiPlugin extends AbstractUIPlugin {
         CorePlugin.listenerRegistry().removeEventListener(this.workingSetsAddingProjectCreatedListener);
         CorePlugin.listenerRegistry().removeEventListener(this.executionShowingBuildLaunchRequestListener);
         DebugPlugin.getDefault().getLaunchManager().removeLaunchListener(this.consoleShowingLaunchListener);
+        getWorkbench().getService(ICommandService.class).removeExecutionListener(refreshListener);
     }
 
     public static UiPlugin getInstance() {

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/workspace/GradleClasspathContainerRefresher.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/workspace/GradleClasspathContainerRefresher.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ *     Ian Stewart-Binks (Red Hat Inc.) - Bug 473862 - F5 key shortcut doesn't refresh project folder contents
+ */
+package org.eclipse.buildship.ui.workspace;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.buildship.core.CorePlugin;
+import org.eclipse.buildship.core.GradlePluginsRuntimeException;
+import org.eclipse.buildship.core.console.ProcessStreams;
+import org.eclipse.buildship.core.workspace.GradleClasspathContainer;
+import org.eclipse.buildship.ui.util.predicate.Predicates;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdapterManager;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProgressListener;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableSet;
+import com.gradleware.tooling.toolingmodel.OmniGradleBuildStructure;
+import com.gradleware.tooling.toolingmodel.OmniGradleProjectStructure;
+import com.gradleware.tooling.toolingmodel.repository.FetchStrategy;
+import com.gradleware.tooling.toolingmodel.repository.FixedRequestAttributes;
+import com.gradleware.tooling.toolingmodel.repository.TransientRequestAttributes;
+
+public class GradleClasspathContainerRefresher {
+    
+    public static void refresh(final ExecutionEvent event) {
+        Set<OmniGradleProjectStructure> rootProjects = collectSelectedRootGradleProjects(event);
+        for (IJavaProject javaProject : collectAllRelatedWorkspaceProjects(rootProjects)) {
+            GradleClasspathContainer.requestUpdateOf(javaProject);
+        }
+    }
+
+    private static List<IJavaProject> collectAllRelatedWorkspaceProjects(Set<OmniGradleProjectStructure> rootProjects) {
+        final ImmutableSet<String> allProjectNames = getAllProjectNames(rootProjects);
+        return getExistingJavaProjects(allProjectNames);
+    }
+
+    private static ImmutableSet<String> getAllProjectNames(Set<OmniGradleProjectStructure> rootProjects) {
+        ImmutableSet.Builder<String> relatedProjects = ImmutableSet.builder();
+        for (OmniGradleProjectStructure rootProject : rootProjects) {
+            relatedProjects.addAll(getAllProjectNamesInGradleRootProject(rootProject));
+        }
+
+        return relatedProjects.build();
+    }
+
+    private static List<String> getAllProjectNamesInGradleRootProject(OmniGradleProjectStructure root) {
+        Builder<String> result = ImmutableList.builder();
+        result.add(root.getName());
+        for (OmniGradleProjectStructure child : root.getChildren()) {
+            result.add(child.getName());
+        }
+        return result.build();
+    }
+
+    private static List<IJavaProject> getExistingJavaProjects(final ImmutableSet<String> projectNames) {
+        return FluentIterable.from(CorePlugin.workspaceOperations().getAllProjects()).filter(new Predicate<IProject>() {
+
+            @Override
+            public boolean apply(IProject project) {
+                try {
+                    return project.isAccessible() && projectNames.contains(project.getName()) && project.hasNature(JavaCore.NATURE_ID);
+                } catch (CoreException e) {
+                    throw new GradlePluginsRuntimeException(e);
+                }
+            }
+        }).transform(new Function<IProject, IJavaProject>() {
+
+            @Override
+            public IJavaProject apply(IProject project) {
+                return JavaCore.create(project);
+            }
+        }).toList();
+    }
+
+    private static Set<OmniGradleProjectStructure> collectSelectedRootGradleProjects(ExecutionEvent event) {
+        return FluentIterable.from(collectSelectedProjects(event)).filter(Predicates.hasGradleNature()).transform(new Function<IProject, OmniGradleProjectStructure>() {
+
+            @Override
+            public OmniGradleProjectStructure apply(IProject javaProject) {
+                FixedRequestAttributes requestAttributes = CorePlugin.projectConfigurationManager().readProjectConfiguration(javaProject.getProject()).getRequestAttributes();
+                ProcessStreams stream = CorePlugin.processStreamsProvider().getBackgroundJobProcessStreams();
+
+                OmniGradleBuildStructure structure = CorePlugin
+                        .modelRepositoryProvider()
+                        .getModelRepository(requestAttributes)
+                        .fetchGradleBuildStructure(new TransientRequestAttributes(false, stream.getOutput(), stream.getError(), stream.getInput(),
+                                ImmutableList.<ProgressListener> of(), ImmutableList.<org.gradle.tooling.events.ProgressListener> of(), GradleConnector
+                                        .newCancellationTokenSource().token()), FetchStrategy.LOAD_IF_NOT_CACHED);
+                return structure.getRootProject();
+            }
+        }).toSet();
+    }
+
+    private static List<IProject> collectSelectedProjects(ExecutionEvent event) {
+        ISelection currentSelection = HandlerUtil.getCurrentSelection(event);
+        Builder<IProject> result = ImmutableList.builder();
+        if (currentSelection instanceof IStructuredSelection) {
+            IStructuredSelection selection = (IStructuredSelection) currentSelection;
+            IAdapterManager adapterManager = Platform.getAdapterManager();
+            for (Object selectionItem : selection.toList()) {
+                @SuppressWarnings({"cast", "RedundantCast"})
+                IResource resource = (IResource) adapterManager.getAdapter(selectionItem, IResource.class);
+                if (resource != null) {
+                    IProject project = resource.getProject();
+                    result.add(project);
+                }
+            }
+        }
+        return result.build();
+    }
+
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/workspace/RefreshGradleClasspathContainerHandler.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/workspace/RefreshGradleClasspathContainerHandler.java
@@ -7,48 +7,14 @@
  *
  * Contributors:
  *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ *     Ian Stewart-Binks (Red Hat Inc.) - Bug 473862 - F5 key shortcut doesn't refresh project folder contents
  */
 
 package org.eclipse.buildship.ui.workspace;
 
-import java.util.List;
-import java.util.Set;
-
-import org.gradle.tooling.GradleConnector;
-import org.gradle.tooling.ProgressListener;
-
-import com.google.common.base.Function;
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
-import com.google.common.collect.ImmutableSet;
-
-import com.gradleware.tooling.toolingmodel.OmniGradleBuildStructure;
-import com.gradleware.tooling.toolingmodel.OmniGradleProjectStructure;
-import com.gradleware.tooling.toolingmodel.repository.FetchStrategy;
-import com.gradleware.tooling.toolingmodel.repository.FixedRequestAttributes;
-import com.gradleware.tooling.toolingmodel.repository.TransientRequestAttributes;
-
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
-import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IAdapterManager;
-import org.eclipse.core.runtime.Platform;
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.ui.handlers.HandlerUtil;
-
-import org.eclipse.buildship.core.CorePlugin;
-import org.eclipse.buildship.core.GradlePluginsRuntimeException;
-import org.eclipse.buildship.core.console.ProcessStreams;
-import org.eclipse.buildship.core.workspace.GradleClasspathContainer;
-import org.eclipse.buildship.ui.util.predicate.Predicates;
 
 /**
  * Refreshes the classpath for all Gradle projects that belong to the same builds as the currently selected Gradle projects.
@@ -57,91 +23,8 @@ public final class RefreshGradleClasspathContainerHandler extends AbstractHandle
 
     @Override
     public Object execute(final ExecutionEvent event) throws ExecutionException {
-        Set<OmniGradleProjectStructure> rootProjects = collectSelectedRootGradleProjects(event);
-        for (IJavaProject javaProject : collectAllRelatedWorkspaceProjects(rootProjects)) {
-            GradleClasspathContainer.requestUpdateOf(javaProject);
-        }
+        GradleClasspathContainerRefresher.refresh(event);
         return null;
-    }
-
-    private List<IJavaProject> collectAllRelatedWorkspaceProjects(Set<OmniGradleProjectStructure> rootProjects) {
-        final ImmutableSet<String> allProjectNames = getAllProjectNames(rootProjects);
-        return getExistingJavaProjects(allProjectNames);
-    }
-
-    private ImmutableSet<String> getAllProjectNames(Set<OmniGradleProjectStructure> rootProjects) {
-        ImmutableSet.Builder<String> relatedProjects = ImmutableSet.builder();
-        for (OmniGradleProjectStructure rootProject : rootProjects) {
-            relatedProjects.addAll(getAllProjectNamesInGradleRootProject(rootProject));
-        }
-
-        return relatedProjects.build();
-    }
-
-    private List<String> getAllProjectNamesInGradleRootProject(OmniGradleProjectStructure root) {
-        Builder<String> result = ImmutableList.builder();
-        result.add(root.getName());
-        for (OmniGradleProjectStructure child : root.getChildren()) {
-            result.add(child.getName());
-        }
-        return result.build();
-    }
-
-    private List<IJavaProject> getExistingJavaProjects(final ImmutableSet<String> projectNames) {
-        return FluentIterable.from(CorePlugin.workspaceOperations().getAllProjects()).filter(new Predicate<IProject>() {
-
-            @Override
-            public boolean apply(IProject project) {
-                try {
-                    return project.isAccessible() && projectNames.contains(project.getName()) && project.hasNature(JavaCore.NATURE_ID);
-                } catch (CoreException e) {
-                    throw new GradlePluginsRuntimeException(e);
-                }
-            }
-        }).transform(new Function<IProject, IJavaProject>() {
-
-            @Override
-            public IJavaProject apply(IProject project) {
-                return JavaCore.create(project);
-            }
-        }).toList();
-    }
-
-    private Set<OmniGradleProjectStructure> collectSelectedRootGradleProjects(ExecutionEvent event) {
-        return FluentIterable.from(collectSelectedProjects(event)).filter(Predicates.hasGradleNature()).transform(new Function<IProject, OmniGradleProjectStructure>() {
-
-            @Override
-            public OmniGradleProjectStructure apply(IProject javaProject) {
-                FixedRequestAttributes requestAttributes = CorePlugin.projectConfigurationManager().readProjectConfiguration(javaProject.getProject()).getRequestAttributes();
-                ProcessStreams stream = CorePlugin.processStreamsProvider().getBackgroundJobProcessStreams();
-
-                OmniGradleBuildStructure structure = CorePlugin
-                        .modelRepositoryProvider()
-                        .getModelRepository(requestAttributes)
-                        .fetchGradleBuildStructure(new TransientRequestAttributes(false, stream.getOutput(), stream.getError(), stream.getInput(),
-                                ImmutableList.<ProgressListener> of(), ImmutableList.<org.gradle.tooling.events.ProgressListener> of(), GradleConnector
-                                        .newCancellationTokenSource().token()), FetchStrategy.LOAD_IF_NOT_CACHED);
-                return structure.getRootProject();
-            }
-        }).toSet();
-    }
-
-    private List<IProject> collectSelectedProjects(ExecutionEvent event) {
-        ISelection currentSelection = HandlerUtil.getCurrentSelection(event);
-        Builder<IProject> result = ImmutableList.builder();
-        if (currentSelection instanceof IStructuredSelection) {
-            IStructuredSelection selection = (IStructuredSelection) currentSelection;
-            IAdapterManager adapterManager = Platform.getAdapterManager();
-            for (Object selectionItem : selection.toList()) {
-                @SuppressWarnings({"cast", "RedundantCast"})
-                IResource resource = (IResource) adapterManager.getAdapter(selectionItem, IResource.class);
-                if (resource != null) {
-                    IProject project = resource.getProject();
-                    result.add(project);
-                }
-            }
-        }
-        return result.build();
     }
 
 }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/workspace/RefreshListener.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/workspace/RefreshListener.java
@@ -33,13 +33,12 @@ public class RefreshListener implements IExecutionListener {
 
     @Override
     public void postExecuteSuccess(String commandId, Object returnValue) {
-        
     }
 
     @Override
     public void preExecute(String commandId, ExecutionEvent event) {
         if (commandId.equals("org.eclipse.ui.file.refresh")
-                && PlatformUI.getWorkbench().getService(IContextService.class).getActiveContextIds().contains(UiPluginConstants.GRADLE_NATURE_CONTEXT_ID)) {
+                && ((IContextService) PlatformUI.getWorkbench().getService(IContextService.class)).getActiveContextIds().contains(UiPluginConstants.GRADLE_NATURE_CONTEXT_ID)) {
             GradleClasspathContainerRefresher.refresh(event);
         }
     }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/workspace/RefreshListener.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/workspace/RefreshListener.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Ian Stewart-Binks (Red Hat Inc.) - Bug 473862 - F5 key shortcut doesn't refresh project folder contents
+ */
+package org.eclipse.buildship.ui.workspace;
+
+import org.eclipse.buildship.ui.UiPluginConstants;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.IExecutionListener;
+import org.eclipse.core.commands.NotHandledException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.contexts.IContextService;
+
+/**
+ * Listens for the default Eclipse refresh command.
+ */
+public class RefreshListener implements IExecutionListener {
+
+    @Override
+    public void notHandled(String commandId, NotHandledException exception) {
+    }
+
+    @Override
+    public void postExecuteFailure(String commandId, ExecutionException exception) {
+    }
+
+    @Override
+    public void postExecuteSuccess(String commandId, Object returnValue) {
+        
+    }
+
+    @Override
+    public void preExecute(String commandId, ExecutionEvent event) {
+        if (commandId.equals("org.eclipse.ui.file.refresh")
+                && PlatformUI.getWorkbench().getService(IContextService.class).getActiveContextIds().contains(UiPluginConstants.GRADLE_NATURE_CONTEXT_ID)) {
+            GradleClasspathContainerRefresher.refresh(event);
+        }
+    }
+
+}


### PR DESCRIPTION
Buildship's refresh functionality current overrides the default Eclipse refresh functionality.

This pull request solves the problem by listening for Eclipse's default refresh command. When Buildship detects that the default refresh is being called, it invokes its own refresh. This means that Buildship's refresh command is not limited to just being bound to the 'F5' key, as it was previously, and it also ensures that any changes made to the default Eclipse refresh are persisted (i.e., this is better than just calling `refreshLocal`, as such an approach only tries to mimic the refresh functionality. If the default refresh changed, then Buildship would break the default Eclipse functionality. Such a change can be found [here](https://github.com/Ian-Stewart-Binks/buildship/tree/Bug-473348).)

This approach also ensures that the refresh can be invoked manually by the user through File > Gradle > Refresh Gradle Project'.