### PR TITLE
set local m2 repository to temp directory

### DIFF
--- a/buildSrc/src/main/groovy/eclipsebuild/mavenize/DeployMavenAntTaskExecutor.groovy
+++ b/buildSrc/src/main/groovy/eclipsebuild/mavenize/DeployMavenAntTaskExecutor.groovy
@@ -43,6 +43,7 @@ class DeployMavenAntTaskExecutor {
      */
     void deployBundle(Map options = [:], Pom pomStruct, File bundleFileOrDirectory) {
         workFolder.mkdirs()
+        String temporaryM2FolderPath = new File(workFolder, ".m2").absolutePath
         def pomFile = new File(workFolder, 'myPom.xml')
         File bundleFile
         if (bundleFileOrDirectory.isDirectory()) {
@@ -68,6 +69,8 @@ class DeployMavenAntTaskExecutor {
                 pom refid: 'mypom'
                 if(sourceFile)
                     attach file: sourceFile, type: 'jar', classifier: 'sources'
+
+                localRepository id:"local.repository", path: temporaryM2FolderPath, layout:"default"
                 remoteRepository url: this.target.toURI().toURL().toString(), {
                 }
             }


### PR DESCRIPTION
This avoids polluting the local m2 folder with large junks of temporary data.

Especially used to avoid in the ci invironment to keep ~/.m2 folder clean.
incremental builds are not affected at all as the stuff that is (accidently) pushed to ~/m2 is neither input nor output of any gradle task. pushing files there is just a known issue of the underlaying ant.deploy task used by the installTargetPlatform gradle task