### PR TITLE
Consider classpath entries for projects with .project file

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/projectimport/ImportProjectClasspathTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/projectimport/ImportProjectClasspathTest.groovy
@@ -1,0 +1,152 @@
+package org.eclipse.buildship.core.projectimport
+
+import org.eclipse.buildship.core.test.fixtures.ProjectImportSpecification
+import org.eclipse.core.resources.IFile
+import org.eclipse.core.resources.IProject
+
+class ImportProjectClasspathTest extends ProjectImportSpecification {
+
+    def "Projectimport without classpath file but existing project file, creates a classpath file"() {
+        setup:
+        def location = createSampleProject()
+        file('app', '.project') << '''
+<projectDescription>
+    <name>classpath</name>
+    <comment>Project Classpath created by Buildship.</comment>
+    <projects>
+    </projects>
+    <buildSpec>
+        <buildCommand>
+            <name>org.eclipse.jdt.core.javabuilder</name>
+            <arguments>
+            </arguments>
+        </buildCommand>
+        <buildCommand>
+            <name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+            <arguments>
+            </arguments>
+        </buildCommand>
+    </buildSpec>
+    <natures>
+        <nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+        <nature>org.eclipse.jdt.core.javanature</nature>
+    </natures>
+    <filteredResources>
+        <filter>
+            <id>1442824222615</id>
+            <name></name>
+            <type>26</type>
+            <matcher>
+                <id>org.eclipse.ui.ide.multiFilter</id>
+                <arguments>1.0-projectRelativePath-matches-false-false-build</arguments>
+            </matcher>
+        </filter>
+        <filter>
+            <id>1442824222630</id>
+            <name></name>
+            <type>26</type>
+            <matcher>
+                <id>org.eclipse.ui.ide.multiFilter</id>
+                <arguments>1.0-projectRelativePath-matches-false-false-.gradle</arguments>
+            </matcher>
+        </filter>
+    </filteredResources>
+</projectDescription> '''
+
+        when:
+        executeProjectImportAndWait(location)
+
+        then:
+        IProject customProject = findProject('classpath')
+        IFile classpathFile = customProject.getFile('.classpath')
+        classpathFile != null
+        classpathFile.exists() != null
+    }
+
+    def "Projectimport does not override existing classpath file contents"() {
+        setup:
+        def location = createSampleProject()
+        file('app', '.project') << '''<projectDescription>
+    <name>classpath</name>
+    <comment>Project Classpath created by Buildship.</comment>
+    <projects>
+    </projects>
+    <buildSpec>
+        <buildCommand>
+            <name>org.eclipse.jdt.core.javabuilder</name>
+            <arguments>
+            </arguments>
+        </buildCommand>
+        <buildCommand>
+            <name>org.eclipse.buildship.core.gradleprojectbuilder</name>
+            <arguments>
+            </arguments>
+        </buildCommand>
+    </buildSpec>
+    <natures>
+        <nature>org.eclipse.buildship.core.gradleprojectnature</nature>
+        <nature>org.eclipse.jdt.core.javanature</nature>
+    </natures>
+    <filteredResources>
+        <filter>
+            <id>1442824222615</id>
+            <name></name>
+            <type>26</type>
+            <matcher>
+                <id>org.eclipse.ui.ide.multiFilter</id>
+                <arguments>1.0-projectRelativePath-matches-false-false-build</arguments>
+            </matcher>
+        </filter>
+        <filter>
+            <id>1442824222630</id>
+            <name></name>
+            <type>26</type>
+            <matcher>
+                <id>org.eclipse.ui.ide.multiFilter</id>
+                <arguments>1.0-projectRelativePath-matches-false-false-.gradle</arguments>
+            </matcher>
+        </filter>
+    </filteredResources>
+</projectDescription>'''
+
+        file('app', '.classpath') <<
+                '''<classpath>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+    <classpathentry kind="con" path="existing-classpath-file-entry"/>
+    <classpathentry kind="output" path="bin"/>
+</classpath>'''
+
+        when:
+        executeProjectImportAndWait(location)
+
+        IProject customProject = findProject('classpath')
+        IFile classpathFile = customProject.getFile('.classpath')
+
+        then:
+        classpathFile != null
+        def classPathFile = classpathFile.getLocation().toFile()
+        classPathFile.exists()
+        classPathFile.text.contains('existing-classpath-file-entry')
+    }
+
+    private def createSampleProject() {
+        def location = folder('app')
+        folder('app', 'src' , 'main', 'java')
+        folder('app', 'src' , 'test', 'java')
+        file('app', 'settings.gradle') << 'rootProject.name = \'classpath\''
+        file('app', 'build.gradle') << '''
+        apply plugin: 'java'
+
+        repositories {
+            jcenter()
+        }
+
+        dependencies {
+            compile 'org.slf4j:slf4j-api:1.7.12'
+
+            testCompile 'junit:junit:4.12'
+        }'''
+
+        location
+    }
+}

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/WorkspaceOperationsTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/WorkspaceOperationsTest.groovy
@@ -11,10 +11,6 @@
 
 package org.eclipse.buildship.core.workspace.internal
 
-import com.google.common.collect.ImmutableList
-import com.gradleware.tooling.toolingclient.GradleDistribution
-import com.gradleware.tooling.toolingmodel.Path
-import com.gradleware.tooling.toolingmodel.repository.FixedRequestAttributes
 import org.eclipse.buildship.core.CorePlugin
 import org.eclipse.buildship.core.GradlePluginsRuntimeException
 import org.eclipse.buildship.core.configuration.GradleProjectNature
