### PR TITLE
Re-add a simplified ProjectCreatedEvent

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/ImportingProjectProjectCreatedEvent.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/ImportingProjectProjectCreatedEvent.groovy
@@ -1,0 +1,56 @@
+package org.eclipse.buildship.core.workspace.internal
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Issue;
+
+import com.google.common.collect.ImmutableList
+
+import com.gradleware.tooling.toolingclient.GradleDistribution
+import com.gradleware.tooling.toolingmodel.repository.FixedRequestAttributes
+
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.resources.IWorkspace
+import org.eclipse.core.runtime.IPath
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.jdt.core.IJavaProject
+import org.eclipse.jdt.core.JavaCore
+
+import org.eclipse.buildship.core.CorePlugin
+import org.eclipse.buildship.core.configuration.GradleProjectBuilder
+import org.eclipse.buildship.core.configuration.GradleProjectNature
+import org.eclipse.buildship.core.event.Event
+import org.eclipse.buildship.core.event.EventListener
+import org.eclipse.buildship.core.test.fixtures.WorkspaceSpecification
+import org.eclipse.buildship.core.test.fixtures.LegacyEclipseSpockTestHelper
+import org.eclipse.buildship.core.test.fixtures.ProjectSynchronizationSpecification
+import org.eclipse.buildship.core.test.fixtures.TestEnvironment
+import org.eclipse.buildship.core.util.gradle.GradleDistributionWrapper
+import org.eclipse.buildship.core.util.progress.AsyncHandler
+import org.eclipse.buildship.core.util.variable.ExpressionUtils
+import org.eclipse.buildship.core.workspace.WorkspaceGradleOperations
+
+class ImportingProjectProjectCreatedEvent extends ProjectSynchronizationSpecification {
+
+    def "Can receive ProjectCreatedEvent"() {
+        given:
+        boolean eventReceived = false
+
+        CorePlugin.listenerRegistry().addEventListener(new EventListener() {
+            public void onEvent(Event event) {
+                eventReceived = true
+            }
+        })
+
+        when:
+        synchronizeAndWait(newSampleProject())
+
+        then:
+        eventReceived == true
+    }
+
+    def File newSampleProject() {
+        workspaceDir('sample')
+    }
+
+}

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/ProjectCreatedEvent.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/ProjectCreatedEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ */
+
+package org.eclipse.buildship.core.workspace;
+
+import org.eclipse.buildship.core.event.Event;
+import org.eclipse.core.resources.IProject;
+
+/**
+ * Event informing that a new {@link IProject} has been created during a Gradle project import.
+ */
+public interface ProjectCreatedEvent extends Event {
+
+    /**
+     * The project created during a Gradle project import.
+     *
+     * @return the created project
+     */
+    IProject getProject();
+
+}

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultProjectCreatedEvent.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultProjectCreatedEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Simon Scholz (vogella GmbH) - initial API and implementation and initial documentation
+ */
+
+package org.eclipse.buildship.core.workspace.internal;
+
+import com.google.common.base.Preconditions;
+import org.eclipse.buildship.core.workspace.ProjectCreatedEvent;
+import org.eclipse.core.resources.IProject;
+
+/**
+ * Default implementation of {@link ProjectCreatedEvent}.
+ */
+public final class DefaultProjectCreatedEvent implements ProjectCreatedEvent {
+
+    private final IProject project;
+
+    public DefaultProjectCreatedEvent(IProject project) {
+        this.project = Preconditions.checkNotNull(project);
+    }
+
+    @Override
+    public IProject getProject() {
+        return this.project;
+    }
+
+}

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultWorkspaceGradleOperations.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultWorkspaceGradleOperations.java
@@ -52,6 +52,7 @@ import org.eclipse.buildship.core.util.file.RelativePathUtils;
 import org.eclipse.buildship.core.util.predicate.Predicates;
 import org.eclipse.buildship.core.workspace.GradleClasspathContainer;
 import org.eclipse.buildship.core.workspace.NewProjectHandler;
+import org.eclipse.buildship.core.workspace.ProjectCreatedEvent;
 import org.eclipse.buildship.core.workspace.WorkspaceGradleOperations;
 
 /**
@@ -288,6 +289,10 @@ public final class DefaultWorkspaceGradleOperations implements WorkspaceGradleOp
             } else {
                 workspaceProject = addNewEclipseProjectToWorkspace(project, gradleBuild, rootRequestAttributes, new SubProgressMonitor(monitor, 1));
             }
+
+            // notify the listeners that a new IProject is available in the workspace
+            ProjectCreatedEvent event = new DefaultProjectCreatedEvent(workspaceProject);
+            CorePlugin.listenerRegistry().dispatch(event);
         } finally {
             monitor.done();
         }


### PR DESCRIPTION
See https://discuss.gradle.org/t/projectcreatedevent-alternatives/15208

Our team (Liferay) was relying on the ProjectCreatedEvent in order to do some custom configuration based on our developer's gradle projects.  In this pull I've re-added the ProjectCreatedEvent but simplified it (removed the working sets api), so just basically be a signal for the newly created project.  I hope the buildship team has a chance to consider the PR.