### PR TITLE
Import the stsmigration plugin during oomph setup

### DIFF
--- a/buildship.setup
+++ b/buildship.setup
@@ -264,6 +264,12 @@
         <operand
             xsi:type="predicates:NamePredicate"
             pattern="org\.eclipse\.buildship\.site"/>
+        <operand
+            xsi:type="predicates:NamePredicate"
+            pattern="org\.eclipse\.buildship\.stsmigration"/>
+        <operand
+            xsi:type="predicates:NamePredicate"
+            pattern="org\.eclipse\.buildship\.stsmigration\.test"/>
       </predicate>
     </sourceLocator>
   </setupTask>


### PR DESCRIPTION
Since that plugin is referenced in the feature, it is mandatory and should be
in the workspace to avoid feature related warnings and build errors.

I have an Eclipse CLA.

Change-Id: Ie280721b66d8b7289dc0cb13b65a511355a4c523
Signed-off-by: Michael Keppler <Michael.Keppler@gmx.de>