### PR TITLE
Make Gradle classpath containers of different projects unequal

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerInitializer.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerInitializer.java
@@ -65,4 +65,8 @@ public final class GradleClasspathContainerInitializer extends ClasspathContaine
         return GradleClasspathContainerUpdater.updateFromStorage(javaProject, null);
     }
 
+    @Override
+    public Object getComparisonID(IPath containerPath, IJavaProject project) {
+        return project;
+    }
 }


### PR DESCRIPTION
JDT de-duplicates classpath containers when computing the runtime
classpath for a project. By default all containers with the same path
are considered equal. This breaks when a user manually adds a Gradle
project to the classpath of another Gradle project (which is still a
valid use case while composite builds and WTP don't work together, as
well as for quick experimentation). See
https://github.com/gradle/gradle/issues/1516#issuecomment-284649135

The fix is simple: Our container should be considered different for each
project.

Signed-off-by: Stefan Oehme <st.oehme@gmail.com>