@@ -22,6 +18,7 @@ import org.eclipse.buildship.core.configuration.ProjectConfiguration
 import org.eclipse.buildship.core.test.fixtures.LegacyEclipseSpockTestHelper
 import org.eclipse.buildship.core.workspace.GradleClasspathContainer
 import org.eclipse.buildship.core.workspace.WorkspaceOperations
+import org.eclipse.core.resources.IFile
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.IProjectDescription
 import org.eclipse.core.runtime.NullProgressMonitor
@@ -30,8 +27,14 @@ import org.eclipse.jdt.core.JavaCore
 import org.eclipse.jdt.launching.JavaRuntime
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+
 import spock.lang.Shared
 import spock.lang.Specification
+
+import com.google.common.collect.ImmutableList
+import com.gradleware.tooling.toolingclient.GradleDistribution
+import com.gradleware.tooling.toolingmodel.Path
+import com.gradleware.tooling.toolingmodel.repository.FixedRequestAttributes
 
 class WorkspaceOperationsTest extends Specification {
 
@@ -60,6 +63,19 @@ class WorkspaceOperationsTest extends Specification {
         project.getDescription().natureIds.length == 1
     }
 
+    def "Created Java Project always contains a classpath file"() {
+        setup:
+        workspaceOperations.deleteAllProjects(new NullProgressMonitor())
+        def projectFolder = tempFolder.newFolder("sample-project-folder")
+
+        when:
+        IProject project = workspaceOperations.createProject("sample-project", projectFolder, ImmutableList.of(JavaCore.NATURE_ID, GradleProjectNature.ID), null)
+        IFile classpathFile = project.getFile('.classpath')
+        then:
+        classpathFile != null
+        classpathFile.exists() != null
+    }
+
     def "Project can be created without any natures"() {
         setup:
         workspaceOperations.deleteAllProjects(new NullProgressMonitor())
@@ -84,7 +100,6 @@ class WorkspaceOperationsTest extends Specification {
         project.getDescription().natureIds.length == 2
         project.getDescription().natureIds[0] == JavaCore.NATURE_ID
         project.getDescription().natureIds[1] == GradleProjectNature.ID
-
     }
 
     def "Importing nonexisting folder fails"() {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultWorkspaceGradleOperations.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultWorkspaceGradleOperations.java
@@ -12,16 +12,10 @@
 
 package org.eclipse.buildship.core.workspace.internal;
 
-import com.google.common.base.Function;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
-import com.gradleware.tooling.toolingmodel.OmniEclipseGradleBuild;
-import com.gradleware.tooling.toolingmodel.OmniEclipseProject;
-import com.gradleware.tooling.toolingmodel.OmniGradleProject;
-import com.gradleware.tooling.toolingmodel.repository.FixedRequestAttributes;
-import com.gradleware.tooling.toolingmodel.util.Maybe;
+import java.io.File;
+import java.util.List;
+import java.util.Set;
+
 import org.eclipse.buildship.core.CorePlugin;
 import org.eclipse.buildship.core.GradlePluginsRuntimeException;
 import org.eclipse.buildship.core.configuration.GradleProjectNature;
@@ -44,9 +38,16 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.gradle.api.specs.Spec;
 
-import java.io.File;
-import java.util.List;
-import java.util.Set;
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.gradleware.tooling.toolingmodel.OmniEclipseGradleBuild;
+import com.gradleware.tooling.toolingmodel.OmniEclipseProject;
+import com.gradleware.tooling.toolingmodel.OmniGradleProject;
+import com.gradleware.tooling.toolingmodel.repository.FixedRequestAttributes;
+import com.gradleware.tooling.toolingmodel.util.Maybe;
 
 /**
  * Default implementation of the {@link WorkspaceGradleOperations} interface.
@@ -192,7 +193,9 @@ public final class DefaultWorkspaceGradleOperations implements WorkspaceGradleOp
         }
     }
 
-    private IProject addExistingEclipseProjectToWorkspace(OmniEclipseProject project, IProjectDescription projectDescription, FixedRequestAttributes rootRequestAttributes, IProgressMonitor monitor) {
+    private IProject addExistingEclipseProjectToWorkspace(OmniEclipseProject project,
+            IProjectDescription projectDescription, FixedRequestAttributes rootRequestAttributes,
+            IProgressMonitor monitor) throws JavaModelException {
         monitor.beginTask(String.format("Add existing Eclipse project %s for Gradle project %s to the workspace", projectDescription.getName(), project.getName()), 1);
         try {
             // include the existing Eclipse project in the workspace
@@ -202,6 +205,15 @@ public final class DefaultWorkspaceGradleOperations implements WorkspaceGradleOp
             // persist the Gradle-specific configuration in the Eclipse project's .settings folder
             ProjectConfiguration projectConfiguration = ProjectConfiguration.from(rootRequestAttributes, project);
             CorePlugin.projectConfigurationManager().saveProjectConfiguration(projectConfiguration, workspaceProject);
+
+            // if the current Gradle project is a Java project, configure the
+            // Java nature, the classpath, and the source paths
+            if (isJavaProject(project)) {
+                IPath jrePath = JavaRuntime.getDefaultJREContainerEntry().getPath();
+                IClasspathEntry classpathContainer = GradleClasspathContainer.newClasspathEntry();
+                CorePlugin.workspaceOperations().createJavaProject(workspaceProject, jrePath, classpathContainer,
+                        new SubProgressMonitor(monitor, 1));
+            }
 
             return workspaceProject;
         } finally {


### PR DESCRIPTION
Added features in this PR:
* It respects existing .classpath files, so that previous contents remains if it is appropriate
* It also creates a .classpath file, in case a .project file already exists during the project import