### PR TITLE
escape slashes in project name

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultWorkspaceOperations.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultWorkspaceOperations.java
@@ -342,7 +342,7 @@ public final class DefaultWorkspaceOperations implements WorkspaceOperations {
         // as the folder name (even when the project is renamed the underlying folder is also renamed)
         // consequently, for this use case, we have to ignore the name provided by the Gradle model
         // and instead use the folder name
-        return isDirectChildOfWorkspaceRootFolder(location) ? location.getName() : nameInGradleModel;
+        return isDirectChildOfWorkspaceRootFolder(location) ? location.getName() : nameInGradleModel.replace('/', '.');
     }
 
     private IPath resolveProjectLocation(File location) {


### PR DESCRIPTION
Slashes can appear in gradle project names, for example when using includeFlat('libs/lib1').
They need to be escaped when importting into eclipse