### PR TITLE
Allow Java Platform to be first in classpath

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/SingleProjectSynchronizationSpecification.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/SingleProjectSynchronizationSpecification.groovy
@@ -2,6 +2,7 @@ package org.eclipse.buildship.core.workspace.internal
 
 import org.eclipse.jdt.core.IClasspathEntry
 import org.eclipse.jdt.core.JavaCore
+import org.eclipse.jdt.launching.JavaRuntime;
 
 import org.eclipse.buildship.core.Logger;
 import org.eclipse.buildship.core.configuration.GradleProjectNature
@@ -210,7 +211,7 @@ abstract class SingleProjectSynchronizationSpecification extends ProjectSynchron
         project.hasNature(JavaCore.NATURE_ID)
     }
 
-    def "If the project applies the Java plugin, then the Gradle classpath container is added"() {
+    def "If the project applies the Java plugin, then the Gradle classpath container is added after JRE Container"() {
         setup:
         prepareProject("sample-project")
         def projectDir = dir('sample-project') {
@@ -223,9 +224,17 @@ abstract class SingleProjectSynchronizationSpecification extends ProjectSynchron
 
         then:
         def project = findProject('sample-project')
-        JavaCore.create(project).rawClasspath.find{
+
+        def classpath = JavaCore.create(project).rawClasspath
+        classpath.find{
             it.entryKind == IClasspathEntry.CPE_CONTAINER &&
             it.path == GradleClasspathContainer.CONTAINER_PATH
+        }
+        for(entry in classpath) {
+            if(entry.entryKind == IClasspathEntry.CPE_CONTAINER) {
+                assert entry.path.segment(0) == JavaRuntime.JRE_CONTAINER
+                break;
+            }
         }
     }
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SynchronizeGradleBuildOperation.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SynchronizeGradleBuildOperation.java
@@ -213,10 +213,10 @@ final class SynchronizeGradleBuildOperation implements IWorkspaceRunnable {
         //old Gradle versions did not expose natures, so we need to add the Java nature explicitly
         CorePlugin.workspaceOperations().addNature(workspaceProject, JavaCore.NATURE_ID, progress.newChild(1));
         IJavaProject javaProject = JavaCore.create(workspaceProject);
+        JavaSourceSettingsUpdater.update(javaProject, project.getJavaSourceSettings().get(), progress.newChild(1));
         GradleClasspathContainer.addIfNotPresent(javaProject, progress.newChild(1));
         ClasspathContainerUpdater.updateFromModel(javaProject, project, this.allProjects, progress.newChild(1));
         WtpClasspathUpdater.update(javaProject, project, progress.newChild(1));
-        JavaSourceSettingsUpdater.update(javaProject, project.getJavaSourceSettings().get(), progress.newChild(1));
         SourceFolderUpdater.update(javaProject, project.getSourceDirectories(), progress.newChild(1));
     }
 


### PR DESCRIPTION
Change order of classpath building to allow java platform to load before external dependencies.