### PR TITLE
Bug 474473 - Allow to reruns tests from the Java editor

### DIFF
--- a/org.eclipse.buildship.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.core/META-INF/MANIFEST.MF
@@ -17,7 +17,8 @@ Require-Bundle: org.eclipse.core.net,
  org.eclipse.debug.core,
  org.slf4j.api;bundle-version="[1.7.2,1.8.0)",
  com.google.gson;bundle-version="[2.2.4,2.3.0)",
- com.gradleware.tooling.model;bundle-version="[0.7.0,0.8.0)"
+ com.gradleware.tooling.model;bundle-version="[0.7.0,0.8.0)",
+ org.eclipse.core.expressions
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.buildship.core,
  org.eclipse.buildship.core.configuration,

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleJvmTestLaunchRequestJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleJvmTestLaunchRequestJob.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ */
+
+package org.eclipse.buildship.core.launch;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.text.DateFormat;
+import java.util.Date;
+
+import org.eclipse.buildship.core.CorePlugin;
+import org.eclipse.buildship.core.console.ProcessDescription;
+import org.eclipse.buildship.core.i18n.CoreMessages;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.gradleware.tooling.toolingclient.Request;
+import com.gradleware.tooling.toolingclient.TestConfig;
+
+/**
+ * Executes tests through Gradle based on a given list of {@code IJavaElement}
+ * instances and a given set of {@code GradleRunConfigurationAttributes}.
+ */
+public final class RunGradleJvmTestLaunchRequestJob extends BaseLaunchRequestJob {
+
+    private final GradleRunConfigurationAttributes configurationAttributes;
+    private ImmutableList<String> testClasses;
+
+    public RunGradleJvmTestLaunchRequestJob(Iterable<String> testClasses,
+            GradleRunConfigurationAttributes configurationAttributes) {
+        super("Launching Gradle Tests", false);
+        this.testClasses = ImmutableList.copyOf(testClasses);
+        this.configurationAttributes = Preconditions.checkNotNull(configurationAttributes);
+    }
+
+    @Override
+    protected String getJobTaskName() {
+        return "Launch Gradle Tests";
+    }
+
+    @Override
+    protected GradleRunConfigurationAttributes getConfigurationAttributes() {
+        return this.configurationAttributes;
+    }
+
+    @Override
+    protected ProcessDescription createProcessDescription() {
+        String processName = createProcessName(this.configurationAttributes.getWorkingDir());
+        return new TestLaunchProcessDescription(processName);
+    }
+
+    private String createProcessName(File workingDir) {
+        return String.format("[Gradle Project] %s in %s (%s)", Joiner.on(' ').join(this.testClasses),
+                workingDir.getAbsolutePath(),
+                DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM).format(new Date()));
+    }
+
+    @Override
+    protected Request<Void> createRequest() {
+        return CorePlugin.toolingClient().newTestLaunchRequest(TestConfig.forJvmTestClasses(this.testClasses));
+    }
+
+    @Override
+    protected void writeExtraConfigInfo(OutputStreamWriter writer) throws IOException {
+        writer.write(String.format("%s: %s%n", CoreMessages.RunConfiguration_Label_Tests, this.testClasses));
+    }
+
+    /**
+     * Implementation of {@code ProcessDescription}.
+     */
+    private final class TestLaunchProcessDescription extends BaseProcessDescription {
+
+        public TestLaunchProcessDescription(String processName) {
+            super(processName, RunGradleJvmTestLaunchRequestJob.this,
+                    RunGradleJvmTestLaunchRequestJob.this.configurationAttributes);
+        }
+
+        @Override
+        public boolean isRerunnable() {
+            return true;
+        }
+
+        @Override
+        public void rerun() {
+            RunGradleJvmTestLaunchRequestJob job = new RunGradleJvmTestLaunchRequestJob(
+                    RunGradleJvmTestLaunchRequestJob.this.testClasses,
+                    RunGradleJvmTestLaunchRequestJob.this.configurationAttributes);
+            job.schedule();
+        }
+
+    }
+
+}

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleJvmTestMethodLaunchRequestJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleJvmTestMethodLaunchRequestJob.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ */
+
+package org.eclipse.buildship.core.launch;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.Map;
+
+import org.eclipse.buildship.core.CorePlugin;
+import org.eclipse.buildship.core.console.ProcessDescription;
+import org.eclipse.buildship.core.i18n.CoreMessages;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.gradleware.tooling.toolingclient.Request;
+import com.gradleware.tooling.toolingclient.TestConfig;
+
+/**
+ * Executes tests through Gradle based on a given list of {@code String}
+ * instances and a given set of {@code GradleRunConfigurationAttributes}.
+ */
+public final class RunGradleJvmTestMethodLaunchRequestJob extends BaseLaunchRequestJob {
+
+    private final GradleRunConfigurationAttributes configurationAttributes;
+    private ImmutableMap<String, Iterable<String>> classNamesWithMethods;
+
+    public RunGradleJvmTestMethodLaunchRequestJob(Map<String, Iterable<String>> classNamesWithMethods,
+            GradleRunConfigurationAttributes configurationAttributes) {
+        super("Launching Gradle Tests", false);
+        this.classNamesWithMethods = ImmutableMap.copyOf(classNamesWithMethods);
+        this.configurationAttributes = Preconditions.checkNotNull(configurationAttributes);
+    }
+
+    @Override
+    protected String getJobTaskName() {
+        return "Launch Gradle Test Methods";
+    }
+
+    @Override
+    protected GradleRunConfigurationAttributes getConfigurationAttributes() {
+        return this.configurationAttributes;
+    }
+
+    @Override
+    protected ProcessDescription createProcessDescription() {
+        String processName = createProcessName(this.configurationAttributes.getWorkingDir());
+        return new TestLaunchProcessDescription(processName);
+    }
+
+    private String createProcessName(File workingDir) {
+        return String.format("%s [Gradle Project] %s in %s (%s)",
+                Joiner.on(' ').join(this.classNamesWithMethods.keySet()),
+                Joiner.on(' ').join(this.classNamesWithMethods.values()), workingDir.getAbsolutePath(),
+                DateFormat.getDateTimeInstance(DateFormat.MEDIUM, DateFormat.MEDIUM).format(new Date()));
+    }
+
+    @Override
+    protected Request<Void> createRequest() {
+        return CorePlugin.toolingClient()
+                .newTestLaunchRequest(TestConfig.forJvmTestMethods(this.classNamesWithMethods));
+    }
+
+    @Override
+    protected void writeExtraConfigInfo(OutputStreamWriter writer) throws IOException {
+        writer.write(String.format("%s: %s%n", CoreMessages.RunConfiguration_Label_Tests,
+                this.classNamesWithMethods.keySet()));
+    }
+
+    /**
+     * Implementation of {@code ProcessDescription}.
+     */
+    private final class TestLaunchProcessDescription extends BaseProcessDescription {
+
+        public TestLaunchProcessDescription(String processName) {
+            super(processName, RunGradleJvmTestMethodLaunchRequestJob.this,
+                    RunGradleJvmTestMethodLaunchRequestJob.this.configurationAttributes);
+        }
+
+        @Override
+        public boolean isRerunnable() {
+            return true;
+        }
+
+        @Override
+        public void rerun() {
+            RunGradleJvmTestMethodLaunchRequestJob job = new RunGradleJvmTestMethodLaunchRequestJob(
+                    RunGradleJvmTestMethodLaunchRequestJob.this.classNamesWithMethods,
+                    RunGradleJvmTestMethodLaunchRequestJob.this.configurationAttributes
+            );
+            job.schedule();
+        }
+
+    }
+
+}

