### PR TITLE
Bug 477365 - Show multiple exceptions on one error dialog

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/notification/UserNotification.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/notification/UserNotification.java
@@ -19,12 +19,18 @@ public interface UserNotification {
     /**
      * Notifies the user about the occurrence of an error.
      *
-     * @param headline the headline of the error
-     * @param message the concise error description
-     * @param details the detailed error description
-     * @param severity the severity of the error; must be one of the valid {@link org.eclipse.core.runtime.IStatus#getSeverity()} values
-     * @param throwable the exception to notify the user about
+     * @param headline
+     *            the headline of the error
+     * @param message
+     *            the concise error description
+     * @param details
+     *            the detailed error description
+     * @param severity
+     *            the severity of the error; must be one of the valid
+     *            {@link org.eclipse.core.runtime.IStatus#getSeverity()} values
+     * @param throwables
+     *            the exception to notify the user about
      */
-    void errorOccurred(String headline, String message, String details, int severity, Throwable throwable);
+    void errorOccurred(String headline, String message, String details, int severity, Throwable... throwables);
 
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/notification/internal/ConsoleUserNotification.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/notification/internal/ConsoleUserNotification.java
@@ -19,7 +19,7 @@ import org.eclipse.buildship.core.notification.UserNotification;
 public final class ConsoleUserNotification implements UserNotification {
 
     @Override
-    public void errorOccurred(String headline, String message, String details, int severity, Throwable throwable) {
+    public void errorOccurred(String headline, String message, String details, int severity, Throwable... throwable) {
         System.err.println("User notification: headline=[" + headline + "], message=[" + message + "], details=[" + details + "], severity=" + severity + "], exception=[" + throwable + "]");
     }
 

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/dialog/ErrorDialogTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/dialog/ErrorDialogTest.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ */
+
+package org.eclipse.buildship.ui.dialog
+
+import org.eclipse.buildship.core.CorePlugin
+import org.eclipse.buildship.ui.i18n.UiMessages
+import org.eclipse.buildship.ui.notification.ExceptionDetailsDialog
+import org.eclipse.buildship.ui.test.fixtures.SwtBotSpecification
+import org.eclipse.core.runtime.IStatus
+import org.eclipse.jface.dialogs.IDialogConstants
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException
+import org.eclipse.swtbot.swt.finder.waits.Conditions
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTable
+
+class ErrorDialogTest extends SwtBotSpecification {
+
+    def "Open ExceptionDetailsDialog with single Throwable without TableViewer for errors"() {
+        setup:
+        // open dialog in a different thread so that the SWTBot is not blocked
+        bot.activeShell().display.asyncExec({
+            def userNatification = CorePlugin.userNotification()
+            userNatification.errorOccurred("headline", 'message', 'details', IStatus.ERROR, new NullPointerException('Self instanciated Buildship NPE'))
+        } as Runnable
+        )
+        when:
+        SWTBotShell shell = bot.shell("headline")
+        shell.activate()
+        bot.waitUntil(Conditions.shellIsActive("headline"))
+        bot.tableWithId(ExceptionDetailsDialog.class.getName() + "TableViewer:errorViewer")
+
+        then:
+        WidgetNotFoundException ex = thrown()
+
+        ex.message == "Could not find widget matching: (of type 'Table' and with key/value (org.eclipse.swtbot.widget.key/org.eclipse.buildship.ui.notification.ExceptionDetailsDialogTableViewer:errorViewer))"
+
+        cleanup:
+        // press ok to close the Exception dialog
+        bot.button(IDialogConstants.OK_LABEL).click()
+    }
+
+    def "Open ExceptionDetailsDialog with multiple Throwables with TableViewer for errors"() {
+        setup:
+        // open dialog in a different thread so that the SWTBot is not blocked
+        bot.activeShell().display.asyncExec({
+            def userNatification = CorePlugin.userNotification()
+            userNatification.errorOccurred(UiMessages.Dialog_Title_Multiple_Error, 'message', 'details', IStatus.ERROR, new NullPointerException('Self instanciated Buildship NPE'), new RuntimeException('Self instanciated Buildship RuntimeException'))
+        } as Runnable
+        )
+        when:
+        SWTBotShell shell = bot.shell(UiMessages.Dialog_Title_Multiple_Error)
+        shell.activate()
+        bot.waitUntil(Conditions.shellIsActive(UiMessages.Dialog_Title_Multiple_Error))
+        bot.tableWithId(ExceptionDetailsDialog.class.getName() + "TableViewer:errorViewer")
+
+        then:
+        notThrown WidgetNotFoundException
+
+        cleanup:
+        // press ok to close the Exception dialog
+        bot.button(IDialogConstants.OK_LABEL).click()
+    }
+
+    def "Open ExceptionDetailsDialog, select the second error and show it's details"() {
+        setup:
+        // open dialog in a different thread so that the SWTBot is not blocked
+        bot.activeShell().display.asyncExec({
+            def userNatification = CorePlugin.userNotification()
+            userNatification.errorOccurred(UiMessages.Dialog_Title_Multiple_Error, 'message', 'details', IStatus.ERROR, new NullPointerException('Self instanciated Buildship NPE'), new RuntimeException('Self instanciated Buildship RuntimeException'))
+        } as Runnable
+        )
+        SWTBotShell shell = bot.shell(UiMessages.Dialog_Title_Multiple_Error)
+        shell.activate()
+        bot.waitUntil(Conditions.shellIsActive(UiMessages.Dialog_Title_Multiple_Error))
+        SWTBotTable errorTable = bot.tableWithId(ExceptionDetailsDialog.class.getName() + "TableViewer:errorViewer")
+        bot.table().getTableItem(1).select()
+
+        when:
+        bot.button(IDialogConstants.SHOW_DETAILS_LABEL).click();
+
+        String text = bot.text().getText();
+
+        then:
+        // ensure that only the error of the selected RuntimeException shown in the details text
+        text.contains("RuntimeException")
+
+        !text.contains("NPE")
+
+        cleanup:
+        // press ok to close the Exception dialog
+        bot.button(IDialogConstants.OK_LABEL).click()
+    }
+
+    def "Open ExceptionDetailsDialog with multiple errors and open details without selecting an error"() {
+        setup:
+        // open dialog in a different thread so that the SWTBot is not blocked
+        bot.activeShell().display.asyncExec({
+            def userNatification = CorePlugin.userNotification()
+            userNatification.errorOccurred(UiMessages.Dialog_Title_Multiple_Error, 'message', 'details', IStatus.ERROR, new NullPointerException('Self instanciated Buildship NPE'), new RuntimeException('Self instanciated Buildship RuntimeException'))
+        } as Runnable
+        )
+        SWTBotShell shell = bot.shell(UiMessages.Dialog_Title_Multiple_Error)
+        shell.activate()
+        bot.waitUntil(Conditions.shellIsActive(UiMessages.Dialog_Title_Multiple_Error))
+        SWTBotTable errorTable = bot.tableWithId(ExceptionDetailsDialog.class.getName() + "TableViewer:errorViewer")
+
+        when:
+        bot.button(IDialogConstants.SHOW_DETAILS_LABEL).click();
+
+        String text = bot.text().getText();
+
+        String selectionText = "selectionText"
+        String firstItemText = "firstItemText"
+
+        bot.activeShell().display.syncExec(
+                {
+                    selectionText = errorTable.widget.getSelection()[0].getText()
+                    firstItemText = errorTable.getTableItem(0).widget.getText()
+                } as Runnable
+                )
+
+        then:
+        // ensure that the first error in the dialog is selected...
+        errorTable.selectionCount() == 1
+        selectionText == firstItemText
+
+        // ...  and therefore the NPE error is shown in the details text
+        text.contains("NPE")
+
+        !text.contains("RuntimeException")
+
+
+        cleanup:
+        // press ok to close the Exception dialog
+        bot.button(IDialogConstants.OK_LABEL).click()
+    }
+
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/i18n/UiMessages.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/i18n/UiMessages.java
@@ -40,6 +40,8 @@ public final class UiMessages extends NLS {
 
     public static String Button_CopyFailuresToClipboard_Tooltip;
 
+    public static String Dialog_Title_Multiple_Error;
+
     static {
         // initialize resource bundle
         NLS.initializeMessages(BUNDLE_NAME, UiMessages.class);

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/notification/DialogUserNotification.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/notification/DialogUserNotification.java
@@ -11,9 +11,8 @@
 
 package org.eclipse.buildship.ui.notification;
 
-import org.eclipse.swt.widgets.Shell;
-
 import org.eclipse.buildship.core.notification.UserNotification;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.PlatformUI;
 
 /**
@@ -21,15 +20,24 @@ import org.eclipse.ui.PlatformUI;
  */
 public final class DialogUserNotification implements UserNotification {
 
+    private volatile ExceptionDetailsDialog dialog;
+
     @Override
-    public void errorOccurred(final String headline, final String message, final String details, final int severity, final Throwable throwable) {
+    public void errorOccurred(final String headline, final String message, final String details, final int severity,
+            final Throwable... throwables) {
         PlatformUI.getWorkbench().getDisplay().syncExec(new Runnable() {
 
             @Override
             public void run() {
                 Shell shell = PlatformUI.getWorkbench().getDisplay().getActiveShell();
-                ExceptionDetailsDialog dialog = new ExceptionDetailsDialog(shell, headline,  message, details, severity, throwable);
-                dialog.open();
+                if (DialogUserNotification.this.dialog == null || DialogUserNotification.this.dialog.getShell() == null
+                        || DialogUserNotification.this.dialog.getShell().isDisposed()) {
+                    DialogUserNotification.this.dialog = new ExceptionDetailsDialog(shell, headline, message, details,
+                            severity, throwables);
+                    DialogUserNotification.this.dialog.open();
+                } else {
+                    DialogUserNotification.this.dialog.addException(throwables);
+                }
             }
         });
     }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/notification/ExceptionDetailsDialog.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/notification/ExceptionDetailsDialog.java
@@ -13,13 +13,30 @@ package org.eclipse.buildship.ui.notification;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.io.Writer;
+import java.util.List;
 
-import com.google.common.base.Preconditions;
-
+import org.eclipse.buildship.core.GradlePluginsRuntimeException;
+import org.eclipse.buildship.ui.i18n.UiMessages;
+import org.eclipse.buildship.ui.util.font.FontUtils;
+import org.eclipse.buildship.ui.util.test.SWTBotWidgetIdentifierKey;
+import org.eclipse.core.databinding.beans.PojoProperties;
+import org.eclipse.core.databinding.observable.list.IListChangeListener;
+import org.eclipse.core.databinding.observable.list.IObservableList;
+import org.eclipse.core.databinding.observable.list.ListChangeEvent;
+import org.eclipse.core.databinding.property.Properties;
 import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jface.databinding.viewers.ViewerSupport;
 import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ISelectionChangedListener;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.viewers.StructuredViewer;
+import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.jface.window.SameShellProvider;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.dnd.Clipboard;
@@ -39,9 +56,9 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
 
-import org.eclipse.buildship.core.GradlePluginsRuntimeException;
-import org.eclipse.buildship.ui.i18n.UiMessages;
-import org.eclipse.buildship.ui.util.font.FontUtils;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 
 /**
  * Custom {@link Dialog} implementation showing an exception and its stacktrace.
@@ -55,21 +72,50 @@ public final class ExceptionDetailsDialog extends Dialog {
     private final String title;
     private final String message;
     private final String details;
-    private final Throwable throwable;
+    private final IObservableList throwables;
 
     private Button detailsButton;
     private Control stackTraceArea;
 
     private Clipboard clipboard;
+    private Text detailText;
+    private StructuredViewer errorViewer;
 
-    public ExceptionDetailsDialog(Shell shell, String title, String message, String details, int severity, Throwable throwable) {
+    public ExceptionDetailsDialog(Shell shell, String title, String message, String details, int severity,
+            Throwable... throwable) {
         super(new SameShellProvider(shell));
 
         this.image = getIconForSeverity(severity, shell);
         this.title = Preconditions.checkNotNull(title);
         this.message = Preconditions.checkNotNull(message);
         this.details = Preconditions.checkNotNull(details);
-        this.throwable = Preconditions.checkNotNull(throwable);
+
+        this.throwables = Properties.selfList(Throwable.class)
+                .observe(Lists.newArrayList(Preconditions.checkNotNull(throwable)));
+
+        this.throwables.addListChangeListener(new IListChangeListener() {
+
+            @Override
+            public void handleListChange(ListChangeEvent event) {
+
+                if (isMultiErrorDialog()) {
+                    if (ExceptionDetailsDialog.this.errorViewer == null
+                            || ExceptionDetailsDialog.this.errorViewer.getControl() == null
+                            || ExceptionDetailsDialog.this.errorViewer.getControl().isDisposed()) {
+                        // dispose the contents of the single error dialog ...
+                        Composite dialogAreaComposite = (Composite) ExceptionDetailsDialog.this.dialogArea;
+                        Control[] children = dialogAreaComposite.getChildren();
+                        for (Control control : children) {
+                            control.dispose();
+                        }
+                        // ... and create the MultiErrorDialog
+                        createMultiErrorDialog(dialogAreaComposite);
+                        relayoutShell();
+                    }
+                }
+
+            }
+        });
 
         setShellStyle(SWT.DIALOG_TRIM | SWT.RESIZE | SWT.APPLICATION_MODAL);
     }
@@ -77,19 +123,19 @@ public final class ExceptionDetailsDialog extends Dialog {
     private Image getIconForSeverity(int severity, Shell shell) {
         int swtImageKey;
         switch (severity) {
-            case IStatus.OK:
-            case IStatus.INFO:
-                swtImageKey = SWT.ICON_INFORMATION;
-                break;
-            case IStatus.WARNING:
-            case IStatus.CANCEL:
-                swtImageKey = SWT.ICON_WARNING;
-                break;
-            case IStatus.ERROR:
-                swtImageKey = SWT.ICON_ERROR;
-                break;
-            default:
-                throw new GradlePluginsRuntimeException("Can't find image for severity: " + severity);
+        case IStatus.OK:
+        case IStatus.INFO:
+            swtImageKey = SWT.ICON_INFORMATION;
+            break;
+        case IStatus.WARNING:
+        case IStatus.CANCEL:
+            swtImageKey = SWT.ICON_WARNING;
+            break;
+        case IStatus.ERROR:
+            swtImageKey = SWT.ICON_ERROR;
+            break;
+        default:
+            throw new GradlePluginsRuntimeException("Can't find image for severity: " + severity); //$NON-NLS-1$
         }
 
         return shell.getDisplay().getSystemImage(swtImageKey);
@@ -105,10 +151,56 @@ public final class ExceptionDetailsDialog extends Dialog {
     @Override
     protected Control createDialogArea(Composite parent) {
         Composite container = (Composite) super.createDialogArea(parent);
+        ((GridLayout) container.getLayout()).numColumns = 2;
         container.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
+        if (isMultiErrorDialog()) {
+            createMultiErrorDialog(container);
+        } else {
+            createSingleErrorDialog(container);
+        }
+
+        this.clipboard = new Clipboard(getShell().getDisplay());
+
+        return container;
+    }
+
+    private void createMultiErrorDialog(Composite container) {
+
+        // change the title of the shell
+        getShell().setText(UiMessages.Dialog_Title_Multiple_Error);
+
         // dialog image
-        ((GridLayout) container.getLayout()).numColumns = 2;
+        Label imageLabel = new Label(container, 0);
+        this.image.setBackground(imageLabel.getBackground());
+        imageLabel.setImage(this.image);
+        imageLabel.setLayoutData(new GridData(GridData.HORIZONTAL_ALIGN_CENTER | GridData.VERTICAL_ALIGN_BEGINNING));
+
+        // message label
+        Label messageLabel = new Label(container, SWT.WRAP);
+        messageLabel.setText(this.message);
+        GridDataFactory.swtDefaults().align(SWT.FILL, SWT.TOP).grab(true, false).applyTo(messageLabel);
+
+        this.errorViewer = new TableViewer(container);
+        this.errorViewer.getControl().setData(SWTBotWidgetIdentifierKey.DEFAULT_KEY,
+                ExceptionDetailsDialog.class.getName() + "TableViewer:errorViewer"); //$NON-NLS-1$
+        GridDataFactory.fillDefaults().grab(true, true).hint(SWT.DEFAULT, 80).span(2, 1)
+                .applyTo(this.errorViewer.getControl());
+        ViewerSupport.bind(this.errorViewer, this.throwables, PojoProperties.value("message")); //$NON-NLS-1$
+        this.errorViewer.addSelectionChangedListener(new ISelectionChangedListener() {
+
+            @Override
+            public void selectionChanged(SelectionChangedEvent event) {
+                if (ExceptionDetailsDialog.this.detailText != null
+                        && !ExceptionDetailsDialog.this.detailText.isDisposed()) {
+                    ExceptionDetailsDialog.this.detailText.setText(getStackTrace(getSelectedThrowables()));
+                }
+            }
+        });
+    }
+
+    private void createSingleErrorDialog(Composite container) {
+        // dialog image
         Label imageLabel = new Label(container, 0);
         this.image.setBackground(imageLabel.getBackground());
         imageLabel.setImage(this.image);
@@ -117,7 +209,7 @@ public final class ExceptionDetailsDialog extends Dialog {
         // composite to include all text widgets
         Composite textArea = new Composite(container, SWT.NONE);
         GridLayout textAreaLayout = new GridLayout(1, false);
-        textAreaLayout.verticalSpacing = FontUtils.getFontHeightInPixels(parent.getFont());
+        textAreaLayout.verticalSpacing = FontUtils.getFontHeightInPixels(container.getFont());
         textArea.setLayout(textAreaLayout);
         GridData textAreaLayoutData = new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1);
         textAreaLayoutData.widthHint = convertHorizontalDLUsToPixels(IDialogConstants.MINIMUM_MESSAGE_AREA_WIDTH);
@@ -138,18 +230,15 @@ public final class ExceptionDetailsDialog extends Dialog {
         detailsLabelGridData.verticalAlignment = SWT.TOP;
         detailsLabelGridData.grabExcessHorizontalSpace = true;
         detailsLabel.setLayoutData(detailsLabelGridData);
-
-        this.clipboard = new Clipboard(getShell().getDisplay());
-
-        return container;
     }
 
     @Override
     protected void createButtonsForButtonBar(Composite parent) {
-        Button copyExceptionButton = createButton(parent, COPY_EXCEPTION_BUTTON_ID, "", false);
+        Button copyExceptionButton = createButton(parent, COPY_EXCEPTION_BUTTON_ID, "", false); //$NON-NLS-1$
         copyExceptionButton.setToolTipText(UiMessages.Button_CopyFailuresToClipboard_Tooltip);
         copyExceptionButton.setImage(PlatformUI.getWorkbench().getSharedImages().getImage(ISharedImages.IMG_TOOL_COPY));
-        this.detailsButton = createButton(parent, IDialogConstants.DETAILS_ID, IDialogConstants.SHOW_DETAILS_LABEL, false);
+        this.detailsButton = createButton(parent, IDialogConstants.DETAILS_ID, IDialogConstants.SHOW_DETAILS_LABEL,
+                false);
         Button okButton = createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
         okButton.setFocus();
     }
@@ -157,8 +246,8 @@ public final class ExceptionDetailsDialog extends Dialog {
     @Override
     protected void setButtonLayoutData(Button button) {
         if (button.getData() != null && button.getData().equals(COPY_EXCEPTION_BUTTON_ID)) {
-            // do not set a width hint for the copy error button, like it is done in the super
-            // implementation
+            // do not set a width hint for the copy error button, like it is
+            // done in the super implementation
             GridDataFactory.swtDefaults().applyTo(button);
             return;
         }
@@ -167,7 +256,8 @@ public final class ExceptionDetailsDialog extends Dialog {
 
     @Override
     protected void initializeBounds() {
-        // do not make columns equal width so that we can have a smaller 'copy failure' button
+        // do not make columns equal width so that we can have a smaller 'copy
+        // failure' button
         Composite buttonBar = (Composite) getButtonBar();
         GridLayout layout = (GridLayout) buttonBar.getLayout();
         layout.makeColumnsEqualWidth = false;
@@ -179,34 +269,65 @@ public final class ExceptionDetailsDialog extends Dialog {
         if (id == IDialogConstants.DETAILS_ID) {
             toggleStacktraceArea();
         } else if (id == COPY_EXCEPTION_BUTTON_ID) {
-            copyErrorToClipboard();
+            List<Throwable> throwables = getSelectedThrowables();
+            copyErrorToClipboard(throwables);
         } else {
             super.buttonPressed(id);
         }
     }
 
-    private void copyErrorToClipboard() {
+    private List<Throwable> getSelectedThrowables() {
+        if (this.errorViewer != null) {
+            ISelection selection = this.errorViewer.getSelection();
+            if (!selection.isEmpty() && selection instanceof IStructuredSelection) {
+                @SuppressWarnings("unchecked")
+                List<Throwable> throwableList = ((IStructuredSelection) selection).toList();
+                return ImmutableList.copyOf(throwableList);
+            } else {
+                // if nothing is selected then select the first throwable
+                Throwable throwable = (Throwable) this.throwables.get(0);
+                this.errorViewer.setSelection(new StructuredSelection(throwable));
+                return ImmutableList.of(throwable);
+            }
+        } else {
+            // if the errorViewer is not shown there is only one Throwable shown
+            // by this dialog
+            Throwable throwable = (Throwable) this.throwables.get(0);
+            return ImmutableList.of(throwable);
+        }
+    }
+
+    protected boolean isMultiErrorDialog() {
+        return this.throwables.size() > 1;
+    }
+
+    private void copyErrorToClipboard(List<Throwable> throwables) {
         StringBuilder sb = new StringBuilder();
         sb.append(this.message);
         sb.append(LINE_SEPARATOR);
         sb.append(this.details);
         sb.append(LINE_SEPARATOR);
-        sb.append(getStackTrace());
+        sb.append(getStackTrace(throwables));
 
-        this.clipboard.setContents(new String[]{sb.toString()}, new Transfer[]{TextTransfer.getInstance()});
+        this.clipboard.setContents(new String[] { sb.toString() }, new Transfer[] { TextTransfer.getInstance() });
     }
 
     private void toggleStacktraceArea() {
         // show/hide stacktrace
         if (this.stackTraceArea == null) {
-            this.stackTraceArea = createStacktraceArea((Composite) getContents());
+            this.stackTraceArea = createStacktraceArea((Composite) getContents(), getSelectedThrowables());
             this.detailsButton.setText(IDialogConstants.HIDE_DETAILS_LABEL);
         } else {
             this.stackTraceArea.dispose();
             this.stackTraceArea = null;
+            this.detailText = null;
             this.detailsButton.setText(IDialogConstants.SHOW_DETAILS_LABEL);
         }
 
+        relayoutShell();
+    }
+
+    private void relayoutShell() {
         // compute the new window size
         Point oldSize = getContents().getSize();
         Point newSize = getContents().computeSize(SWT.DEFAULT, SWT.DEFAULT);
@@ -225,7 +346,7 @@ public final class ExceptionDetailsDialog extends Dialog {
         ((Composite) getContents()).layout();
     }
 
-    private Control createStacktraceArea(Composite parent) {
+    private Control createStacktraceArea(Composite parent, List<Throwable> throwables) {
         // create the stacktrace container area
         Composite container = new Composite(parent, SWT.NONE);
         container.setLayoutData(new GridData(GridData.FILL_BOTH));
@@ -234,16 +355,20 @@ public final class ExceptionDetailsDialog extends Dialog {
         container.setLayout(containerLayout);
 
         // create stacktrace content
-        Text text = new Text(container, SWT.MULTI | SWT.READ_ONLY | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL);
-        text.setLayoutData(new GridData(GridData.FILL_BOTH));
-        text.setText(getStackTrace());
+        this.detailText = new Text(container, SWT.MULTI | SWT.READ_ONLY | SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL);
+        this.detailText.setLayoutData(new GridData(GridData.FILL_BOTH));
+        this.detailText.setText(getStackTrace(throwables));
 
         return container;
     }
 
-    private String getStackTrace() {
-        StringWriter writer = new StringWriter(1000);
-        this.throwable.printStackTrace(new PrintWriter(writer));
+    private String getStackTrace(List<Throwable> throwables) {
+        Writer writer = new StringWriter(1000);
+        PrintWriter printWriter = new PrintWriter(writer);
+        for (Throwable throwable : throwables) {
+            throwable.printStackTrace(printWriter);
+            printWriter.write(LINE_SEPARATOR);
+        }
         return writer.toString();
     }
 
@@ -254,6 +379,10 @@ public final class ExceptionDetailsDialog extends Dialog {
             this.clipboard = null;
         }
         return super.close();
+    }
+
+    public void addException(Throwable... throwable) {
+        this.throwables.addAll(ImmutableList.copyOf(throwable));
     }
 
 }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/util/test/SWTBotWidgetIdentifierKey.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/util/test/SWTBotWidgetIdentifierKey.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ */
+
+package org.eclipse.buildship.ui.util.test;
+
+/**
+ * Contains the DEFAULT_KEY for clearly identifying widgets in the UI with the
+ * SWTBot. This class uses the same key as the
+ * org.eclipse.swtbot.swt.finder.utils.SWTBotPreferences class and only exists
+ * to avoid a dependency to the SWTBot plugin here.
+ *
+ */
+public final class SWTBotWidgetIdentifierKey {
+
+    private SWTBotWidgetIdentifierKey() {
+    }
+
+    /**
+     * @see SWTBotPreferences#DEFAULT_KEY
+     */
+    private static final String KEY_DEFAULT_KEY = "org.eclipse.swtbot.search.defaultKey";
+
+    /**
+     * The default key used to match SWT widgets. Defaults to
+     * {@code org.eclipse.swtbot.widget.key}. To set another default use the
+     * system property
+     * {@value org.eclipse.swtbot.swt.finder.utils.SWTBotPreferenceConstants#KEY_DEFAULT_KEY}
+     * .
+     */
+    public static String DEFAULT_KEY = System.getProperty(KEY_DEFAULT_KEY, "org.eclipse.swtbot.widget.key");
+
+}

--- a/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/i18n/UiMessages.properties
+++ b/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/i18n/UiMessages.properties
@@ -27,3 +27,4 @@ Action_RerunFailedTests_Tooltip=Rerun the failed tests
 Action_ShowTreeHeader_Text=Show Header
 
 Button_CopyFailuresToClipboard_Tooltip=Copy the failure details to the clipboard
+Dialog_Title_Multiple_Error=Multiple problems have occurred


### PR DESCRIPTION
The ExceptionDialog is now able to handle multiple exceptions and Throwables can also be added at runtime an opened ExceptionDialog. Therefore the ExceptionDialog has a new addException method, which adds Throwables to the observable list, which is bound to an errorViewer. This errorViewer is shown on the dialog in case there are more than one Throwable, which should be shown. 