### PR TITLE
Use eclipse preference color and font for gradle consoles

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/console/GradleConsole.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/console/GradleConsole.java
@@ -21,8 +21,11 @@ import org.eclipse.buildship.ui.UiPlugin;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.internal.ui.DebugUIPlugin;
 import org.eclipse.debug.internal.ui.preferences.IDebugPreferenceConstants;
+import org.eclipse.debug.ui.IDebugUIConstants;
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.Font;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.console.IOConsole;
 import org.eclipse.ui.console.IOConsoleInputStream;
@@ -69,6 +72,12 @@ public final class GradleConsole extends IOConsole implements ProcessStreams {
             @SuppressWarnings("restriction")
             @Override
             public void run() {
+                Font consoleFont = JFaceResources.getFont(IDebugUIConstants.PREF_CONSOLE_FONT);
+                GradleConsole.this.setFont(consoleFont);
+                
+                Color backgroundColor = DebugUIPlugin.getPreferenceColor(IDebugPreferenceConstants.CONSOLE_BAKGROUND_COLOR);
+                GradleConsole.this.setBackground(backgroundColor);
+
                 Color inputColor = DebugUIPlugin.getPreferenceColor(IDebugPreferenceConstants.CONSOLE_SYS_IN_COLOR);
                 GradleConsole.this.inputStream.setColor(inputColor);
 


### PR DESCRIPTION
Currently [GradleConsole](https://github.com/eclipse/buildship/blob/master/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/console/GradleConsole.java) does not use the eclipse preference colour or preference font for consoles. However, because it **does** use the preference *foreground* colour this leads to invisible (or difficult to read) text if a "reversed" colour scheme is used. This PR alters the behaviour of `GradleConsole` to apply the font and background colour selections defined in the eclipse preferences.

Whilst this is admittedly a minor change, the effects are quite debilitating since it requires highlighting the text in the console window in order to read it. Buildship is fantastic but this minor tweak will make a huge difference to those of us foolish enough to use dark console colour schemes.

### Demonstration

##### Console output with default settings

![Gradle console output with default settings](http://www.eq2.co.uk/pr/buildship/console-before.png)

##### Console colour preferences changed to a reversed colour scheme

![Preferences dialogue showing reversed colours](http://www.eq2.co.uk/pr/buildship/preferences-dialogue.png)

##### produces the following output:

![Gradle console output with reversed colour scheme](http://www.eq2.co.uk/pr/buildship/console-reverse.png)

##### After applying the changes in this PR: colour and font selection is applied

![Gradle console output after fix](http://www.eq2.co.uk/pr/buildship/console-after.png)