--- a/org.eclipse.buildship.ui/plugin.xml
+++ b/org.eclipse.buildship.ui/plugin.xml
@@ -261,7 +261,76 @@
         </launchConfigurationTabGroup>
     </extension>
 
-    <!-- properties view for tasks and projects -->
+    <!-- Launchshortcut to add entries in the "Run As" menus -->
+    <extension
+          point="org.eclipse.debug.ui.launchShortcuts">
+       <shortcut
+             class="org.eclipse.buildship.ui.launch.TestLaunchShortcut"
+             id="org.eclipse.buildship.ui.shortcut.test"
+             label="Gradle Test"
+             modes="run">
+          <configurationType
+                id="org.eclipse.buildship.core.launch.runconfiguration">
+          </configurationType>
+          <contextualLaunch>
+             <contextLabel
+                   label="Gradle Test"
+                   mode="run">
+             </contextLabel>
+             <enablement>
+                <with
+                      variable="selection">
+                   <and>
+                      <iterate
+                            ifEmpty="false"
+                            operator="and">
+                         <not>
+                            <or>
+                               <instanceof
+                                     value="org.eclipse.jdt.core.IPackageFragmentRoot">
+                               </instanceof>
+                               <instanceof
+                                     value="org.eclipse.jdt.core.IJavaProject">
+                               </instanceof>
+                               <instanceof
+                                     value="org.eclipse.jdt.core.IPackageFragment">
+                               </instanceof>
+                            </or>
+                         </not>
+                         <adapt
+                               type="org.eclipse.jdt.core.IJavaElement">
+                            <test
+                                  forcePluginActivation="true"
+                                  property="buildship.propertyTester.projectnature"
+                                  value="org.eclipse.buildship.core.gradleprojectnature">
+                            </test>
+                            <or>
+                               <test
+                                     property="org.eclipse.jdt.core.hasTypeOnClasspath"
+                                     value="junit.framework.Test">
+                               </test>
+                               <test
+                                     property="org.eclipse.jdt.core.hasTypeOnClasspath"
+                                     value="spock.lang.Specification">
+                               </test>
+                            </or>
+                         </adapt>
+                      </iterate>
+                      <test
+                            property="buildship.propertyTester.singleprojectselection">
+                      </test>
+                   </and>
+                </with>
+             </enablement>
+          </contextualLaunch>
+          <description
+                description="Runs the selected test with Gradle"
+                mode="run">
+          </description>
+       </shortcut>
+    </extension>
+    
+    <!-- Adapters for showing gradle items in the properties view -->
     <extension
           point="org.eclipse.core.runtime.adapters">
        <factory
