### PR TITLE
Use Predicates#hasGradleNature() in Classpath refresher and ContextActivatingSelectionListener

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/collections/AdapterFunction.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/collections/AdapterFunction.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ */
+
+package org.eclipse.buildship.core.util.collections;
+
+import org.eclipse.core.runtime.IAdapterManager;
+
+import com.google.common.base.Function;
+
+/**
+ * {@link Function} which is used to get a certain adapter from an input object.
+ *
+ * @param <T>
+ */
+public final class AdapterFunction<T> implements Function<Object, T> {
+
+    private Class<T> adapter;
+    private IAdapterManager adapterManager;
+
+    public AdapterFunction(Class<T> adapter, IAdapterManager adapterManager) {
+        this.adapter = adapter;
+        this.adapterManager = adapterManager;
+    }
+
+    @SuppressWarnings({ "unchecked", "cast", "RedundantCast" })
+    @Override
+    public T apply(Object adaptable) {
+        return (T) this.adapterManager.getAdapter(adaptable, this.adapter);
+    }
+
+}

--- a/org.eclipse.buildship.ui/plugin.xml
+++ b/org.eclipse.buildship.ui/plugin.xml
@@ -171,6 +171,19 @@
       <handler
             commandId="org.eclipse.buildship.ui.commands.refreshproject"
             class="org.eclipse.buildship.ui.workspace.RefreshProjectHandler">
+         <activeWhen>
+            <and>
+               <with
+                     variable="activeContexts">
+                  <iterate
+                        operator="or">
+                     <equals
+                           value="org.eclipse.buildship.ui.contexts.gradlenature">
+                     </equals>
+                  </iterate>
+               </with>
+            </and>
+         </activeWhen>
       </handler>
     </extension>
 


### PR DESCRIPTION
Resolves the Task: "There is a mismatch between the logic when the "Refresh Project" context entry is made visible in the context menu and when the execution starts. We should unify the logic from the predicate used by ContextActivatingSelectionListener and GradleClasspathContainerRefresher#collectSelectedProjects()."

* It lets the GradleClasspathContainerRefresher also use the Predicates#hasGradleNature() predicate for getting the right projects to be refreshed