### PR TITLE
Replace GradleClasspathContainer on project only if content changed

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerUpdaterTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerUpdaterTest.groovy
@@ -93,6 +93,31 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         path << ['linked_folder', '/linked_folder']
     }
 
+    def "Verify container is only updated on project, if content has changed"(){
+        given:
+        def gradleProject = gradleProjectWithClasspath(
+                externalDependency(dir("foo")),
+                externalDependency(dir("bar"))
+                )
+
+        expect:
+        def initialContainer = gradleClasspathContainer
+        initialContainer
+
+        when:
+        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, gradleProject.all.toSet(), null)
+
+        then:
+        def modifiedContainer = gradleClasspathContainer
+        !modifiedContainer.is(initialContainer)
+
+        when:
+        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, gradleProject.all.toSet(), null)
+
+        then:
+        modifiedContainer.is(gradleClasspathContainer)
+    }
+
     OmniEclipseProject gradleProjectWithClasspath(Object... dependencies) {
         Stub(OmniEclipseProject) {
             getExternalDependencies() >> dependencies.findAll { it instanceof OmniExternalDependency }
@@ -115,5 +140,9 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
 
     IClasspathEntry[] getResolvedClasspath() {
         project.getResolvedClasspath(false)
+    }
+
+    GradleClasspathContainer getGradleClasspathContainer(){
+        JavaCore.getClasspathContainer(GradleClasspathContainer.CONTAINER_PATH, project)
     }
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultGradleClasspathContainer.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultGradleClasspathContainer.java
@@ -11,6 +11,7 @@
 
 package org.eclipse.buildship.core.workspace.internal;
 
+import java.util.Arrays;
 import java.util.List;
 
 import com.google.common.base.Preconditions;
@@ -54,6 +55,30 @@ public final class DefaultGradleClasspathContainer extends GradleClasspathContai
     @Override
     public int getKind() {
         return IClasspathContainer.K_APPLICATION;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = 31 * result + Arrays.hashCode(this.classpathEntries);
+        result = 31 * result + this.containerPath.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+
+        DefaultGradleClasspathContainer other = (DefaultGradleClasspathContainer) obj;
+        return Arrays.equals(this.classpathEntries, other.classpathEntries) && this.containerPath.equals(other.containerPath);
     }
 
 }


### PR DESCRIPTION
This pull request fixes the problem that on each synchronization the GradleClasspathContainer is replaced on the project, although there are no changes. This issue caused on big projects unnecessary incremental builds, because the project description is marked as changed after the classpath container is replaced. See also Gradle discussion [1].

Eclipse internal checks if the old classpath container differs from the new classpath container [2]. Therefore the fix only implements the equals() and hashcode() of the GradleClasspathContainer to fix the problem.

[1] https://discuss.gradle.org/t/classpath-container-update-on-synchronization/21499
[2] org.eclipse.jdt.internal.core.SetContainerOperation.executeOperation()