@@ -325,7 +394,7 @@
                                     operator="or"
                                     ifEmpty="false">
                                 <adapt
-                                        type="org.eclipse.core.resources.IProject">
+                                        type="org.eclipse.core.resources.IResource">
                                     <test
                                             forcePluginActivation="true"
                                             property="org.eclipse.core.resources.projectNature"
@@ -354,5 +423,17 @@
        <plugin
              id="org.eclipse.buildship.ui">
        </plugin>
+    </extension>
+
+   <!-- PropertyTester, which are used for visibility and enablement constraints in the UI -->
+   <extension
+          point="org.eclipse.core.expressions.propertyTesters">
+       <propertyTester
+             class="org.eclipse.buildship.ui.propertytester.ProjectPropertyTester"
+             id="org.eclipse.buildship.ui.propertyTester.nature"
+             namespace="buildship.propertyTester"
+             properties="projectnature,singleprojectselection"
+             type="java.lang.Object">
+       </propertyTester>
     </extension>
 </plugin>

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/launch/LaunchMessages.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/launch/LaunchMessages.java
@@ -26,6 +26,10 @@ public final class LaunchMessages extends NLS {
     public static String Tab_Name_JavaHome;
     public static String Tab_Name_Arguments;
 
+    public static String Test_Not_Found_Dialog_Details;
+    public static String Test_Not_Found_Dialog_Message;
+    public static String Test_Not_Found_Dialog_Title;
+
     public static String Title_BrowseFileSystemDialog;
     public static String Title_BrowseWorkspaceDialog;
 

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/launch/TestLaunchShortcut.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/launch/TestLaunchShortcut.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ */
+
+package org.eclipse.buildship.ui.launch;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.buildship.core.CorePlugin;
+import org.eclipse.buildship.core.launch.GradleRunConfigurationAttributes;
+import org.eclipse.buildship.core.launch.RunGradleJvmTestLaunchRequestJob;
+import org.eclipse.buildship.core.launch.RunGradleJvmTestMethodLaunchRequestJob;
+import org.eclipse.buildship.ui.UiPlugin;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.debug.ui.ILaunchShortcut;
+import org.eclipse.jdt.core.IClassFile;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.ui.actions.SelectionConverter;
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.jface.viewers.ISelection;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.ui.IEditorPart;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.gradleware.tooling.toolingmodel.repository.FixedRequestAttributes;
+
+/**
+ * This {@link ILaunchShortcut} is used to offer the opportunity to run tests
+ * from the editor or package explorer.
+ */
+@SuppressWarnings("restriction")
+public class TestLaunchShortcut implements ILaunchShortcut {
+
+    @Override
+    public void launch(ISelection selection, String mode) {
+        if (selection instanceof IStructuredSelection) {
+            launch(((IStructuredSelection) selection).toList(), mode);
+        } else {
+            logNoTestsFound();
+        }
+    }
+
+    @Override
+    public void launch(IEditorPart editor, String mode) {
+        ITypeRoot element = JavaUI.getEditorInputTypeRoot(editor.getEditorInput());
+        if (element != null) {
+            Optional<IMethod> selectedMethod = resolveSelectedMethodName(editor, element);
+            if (selectedMethod.isPresent()) {
+                launch(ImmutableList.of(selectedMethod.get()), mode);
+            } else {
+                launch(ImmutableList.of(element), mode);
+            }
+        } else {
+            logNoTestsFound();
+        }
+    }
+
+    protected void performLaunch(List<? extends IJavaElement> elementsToLaunch, String mode) {
+        // get the right attributes for the GradleRunConfigurationAttributes
+        IJavaElement javaElement = elementsToLaunch.get(0);
+        IProject project = javaElement.getResource().getProject();
+
+        FixedRequestAttributes attributes = CorePlugin.projectConfigurationManager().readProjectConfiguration(project)
+                .getRequestAttributes();
+
+        String gradleUserHome = attributes.getGradleUserHome() != null
+                ? attributes.getGradleUserHome().getAbsolutePath() : null;
+        String javaHome = attributes.getJavaHome() != null ? attributes.getJavaHome().getAbsolutePath() : null;
+
+        GradleRunConfigurationAttributes configurationAttributes = GradleRunConfigurationAttributes.with(
+                ImmutableList.<String> of(), attributes.getProjectDir().getAbsolutePath(),
+                attributes.getGradleDistribution(), gradleUserHome, javaHome, attributes.getJvmArguments(),
+                attributes.getArguments(), true, true);
+
+        Job runTestsJob = null;
+        if (containsMethods(elementsToLaunch)) {
+            runTestsJob = new RunGradleJvmTestMethodLaunchRequestJob(getClassNamesWithMethods(elementsToLaunch),
+                    configurationAttributes);
+        } else {
+            runTestsJob = new RunGradleJvmTestLaunchRequestJob(getClassNames(elementsToLaunch),
+                    configurationAttributes);
+        }
+        runTestsJob.schedule();
+    }
+
+    private Iterable<String> getClassNames(List<? extends IJavaElement> elementsToLaunch) {
+        return FluentIterable.from(elementsToLaunch).filter(IType.class)
+                .transform(new Function<IJavaElement, String>() {
+
+                    @Override
+                    public String apply(IJavaElement javaElement) {
+                        return ((IType) javaElement).getFullyQualifiedName();
+                    }
+                }).toSet();
+    }
+
+    private Map<String, Iterable<String>> getClassNamesWithMethods(List<? extends IJavaElement> elementsToLaunch) {
+
+        Map<String, Collection<String>> testMethods = Maps.newHashMap();
+
+        for (IJavaElement javaElement : elementsToLaunch) {
+            if (IJavaElement.METHOD == javaElement.getElementType()) {
+                IMethod method = (IMethod) javaElement;
+                fillClassNameWithMethodMap(testMethods, method);
+            } else if (IJavaElement.TYPE == javaElement.getElementType()) {
+                IType type = (IType) javaElement;
+                try {
+                    IMethod[] methods = type.getMethods();
+                    for (IMethod method : methods) {
+                        fillClassNameWithMethodMap(testMethods, method);
+                    }
+                } catch (JavaModelException e) {
+                    // Only log as info and simply continue
+                    UiPlugin.logger().info(e.getMessage(), e);
+                }
+            }
+        }
+
+        return ImmutableMap.<String, Iterable<String>> copyOf(testMethods);
+    }
+
+    private void fillClassNameWithMethodMap(Map<String, Collection<String>> testMethods, IMethod method) {
+        Collection<String> methodNames = testMethods.get(method.getDeclaringType().getFullyQualifiedName());
+        if (methodNames == null) {
+            methodNames = Lists.newArrayList();
+            testMethods.put(method.getDeclaringType().getFullyQualifiedName(), methodNames);
+        }
+        methodNames.add(method.getElementName());
+    }
+
+    private boolean containsMethods(List<? extends IJavaElement> javaElements) {
+        return FluentIterable.from(javaElements).anyMatch(new Predicate<IJavaElement>() {
+
+            @Override
+            public boolean apply(IJavaElement javaElement) {
+                return IJavaElement.METHOD == javaElement.getElementType();
+            }
+        });
+    }
+
+    private void launch(List<?> elements, String mode) {
+        Builder<IJavaElement> builder = ImmutableList.builder();
+
+        for (Object selected : elements) {
+            IJavaElement element = (IJavaElement) Platform.getAdapterManager().getAdapter(selected, IJavaElement.class);
+
+            if (element != null) {
+                Optional<? extends IJavaElement> elementToLaunch = getElementToLaunch(element);
+                if (elementToLaunch.isPresent()) {
+                    builder.add(elementToLaunch.get());
+                }
+            }
+        }
+
+        ImmutableList<IJavaElement> elementsToLaunch = builder.build();
+
+        if (elementsToLaunch.isEmpty()) {
+            logNoTestsFound();
+            return;
+        }
+        performLaunch(elementsToLaunch, mode);
+    }
+
+    private Optional<? extends IJavaElement> getElementToLaunch(IJavaElement element) {
+        switch (element.getElementType()) {
+        case IJavaElement.CLASS_FILE:
+            return Optional.fromNullable(((IClassFile) element).getType());
+        case IJavaElement.COMPILATION_UNIT:
+            return Optional.fromNullable(((ICompilationUnit) element).findPrimaryType());
+        }
+        return Optional.of(element);
+    }
+
+    private Optional<IMethod> resolveSelectedMethodName(IEditorPart editor, ITypeRoot element) {
+        try {
+            ISelectionProvider selectionProvider = editor.getSite().getSelectionProvider();
+            if (selectionProvider == null) {
+                return Optional.absent();
+            }
+
+            ISelection selection = selectionProvider.getSelection();
+            if (!(selection instanceof ITextSelection)) {
+                return Optional.absent();
+            }
+
+            ITextSelection textSelection = (ITextSelection) selection;
+
+            IJavaElement elementAtOffset = SelectionConverter.getElementAtOffset(element, textSelection);
+            if (elementAtOffset instanceof IMethod) {
+                return Optional.of((IMethod) elementAtOffset);
+            }
+
+        } catch (JavaModelException e) {
+            UiPlugin.logger().info("The method name for running tests cannot be determined", e); //$NON-NLS-1$
+        }
+        return Optional.absent();
+    }
+
+    private void logNoTestsFound() {
+        CorePlugin.userNotification().errorOccurred(LaunchMessages.Test_Not_Found_Dialog_Title,
+                LaunchMessages.Test_Not_Found_Dialog_Message, LaunchMessages.Test_Not_Found_Dialog_Details,
+                IStatus.WARNING, null);
+    }
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/propertytester/ProjectPropertyTester.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/propertytester/ProjectPropertyTester.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ */
+
+package org.eclipse.buildship.ui.propertytester;
+
+import java.util.List;
+
+import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jface.viewers.IStructuredSelection;
+
+import com.google.common.base.Optional;
+
+/**
+ * This {@link PropertyTester} is used the check the project nature of a given
+ * receiver by {@link Properties#projectnature} and whether the receiver
+ * contains only one project by {@link Properties#singleprojectselection}.
+ */
+public class ProjectPropertyTester extends PropertyTester {
+
+    /**
+     * These properties can be tested with {@link ProjectPropertyTester}.
+     */
+    public enum Properties {
+        projectnature, singleprojectselection
+    }
+
+    @Override
+    public boolean test(Object receiver, String propertyString, Object[] args, Object expectedValue) {
+
+        Properties property = Properties.valueOf(propertyString);
+
+        switch (property) {
+        case projectnature:
+            // Check whether the given receiver has the expected project nature
+            Optional<IProject> project = getProject(receiver);
+            try {
+                return project.isPresent() && project.get().isAccessible()
+                        && project.get().hasNature((String) expectedValue);
+            } catch (CoreException e) {
+                return false;
+            }
+        case singleprojectselection:
+            // used to make sure that only members of one project are selected
+            if (receiver instanceof List) {
+                return onlyOneProjectIsSelected((List<?>) receiver);
+            } else if (receiver instanceof IStructuredSelection) {
+                IStructuredSelection selection = (IStructuredSelection) receiver;
+                return onlyOneProjectIsSelected(selection.toList());
+            }
+        }
+
+        return true;
+    }
+
+    protected Optional<IProject> getProject(Object receiver) {
+        Optional<IProject> project = Optional.absent();
+        IResource resource = (IResource) Platform.getAdapterManager().getAdapter(receiver, IResource.class);
+        if (resource != null) {
+            project = Optional.fromNullable(resource.getProject());
+        } else {
+            IJavaElement javaElement = (IJavaElement) Platform.getAdapterManager().getAdapter(receiver,
+                    IJavaElement.class);
+            if (javaElement != null) {
+                IJavaProject javaProject = javaElement.getJavaProject();
+                if (javaProject != null) {
+                    project = Optional.fromNullable(javaProject.getProject());
+                }
+            }
+        }
+        return project;
+    }
+
+    protected boolean onlyOneProjectIsSelected(List<?> list) {
+        if (list.isEmpty()) {
+            return false;
+        }
+        Optional<IProject> firstProject = getProject(list.get(0));
+        for (Object object : list) {
+            Optional<IProject> projectIterate = getProject(object);
+            if (!firstProject.equals(projectIterate)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/launch/LaunchMessages.properties
+++ b/org.eclipse.buildship.ui/src/main/resources/org/eclipse/buildship/ui/launch/LaunchMessages.properties
@@ -15,6 +15,10 @@ Tab_Name_GradleUserHome=Gradle User Home
 Tab_Name_JavaHome=Java Home
 Tab_Name_Arguments=Arguments
 
+Test_Not_Found_Dialog_Details=Please select a test class or method in the UI (e.g. Editor or Package Explorer)
+Test_Not_Found_Dialog_Message=There are not tests, which can be executed
+Test_Not_Found_Dialog_Title=No Tests found
+
 Title_BrowseFileSystemDialog=Select Working Directory Location
 Title_BrowseWorkspaceDialog=Select Project
 


### PR DESCRIPTION
This PR adds the possibility to run tests with Gradle from the "Run as" menu in the editor or the package explorer.

It currently just prints what is going to be run.
The actual implementation of the test run needs to be done later, as well as finding already existent ILaunchConfiguration[] objects.
See the TODOs in the org.eclipse.buildship.ui.launch.TestLaunchShortcut class