### PR TITLE
Update manifest versions to allow projects to be open in Eclipse SDK

### DIFF
--- a/org.eclipse.buildship.branding/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.branding/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Buildship, Eclipse Plug-ins for Gradle
 Bundle-SymbolicName: org.eclipse.buildship.branding
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Eclipse Buildship
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ClassPath: .

--- a/org.eclipse.buildship.core.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.core.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Buildship, Eclipse Plug-ins for Gradle - Core Test
 Bundle-SymbolicName: org.eclipse.buildship.core.test;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Eclipse Buildship
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Fragment-Host: org.eclipse.buildship.core

--- a/org.eclipse.buildship.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Buildship, Eclipse Plug-ins for Gradle - Core
 Bundle-SymbolicName: org.eclipse.buildship.core;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Eclipse Buildship
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Activator: org.eclipse.buildship.core.CorePlugin

--- a/org.eclipse.buildship.stsmigration.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.stsmigration.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Buildship, Eclipse Plug-ins for Gradle - STS Gradle Migration Test
 Bundle-SymbolicName: org.eclipse.buildship.stsmigration.test;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Eclipse Buildship
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Fragment-Host: org.eclipse.buildship.stsmigration

--- a/org.eclipse.buildship.stsmigration/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.stsmigration/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Buildship, Eclipse Plug-ins for Gradle - STS Gradle Migration
 Bundle-SymbolicName: org.eclipse.buildship.stsmigration;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Eclipse Buildship
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Activator: org.eclipse.buildship.stsmigration.StsMigrationPlugin

--- a/org.eclipse.buildship.ui.test/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.ui.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Buildship, Eclipse Plug-ins for Gradle - UI Test
 Bundle-SymbolicName: org.eclipse.buildship.ui.test;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Eclipse Buildship
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Fragment-Host: org.eclipse.buildship.ui

--- a/org.eclipse.buildship.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Buildship, Eclipse Plug-ins for Gradle - UI
 Bundle-SymbolicName: org.eclipse.buildship.ui;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 1.0.11.qualifier
 Bundle-Vendor: Eclipse Buildship
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Activator: org.eclipse.buildship.ui.UiPlugin


### PR DESCRIPTION
We often have buildship bundle projects open in Eclipse and also we have downstream bundles that depend on specific versions of buildship bundles (v1.0.11), and since all of the buildship bundle manfiests are still set at 1.0.0.qualifier, Eclipse marks my bundle manifests with an error.  

Would the buildship team be able to keep the manifest versions up-to-date?  