### PR TITLE
Bug 479243 - Runtasks command not enabled in several Eclipse perspectives

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/util/nodeselection/NodeSelection.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/util/nodeselection/NodeSelection.java
@@ -7,9 +7,13 @@
  *
  * Contributors:
  *     Etienne Studer & Donát Csikós (Gradle Inc.) - initial API and implementation and initial documentation
+ *     Simon Scholz <simon.scholz@vogella.com> - Bug 479243
  */
 
 package org.eclipse.buildship.ui.util.nodeselection;
+
+import java.util.Iterator;
+import java.util.List;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -17,15 +21,14 @@ import com.google.common.base.Predicates;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
-
-import java.util.List;
 
 /**
  * Provides information about a given set of selected nodes.
  */
-public final class NodeSelection {
+public final class NodeSelection implements IStructuredSelection {
 
     private static final NodeSelection EMPTY = new NodeSelection(ImmutableList.of());
 
@@ -35,13 +38,9 @@ public final class NodeSelection {
         this.nodes = ImmutableList.copyOf(nodes);
     }
 
-    /**
-     * Returns whether the selection is empty.
-     *
-     * @return {@code true} if the selection is empty, {@code false} otherwise
-     */
+    @Override
     public boolean isEmpty() {
-        return this.nodes.isEmpty();
+        return getNodes().isEmpty();
     }
 
     /**
@@ -50,7 +49,12 @@ public final class NodeSelection {
      * @return {@code true} if a single node is selected, {@code false} otherwise
      */
     public boolean isSingleSelection() {
-        return this.nodes.size() == 1;
+        return size() == 1;
+    }
+
+    @Override
+    public Object getFirstElement() {
+        return isEmpty() ? null : this.nodes.get(0);
     }
 
     /**
@@ -59,6 +63,8 @@ public final class NodeSelection {
      * @return the first node
      * @throws java.lang.IllegalStateException thrown if the selection is empty
      */
+    // TODO remove this method and use getFirstElement(), which is defined by
+    // IStructuredSelection
     public Object getFirstNode() {
         if (isEmpty()) {
             throw new IllegalStateException("Selection is empty.");
@@ -74,6 +80,8 @@ public final class NodeSelection {
      * @return the first node
      * @throws java.lang.IllegalStateException thrown if the selection is empty
      */
+    // TODO rename this method to getFirstElement(Class<T> expectedType) to have
+    // consistent names
     public <T> T getFirstNode(Class<T> expectedType) {
         if (isEmpty()) {
             throw new IllegalStateException("Selection is empty.");
@@ -87,6 +95,8 @@ public final class NodeSelection {
      *
      * @return the list of all nodes
      */
+    // TODO rename this method to "toList" to have
+    // consistent names
     public ImmutableList<?> getNodes() {
         return this.nodes;
     }
@@ -98,6 +108,8 @@ public final class NodeSelection {
      * @return the list of all nodes
      * @throws ClassCastException thrown if a node is not of the expected type
      */
+    // TODO rename this method to "toList" to have
+    // consistent names
     public <T> ImmutableList<T> getNodes(final Class<T> expectedType) {
         return FluentIterable.from(this.nodes).transform(new Function<Object, T>() {
 
@@ -106,6 +118,26 @@ public final class NodeSelection {
                 return expectedType.cast(input);
             }
         }).toList();
+    }
+
+    @Override
+    public Iterator<?> iterator() {
+        return this.nodes.iterator();
+    }
+
+    @Override
+    public int size() {
+        return this.nodes.size();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return this.nodes.toArray();
+    }
+
+    @Override
+    public List<?> toList() {
+        return this.nodes;
     }
 
     /**

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/util/nodeselection/SelectionHistoryManager.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/util/nodeselection/SelectionHistoryManager.java
@@ -7,22 +7,33 @@
  *
  * Contributors:
  *     Etienne Studer & Donát Csikós (Gradle Inc.) - initial API and implementation and initial documentation
+ *     Simon Scholz <simon.scholz@vogella.com> - Bug 479243
  */
 
 package org.eclipse.buildship.ui.util.nodeselection;
 
-import com.google.common.base.Preconditions;
+import java.util.List;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+import org.eclipse.jface.util.SafeRunnable;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
-import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.TreeViewer;
 
 /**
- * Stores the sequence in which the currently selected nodes were selected in the {@link TreeViewer}.
+ * Stores the sequence in which the currently selected nodes were selected in
+ * the {@link TreeViewer} and acts as {@link ISelectionProvider}, which can be
+ * added to an {@link org.eclipse.ui.IViewSite}.
+ *
+ * @see org.eclipse.buildship.ui.view.task.TaskView
  */
-public final class SelectionHistoryManager {
+public final class SelectionHistoryManager implements ISelectionProvider {
+
+    private List<ISelectionChangedListener> selectionChangedListeners = Lists.newCopyOnWriteArrayList();
 
     private final TreeViewer treeViewer;
     private final TreeViewerSelectionListener listener;
@@ -40,32 +51,64 @@ public final class SelectionHistoryManager {
         this.treeViewer.addSelectionChangedListener(this.listener);
     }
 
-    public NodeSelection getSelectionHistory() {
-        return this.selectionHistory;
-    }
-
-    private void handleSelection(IStructuredSelection selection) {
-        NodeSelection nodeSelection = NodeSelection.from(selection);
-        this.selectionHistory = this.selectionHistory.mergeWith(nodeSelection);
-    }
-
     public void dispose() {
         this.treeViewer.removeSelectionChangedListener(this.listener);
     }
 
+    @Override
+    public void addSelectionChangedListener(ISelectionChangedListener listener) {
+        this.selectionChangedListeners.add(listener);
+    }
+
+    @Override
+    public void removeSelectionChangedListener(ISelectionChangedListener listener) {
+        this.selectionChangedListeners.remove(listener);
+    }
+
+    public NodeSelection getSelectionHistory() {
+        return this.selectionHistory;
+    }
+
+    @Override
+    public ISelection getSelection() {
+        return getSelectionHistory();
+    }
+
+    @Override
+    public void setSelection(ISelection selection) {
+        handleSelection(selection);
+    }
+
+    protected void handleSelection(ISelection selection) {
+        NodeSelection nodeSelection = NodeSelection.from(selection);
+        this.selectionHistory = this.selectionHistory.mergeWith(nodeSelection);
+        fireSelectionChanged();
+    }
+
+    protected void fireSelectionChanged() {
+        final SelectionChangedEvent selectionChangedEvent = new SelectionChangedEvent(
+                SelectionHistoryManager.this.treeViewer, getSelection());
+        for (final ISelectionChangedListener listener : this.selectionChangedListeners) {
+            // using SafeRunnable here to ensure that no
+            // ISelectionChangedListener from other plugins can break our code
+            SafeRunnable.run(new SafeRunnable() {
+                @Override
+                public void run() {
+                    listener.selectionChanged(selectionChangedEvent);
+                }
+            });
+        }
+    }
+
     /**
-     * {@code ISelectionChangedListener} that, for each selection change in the tree viewer, updates the selection history accordingly.
+     * {@code ISelectionChangedListener} that, for each selection change in the
+     * tree viewer, updates the selection history accordingly.
      */
     private final class TreeViewerSelectionListener implements ISelectionChangedListener {
 
         @Override
         public void selectionChanged(SelectionChangedEvent event) {
-            ISelection selection = event.getSelection();
-            if (selection instanceof IStructuredSelection) {
-                handleSelection((IStructuredSelection) selection);
-            }
+            handleSelection(event.getSelection());
         }
-
     }
-
 }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/view/task/TaskView.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/view/task/TaskView.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     Etienne Studer & Donát Csikós (Gradle Inc.) - initial API and implementation and initial documentation
+ *     Simon Scholz <simon.scholz@vogella.com> - Bug 479243
  */
 
 package org.eclipse.buildship.ui.view.task;
@@ -134,8 +135,11 @@ public final class TaskView extends ViewPart implements NodeSelectionProvider {
         });
 
         // manage the selection history as required for the task execution
-        getSite().setSelectionProvider(this.treeViewer);
-        this.selectionHistoryManager = new SelectionHistoryManager(this.getTreeViewer());
+        this.selectionHistoryManager = new SelectionHistoryManager(getTreeViewer());
+        // let the SelectionHistoryManager propagate the NodeSelection to the
+        // Workbench
+        getSite().setSelectionProvider(this.selectionHistoryManager);
+
 
         // create toolbar actions, menu items, event listeners, etc.
         this.uiContributionManager = new UiContributionManager(this);


### PR DESCRIPTION
This PR turn the NodeSelection Object into an IStructuredSelection, which is propagated to the Workbench by introducing a NodeSelectionProviderWrapper, which is applied by the TaskView like this:

```java
 this.selectionProvider = new NodeSelectionProviderWrapper(this, getTreeViewer());
 getSite().setSelectionProvider(this.selectionProvider);
```

This PR not only provides a different approach to handle the enablement of Handlers, but also makes the ISelection, which is propagated to the workbench more detailed and let's NodeSelections behave in a natural Eclipse manner.