### PR TITLE
This adds a hand cursor to the previewpage's clickable labels

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectPreviewWizardPage.java
@@ -143,6 +143,7 @@ public final class ProjectPreviewWizardPage extends AbstractWizardPage {
         this.gradleVersionLabel = uiBuilderFactory.newLabel(gradleVersionContainer).alignLeft().disabled().font(this.valueFont).control();
         this.gradleVersionWarningLabel = uiBuilderFactory.newLabel(gradleVersionContainer).alignLeft().control();
         this.gradleVersionWarningLabel.setImage(PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJS_WARN_TSK));
+        this.gradleVersionWarningLabel.setCursor(gradleVersionContainer.getDisplay().getSystemCursor(SWT.CURSOR_HAND));
         this.gradleVersionWarningLabel.setToolTipText(ProjectWizardMessages.Limitations_Tooltip);
         this.gradleVersionWarningLabel.addMouseListener(new MouseAdapter() {
 
@@ -188,6 +189,7 @@ public final class ProjectPreviewWizardPage extends AbstractWizardPage {
         // create an info icon explaining that the preview can deviate from actual values
         Label previewStructureInfoLabel = uiBuilderFactory.newLabel(container).alignLeft().control();
         previewStructureInfoLabel.setImage(PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_OBJS_INFO_TSK));
+        previewStructureInfoLabel.setCursor(container.getDisplay().getSystemCursor(SWT.CURSOR_HAND));
         previewStructureInfoLabel.setToolTipText(ProjectWizardMessages.PreviewStructureInfo_Tooltip);
         previewStructureInfoLabel.addMouseListener(new MouseAdapter() {
 


### PR DESCRIPTION
This PR adds a hand cursor to all clickable labels in the preview page, so that the user gets a clue that this label can also be clicked.