### PR TITLE
BuildCommandUpdater adds GradleProjectBuilder by default

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/BuildCommandUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/BuildCommandUpdater.java
@@ -11,9 +11,14 @@
 
 package org.eclipse.buildship.core.workspace.internal;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.Sets;
 
 import com.gradleware.tooling.toolingmodel.OmniEclipseBuildCommand;
 
@@ -23,37 +28,43 @@ import org.eclipse.core.resources.IProjectDescription;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 
+import org.eclipse.buildship.core.configuration.GradleProjectBuilder;
+
 /**
  * Updates the build commands on the target project.
  */
 final class BuildCommandUpdater {
 
     public static void update(IProject project, Optional<List<OmniEclipseBuildCommand>> buildCommands, IProgressMonitor monitor) throws CoreException {
-        if (buildCommands.isPresent()) {
-            update(project, buildCommands.get(), monitor);
-        }
-    }
-
-    private static void update(IProject project, List<OmniEclipseBuildCommand> buildCommands, IProgressMonitor monitor) throws CoreException {
         IProjectDescription description = project.getDescription();
-        description.setBuildSpec(toCommands(buildCommands, description));
+        Set<ICommand> commands = toCommands(buildCommands, description);
+        description.setBuildSpec(commands.toArray(new ICommand[0]));
         project.setDescription(description, monitor);
     }
 
-    private static ICommand[] toCommands(List<OmniEclipseBuildCommand> buildCommands, IProjectDescription description) {
-        ICommand[] commands = new ICommand[buildCommands.size()];
-        for (int i = 0; i < buildCommands.size(); i++) {
-            OmniEclipseBuildCommand buildCommand = buildCommands.get(i);
-            commands[i] = toCommand(buildCommand, description);
+    private static Set<ICommand> toCommands(Optional<List<OmniEclipseBuildCommand>> buildCommands, IProjectDescription description) {
+        Set<ICommand> commands = Sets.newLinkedHashSet();
+        if (buildCommands.isPresent()) {
+            commands.addAll(toCommands(buildCommands.get(), description));
+        } else {
+            commands.addAll(Arrays.asList(description.getBuildSpec()));
         }
+        commands.add(toCommand(description, GradleProjectBuilder.ID, Collections.<String, String>emptyMap()));
         return commands;
     }
 
-    private static ICommand toCommand(OmniEclipseBuildCommand buildCommand, IProjectDescription description) {
-        ICommand command = description.newCommand();
-        command.setBuilderName(buildCommand.getName());
-        command.setArguments(buildCommand.getArguments());
-        return command;
+    private static Set<? extends ICommand> toCommands(List<OmniEclipseBuildCommand> buildCommands, IProjectDescription description) {
+        Set<ICommand> result = Sets.newLinkedHashSet();
+        for (OmniEclipseBuildCommand buildCommand : buildCommands) {
+            result.add(toCommand(description, buildCommand.getName(), buildCommand.getArguments()));
+        }
+        return result;
     }
 
+    private static ICommand toCommand(IProjectDescription description, String name, Map<String, String> arguments) {
+        ICommand command = description.newCommand();
+        command.setBuilderName(name);
+        command.setArguments(arguments);
+        return command;
+    }
 }


### PR DESCRIPTION
After the latest project synchronization changes the Gradle builder
was no longer added to the projects. This was due to the fact that we
relied on the Gradle nature extension point to add the builder along
with the nature. The builders were overridden by the BuildCommandUpdater
when the used Gradle versions provided natures and builders.

This commit fixes the problem by applying the Gradle builder by default
on all Gradle projects. This behaviour is symmetric with the
ProjectNatureUpdater class implementation.