### PR TITLE
Bug 471943 - Make Buildship work behind the firewall

### DIFF
--- a/org.eclipse.buildship.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.core/META-INF/MANIFEST.MF
@@ -14,6 +14,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.junit.core,
  org.eclipse.jdt.launching,
  org.eclipse.debug.core,
+ org.eclipse.core.net,
  org.slf4j.api;bundle-version="[1.7.2,1.8.0)",
  com.google.gson;bundle-version="[2.2.4,2.3.0)",
  com.gradleware.tooling.model;bundle-version="[0.6.0,0.7.0)"

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/proxy/EclipseProxySettingsSupporter.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/proxy/EclipseProxySettingsSupporter.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Ian Stewart-Binks (Red Hat, Inc.) - Bug 471943 - Make Buildship work behind the firewall
+ */
+
+package org.eclipse.buildship.core.proxy;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import com.google.common.base.Optional;
+import org.eclipse.core.net.proxy.IProxyData;
+import org.eclipse.buildship.core.CorePlugin;
+
+/**
+ * This class propagates Eclipse's proxy settings to System settings, and ensures that the existing System proxy settings
+ * are persisted.
+ */
+public class EclipseProxySettingsSupporter {
+
+    private static String savedHTTPProxyHost, savedHTTPProxyPort, savedHTTPProxyUser, savedHTTPProxyPassword;
+    private static final Lock lock = new ReentrantLock();
+
+    /**
+     * Configures the System properties proxy settings based on the Eclipse proxy settings.
+     */
+    public static void configureEclipseProxySettings() {
+        synchronized(EclipseProxySettingsSupporter.class) {
+            storeSystemProxySettings();
+            configureHTTPProxySettings();
+        }
+    }
+
+    private static void configureHTTPProxySettings() {
+        Optional<IProxyData> httpProxyData = Optional.of(CorePlugin.getProxyService().getProxyData(IProxyData.HTTP_PROXY_TYPE));
+
+        if (httpProxyData.isPresent()) {
+            if (httpProxyData.get().getHost() != null) {
+                System.setProperty("http.proxyHost", httpProxyData.get().getHost());
+            }
+            if (httpProxyData.get().getPort() != -1) {
+                System.setProperty("http.proxyPort", Integer.toString(httpProxyData.get().getPort()));
+            }
+            if (httpProxyData.get().getUserId() != null) {
+                 System.setProperty("http.proxyUser", httpProxyData.get().getUserId());
+            }
+            if (httpProxyData.get().getPassword() != null) {
+                System.setProperty("http.proxyPassword", httpProxyData.get().getPassword());
+            }
+        }
+    }
+
+    /**
+     * Must be called in conjunction with the {@link #restoreSystemProxySettings() restoreSystemProxySettings}
+     * restoreSystemProxySettings method.
+     */
+    private static void storeSystemProxySettings() {
+        // The thread that owns the lock is the thread that is responsible for ensuring that the System
+        // proxy settings persist. If a thread does not/cannot hold the lock, it does not have the responsibility.
+        if (EclipseProxySettingsSupporter.lock.tryLock()) {
+            EclipseProxySettingsSupporter.savedHTTPProxyHost = System.getProperty("http.proxyHost");
+            EclipseProxySettingsSupporter.savedHTTPProxyPort = System.getProperty("http.proxyPort");
+            EclipseProxySettingsSupporter.savedHTTPProxyUser = System.getProperty("http.proxyUser");
+            EclipseProxySettingsSupporter.savedHTTPProxyPassword = System.getProperty("http.proxyPassword");
+        }
+    }
+
+    /**
+     * Restores the proxy settings in the system properties to what they were before
+     * the EclipseProxySettingsSupporter changed them.
+     */
+    public static void restoreSystemProxySettings() {
+        if (((ReentrantLock) EclipseProxySettingsSupporter.lock).isHeldByCurrentThread()) {
+            resetOrClearSystemProperty("http.proxyHost", EclipseProxySettingsSupporter.savedHTTPProxyHost);
+            resetOrClearSystemProperty("http.proxyPort", EclipseProxySettingsSupporter.savedHTTPProxyPort);
+            resetOrClearSystemProperty("http.proxyUser", EclipseProxySettingsSupporter.savedHTTPProxyUser);
+            resetOrClearSystemProperty("http.proxyPassword", EclipseProxySettingsSupporter.savedHTTPProxyPassword);
+            EclipseProxySettingsSupporter.lock.unlock();
+        }
+    }
+
+    private static void resetOrClearSystemProperty(String property, String savedValue) {
+        if (savedValue == null) {
+            System.clearProperty(property);
+        } else {
+            System.setProperty(property, savedValue);
+        }
+    }
+
+}

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/progress/ToolingApiJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/progress/ToolingApiJob.java
@@ -11,13 +11,15 @@
 
 package org.eclipse.buildship.core.util.progress;
 
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.gradle.tooling.CancellationToken;
 import org.gradle.tooling.CancellationTokenSource;
 import org.gradle.tooling.GradleConnector;
 
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.jobs.Job;
+
+import org.eclipse.buildship.core.proxy.EclipseProxySettingsSupporter;
 
 /**
  * Base class for cancellable jobs that invoke the Gradle Tooling API.
@@ -61,10 +63,16 @@ public abstract class ToolingApiJob extends Job {
     @Override
     public final IStatus run(final IProgressMonitor monitor) {
         ToolingApiInvoker invoker = new ToolingApiInvoker(this.workName, this.notifyUserAboutBuildFailures);
+        EclipseProxySettingsSupporter.configureEclipseProxySettings();
+
         return invoker.invoke(new ToolingApiCommand() {
             @Override
             public void run() throws Exception {
-                runToolingApiJob(monitor);
+                try {
+                    runToolingApiJob(monitor);
+                } finally {
+                    EclipseProxySettingsSupporter.restoreSystemProxySettings();
+                }
             }
         }, monitor);
     }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/progress/ToolingApiWorkspaceJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/progress/ToolingApiWorkspaceJob.java
@@ -20,6 +20,8 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 
+import org.eclipse.buildship.core.proxy.EclipseProxySettingsSupporter;
+
 /**
  * Base class for cancellable workspace jobs that invoke the Gradle Tooling API.
  *
@@ -68,10 +70,16 @@ public abstract class ToolingApiWorkspaceJob extends WorkspaceJob {
     @Override
     public final IStatus runInWorkspace(final IProgressMonitor monitor) throws CoreException {
         ToolingApiInvoker invoker = new ToolingApiInvoker(this.workName, this.notifyUserAboutBuildFailures);
+        EclipseProxySettingsSupporter.configureEclipseProxySettings();
+
         return invoker.invoke(new ToolingApiCommand() {
             @Override
             public void run() throws Exception {
-                runToolingApiJobInWorkspace(monitor);
+                try {
+                    runToolingApiJobInWorkspace(monitor);
+                } finally {
+                    EclipseProxySettingsSupporter.restoreSystemProxySettings();
+                }
             }
         }, monitor);
     }

--- a/org.eclipse.buildship.ui.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.ui.test/META-INF/MANIFEST.MF
@@ -10,6 +10,7 @@ Comment: junit has to be a required bundle, otherwise the tests won't launch for
 Require-Bundle: org.eclipse.swtbot.eclipse.finder,
  org.eclipse.swtbot.junit4_x,
  org.junit,
+ org.eclipse.core.net,
  org.apache.log4j
 Bundle-ClassPath: .,
  lib/cglib-nodep-3.1.jar,


### PR DESCRIPTION
This pull request allows Buildship to propagate proxy settings defined in Eclipse to the System settings. The original story can be found [here](https://github.com/eclipse/buildship/blob/f57052cb1489196a21698c92efc64b2c3775ee59/docs/stories/Proxy.md).

This pull request also tackles the issue of concurrency for different `ToolingApiJob`/`ToolingApiWorkspaceJob`s that are trying to store default system properties.

Tests have been excluded from this pull request such that it can be merged in before the Eclipse RC build. I will continue working on the tests. I have not performed smoke testing on the current code.