### PR TITLE
Bug 478054 - Eclipse does not prompt for workspace any more after installing Buildship

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/internal/BuildExecutionParticipants.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/internal/BuildExecutionParticipants.java
@@ -43,7 +43,7 @@ public final class BuildExecutionParticipants {
                     return;
                 }
                 // start the specified plugin
-                bundle.start();
+                bundle.start(Bundle.START_TRANSIENT);
             } catch (Exception e) {
                 String message = String.format("Failed to activate plugin %s referenced in extension point 'executionparticipants'.", pluginId);
                 CorePlugin.logger().error(message, e);


### PR DESCRIPTION
Added the Bundle.START_TRANSIENT flag as suggested by Thomas Watson. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=478054