### PR TITLE
Bug 475015 - Have preview pages reviewed by native speaker

### DIFF
--- a/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.properties
+++ b/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/wizard/project/ProjectWizardMessages.properties
@@ -18,7 +18,7 @@ Title_NewGradleProjectWizardPage=New Gradle Project
 Title_NewGradleProjectOptionsWizardPage=Options
 Title_NewGradleProjectPreviewWizardPage=Preview
 
-CheckButton_ShowWelcomePageNextTime=Show welcome page next time the wizard appears
+CheckButton_ShowWelcomePageNextTime=Show the welcome page the next time the wizard appears
 
 Label_ProjectRootDirectory=Project root directory
 Label_GradleUserHome=Gradle user home directory
@@ -69,9 +69,9 @@ PreviewStructureInfo_Details=Buildship queries only basic structural information
 Import_Wizard_Welcome_Page_Name=GradleWelcome
 Import_Wizard_Paragraph_Main_Title=How to experience the best Gradle integration
 Import_Wizard_Paragraph_Title_Smart_Project_Import=Smart project import
-Import_Wizard_Paragraph_Content_Smart_Project_Import=\nPoint the wizard to the root location of the Gradle project to import. Buildship will take care of importing all the belonging projects. All imported projects that already contain an Eclipse .project file will be left alone, aside from being added the Gradle nature.
+Import_Wizard_Paragraph_Content_Smart_Project_Import=\nPoint the wizard to the root location of the Gradle project to import. Buildship will take care of importing all the belonging projects. All imported projects that already contain an Eclipse .project file will only have the Gradle nature added.
 Import_Wizard_Paragraph_Title_Gradle_Wrapper=Gradle Wrapper
-Import_Wizard_Paragraph_Content_Gradle_Wrapper=\nYou will experience the best Gradle integration if you make use of the Gradle wrapper in your Gradle build and configure it to use the latest released version of Gradle. Using the Gradle wrapper also makes the build most sharable between multiple users.
+Import_Wizard_Paragraph_Content_Gradle_Wrapper=\nYou will experience the best Gradle integration if you make use of the Gradle wrapper in your Gradle build and configure it to use the latest released version of Gradle. Using the Gradle wrapper also makes the build more sharable between multiple users.
 Import_Wizard_Paragraph_Title_Advanced_Options=Advanced options
 Import_Wizard_Paragraph_Content_Advanced_Options=\nUnless you have a very specific reason, leave the advanced options at their default values. The advanced options can be useful to quickly try different settings and see their impact on the import.
 


### PR DESCRIPTION
This pull request makes minor modifications to the project import/creation messages to make them sound more natural.

The existing messages already sounded natural, and are very well-written. I was curious about some of the uses of *best of* and *the best of*, but I concluded that their current uses are appropriate. 

A message that stuck out to me the most was *All imported projects that already contain an Eclipse .project file will be left alone, aside from being added the Gradle nature.*. I've changed it, but I'm uncertain whether it's any better.

@donat / @etienne, Are there any messages in particular that you're concerned about? I can ask some of the other people in the Red Hat office what they think.