### PR TITLE
Resolved org.eclipse.core.commands.common.NotDefinedException during the build

### DIFF
--- a/org.eclipse.buildship.ui/plugin.xml
+++ b/org.eclipse.buildship.ui/plugin.xml
@@ -182,6 +182,12 @@
                 name="In Gradle Tasks View"
                 parentId="org.eclipse.ui.contexts.window">
         </context>
+        <context
+              description="This context is activated, when the selection contain an IProject with the Gradle nature"
+              id="org.eclipse.buildship.ui.contexts.gradlenature"
+              name="Context for selected IProjects with Gradle nature"
+              parentId="org.eclipse.ui.contexts.window">
+        </context>
     </extension>
     <extension
           point="org.eclipse.ui.bindings">


### PR DESCRIPTION
It seems that in a certain commit the "org.eclipse.buildship.ui.contexts.gradlenature" context has been removed from the plugin.xml
Therefore the context could not be found any more.

After applying this PR the build won't have the org.eclipse.core.commands.common.NotDefinedException errors any more