### PR TITLE
Use Guava 21 in e47+ builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ def eclipseVersionAgnosticDependencies = [
     'org.slf4j.simple'                  : '1.7.2',
     'com.google.guava'                  : '15.0.0',
     'com.google.gson'                   : '2.2.4',
-    'org.junit'                         : '4.11.0',
     'org.apache.log4j'                  : '1.2.15',
     'org.eclipse.swtbot.eclipse.finder' : '2.2.1',
     'org.eclipse.swtbot.junit4_x'       : '2.2.1',
@@ -67,6 +66,7 @@ eclipseBuild {
             'com.ibm.icu'                           : '4.4.2',
             'org.eclipse.jface.databinding'         : '1.6.0',
             'org.eclipse.jface.text'                : '3.8.2',
+            'org.junit'                             : '4.11.0',
             "$swtPluginId"                          : '3.100.1'
         ] + eclipseVersionAgnosticDependencies
     }
@@ -99,6 +99,7 @@ eclipseBuild {
             'com.ibm.icu'                           : '50.1.1',
             'org.eclipse.jface.databinding'         : '1.6.200',
             'org.eclipse.jface.text'                : '3.8.101',
+            'org.junit'                             : '4.11.0',
             "$swtPluginId"                          : '3.102.1'
         ] + eclipseVersionAgnosticDependencies
     }
@@ -131,6 +132,7 @@ eclipseBuild {
             'com.ibm.icu'                           : '52.1.1',
             'org.eclipse.jface.databinding'         : '1.6.200',
             'org.eclipse.jface.text'                : '3.9.2',
+            'org.junit'                             : '4.11.0',
             "$swtPluginId"                          : '3.103.2'
         ] + eclipseVersionAgnosticDependencies
     }
@@ -163,6 +165,7 @@ eclipseBuild {
             'org.eclipse.jface.databinding'         : '1.7.0',
             'org.eclipse.jface.text'                : '3.10.0',
             'com.ibm.icu'                           : '54.1.1',
+            'org.junit'                             : '4.11.0',
             "$swtPluginId"                          : "3.104.0"
         ] + eclipseVersionAgnosticDependencies
     }
@@ -170,6 +173,13 @@ eclipseBuild {
     targetPlatform {
         eclipseVersion = '46'
         targetDefinition = file('tooling-e46.target')
+        // TODO define version mapping similarly as above; it makes dependency resolution faster
+        versionMapping = eclipseVersionAgnosticDependencies
+    }
+
+    targetPlatform {
+        eclipseVersion = '47'
+        targetDefinition = file('tooling-e47.target')
         // TODO define version mapping similarly as above; it makes dependency resolution faster
         versionMapping = eclipseVersionAgnosticDependencies
     }

--- a/buildship.setup
+++ b/buildship.setup
@@ -293,13 +293,13 @@
           versionRange="15.0.0"/>
       <requirement
           name="com.gradleware.tooling.client"
-          versionRange="0.19.0"/>
+          versionRange="0.20.0"/>
       <requirement
           name="com.gradleware.tooling.model"
-          versionRange="0.19.0"/>
+          versionRange="0.20.0"/>
       <requirement
           name="com.gradleware.tooling.utils"
-          versionRange="0.19.0"/>
+          versionRange="0.20.0"/>
       <requirement
           name="org.jetbrains.kotlin.feature.feature.group"
           versionRange="0.8.0"/>
@@ -312,7 +312,7 @@
         <repository
             url="http://builds.gradle.org:8000/eclipse/update-site/mirror/kotlin-eclipse-dev"/>
         <repository
-            url="jar:https://repo.gradle.org/gradle/tooling-libs-releases-local/com/gradleware/tooling/p2-repository/0.19.0/p2-repository-0.19.0.zip!/"/>
+            url="jar:https://repo.gradle.org/gradle/tooling-libs-snapshots-local/com/gradleware/tooling/p2-repository/0.20.0-20170516152344/p2-repository-0.20.0-20170516152344.zip!/"/>
       </repositoryList>
       <repositoryList
           name="Mars">
@@ -323,7 +323,7 @@
         <repository
             url="http://builds.gradle.org:8000/eclipse/update-site/mirror/kotlin-eclipse-dev"/>
         <repository
-            url="jar:https://repo.gradle.org/gradle/tooling-libs-releases-local/com/gradleware/tooling/p2-repository/0.19.0/p2-repository-0.19.0.zip!/"/>
+            url="jar:https://repo.gradle.org/gradle/tooling-libs-snapshots-local/com/gradleware/tooling/p2-repository/0.20.0-20170516152344/p2-repository-0.20.0-20170516152344.zip!/"/>
       </repositoryList>
       <repositoryList
           name="Luna">
@@ -334,7 +334,7 @@
         <repository
             url="http://builds.gradle.org:8000/eclipse/update-site/mirror/kotlin-eclipse-dev"/>
         <repository
-            url="jar:https://repo.gradle.org/gradle/tooling-libs-releases-local/com/gradleware/tooling/p2-repository/0.19.0/p2-repository-0.19.0.zip!/"/>
+            url="jar:https://repo.gradle.org/gradle/tooling-libs-snapshots-local/com/gradleware/tooling/p2-repository/0.20.0-20170516152344/p2-repository-0.20.0-20170516152344.zip!/"/>
       </repositoryList>
       <repositoryList
           name="Kepler">
@@ -345,7 +345,7 @@
         <repository
             url="http://builds.gradle.org:8000/eclipse/update-site/mirror/kotlin-eclipse-dev"/>
         <repository
-            url="jar:https://repo.gradle.org/gradle/tooling-libs-releases-local/com/gradleware/tooling/p2-repository/0.19.0/p2-repository-0.19.0.zip!/"/>
+            url="jar:https://repo.gradle.org/gradle/tooling-libs-snapshots-local/com/gradleware/tooling/p2-repository/0.20.0-20170516152344/p2-repository-0.20.0-20170516152344.zip!/"/>
       </repositoryList>
       <repositoryList
           name="Juno">
@@ -356,7 +356,7 @@
         <repository
             url="http://builds.gradle.org:8000/eclipse/update-site/mirror/kotlin-eclipse-dev"/>
         <repository
-            url="jar:https://repo.gradle.org/gradle/tooling-libs-releases-local/com/gradleware/tooling/p2-repository/0.19.0/p2-repository-0.19.0.zip!/"/>
+            url="jar:https://repo.gradle.org/gradle/tooling-libs-snapshots-local/com/gradleware/tooling/p2-repository/0.20.0-20170516152344/p2-repository-0.20.0-20170516152344.zip!/"/>
       </repositoryList>
     </targlet>
     <targlet

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # production library version numbers
-toolingCommonsVersion=0.19.0
+toolingCommonsVersion=0.20.0-20170516152344
 toolingApiVersion=3.5
 
 # testing library version numbers

--- a/org.eclipse.buildship.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.core/META-INF/MANIFEST.MF
@@ -17,9 +17,9 @@ Require-Bundle: org.eclipse.core.expressions,
  org.eclipse.jdt.launching,
  org.eclipse.debug.core,
  org.slf4j.api;bundle-version="1.7.2",
- com.gradleware.tooling.model;bundle-version="[0.19.0,0.20.0)",
- com.gradleware.tooling.client;bundle-version="[0.19.0,0.20.0)",
- com.gradleware.tooling.utils;bundle-version="[0.19.0,0.20.0)"
+ com.gradleware.tooling.model;bundle-version="[0.20.0,0.21.0)",
+ com.gradleware.tooling.client;bundle-version="[0.20.0,0.21.0)",
+ com.gradleware.tooling.utils;bundle-version="[0.20.0,0.21.0)"
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.buildship.core;x-friends:="org.eclipse.buildship.ui,org.eclipse.buildship.kotlin",
  org.eclipse.buildship.core.configuration;x-friends:="org.eclipse.buildship.ui,org.eclipse.buildship.kotlin",

--- a/org.eclipse.buildship.kotlin/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.kotlin/META-INF/MANIFEST.MF
@@ -20,6 +20,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.jetbrains.kotlin.bundled-compiler;bundle-version="[0.8.2,0.9.0)",
  org.jetbrains.kotlin.ui;bundle-version="[0.8.2,0.9.0)",
  org.jetbrains.kotlin.core;bundle-version="[0.8.2,0.9.0)",
- com.gradleware.tooling.model;bundle-version="[0.19.0,0.20.0)",
- com.gradleware.tooling.client;bundle-version="[0.19.0,0.20.0)",
- com.gradleware.tooling.utils;bundle-version="[0.19.0,0.20.0)"
+ com.gradleware.tooling.model;bundle-version="[0.20.0,0.21.0)",
+ com.gradleware.tooling.client;bundle-version="[0.20.0,0.21.0)",
+ com.gradleware.tooling.utils;bundle-version="[0.20.0,0.21.0)"

--- a/org.eclipse.buildship.site/build.gradle
+++ b/org.eclipse.buildship.site/build.gradle
@@ -52,6 +52,15 @@ dependencies {
     signedExternalPlugin withEclipseBundle('com.google.guava')
 }
 
+// tooling-commons would bring in Guava 15.0 by default
+configurations.all {
+    resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+        if (eclipsebuild.Config.on(project).targetPlatform.eclipseVersion >= '47' && details.requested.name == 'com.google.guava') {
+            details.useVersion '21.0.0'
+        }
+    }
+}
+
 task uploadUpdateSite(dependsOn : createP2Repository) {
     description = "Uploads the generated update site to the eclipse.org server."
 

--- a/org.eclipse.buildship.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.ui/META-INF/MANIFEST.MF
@@ -21,8 +21,8 @@ Require-Bundle: org.eclipse.buildship.core,
  org.eclipse.jface.databinding,
  org.eclipse.jface.text,
  com.ibm.icu,
- com.gradleware.tooling.model;bundle-version="[0.19.0,0.20.0)",
- com.gradleware.tooling.client;bundle-version="[0.19.0,0.20.0)",
- com.gradleware.tooling.utils;bundle-version="[0.19.0,0.20.0)"
+ com.gradleware.tooling.model;bundle-version="[0.20.0,0.21.0)",
+ com.gradleware.tooling.client;bundle-version="[0.20.0,0.21.0)",
+ com.gradleware.tooling.utils;bundle-version="[0.20.0,0.21.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/tooling-e42.target
+++ b/tooling-e42.target
@@ -7,11 +7,11 @@
 <repository location="http://builds.gradle.org:8000/eclipse/update-site/mirror/releases-juno/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.gradle.toolingapi" version="3.5.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.utils" version="0.19.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.client" version="0.19.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.model" version="0.19.0.v20170412105839"/>
-<repository location="jar:https://repo.gradle.org/gradle/tooling-libs-releases-local/com/gradleware/tooling/p2-repository/0.19.0/p2-repository-0.19.0.zip!/"/>
+<unit id="org.gradle.toolingapi" version="3.5.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.utils" version="0.20.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.client" version="0.20.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.model" version="0.20.0.v20170516152344"/>
+<repository location="jar:https://repo.gradle.org/gradle/tooling-libs-snapshots-local/com/gradleware/tooling/p2-repository/0.20.0-20170516152344/p2-repository-0.20.0-20170516152344.zip!/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.jetbrains.kotlin.feature.feature.group" version="0.8.2.v20170324-0008"/>

--- a/tooling-e43.target
+++ b/tooling-e43.target
@@ -7,11 +7,11 @@
 <repository location="http://builds.gradle.org:8000/eclipse/update-site/mirror/releases-kepler/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.gradle.toolingapi" version="3.5.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.utils" version="0.19.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.client" version="0.19.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.model" version="0.19.0.v20170412105839"/>
-<repository location="jar:https://repo.gradle.org/gradle/tooling-libs-releases-local/com/gradleware/tooling/p2-repository/0.19.0/p2-repository-0.19.0.zip!/"/>
+<unit id="org.gradle.toolingapi" version="3.5.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.utils" version="0.20.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.client" version="0.20.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.model" version="0.20.0.v20170516152344"/>
+<repository location="jar:https://repo.gradle.org/gradle/tooling-libs-snapshots-local/com/gradleware/tooling/p2-repository/0.20.0-20170516152344/p2-repository-0.20.0-20170516152344.zip!/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.jetbrains.kotlin.feature.feature.group" version="0.8.2.v20170324-0008"/>

--- a/tooling-e45.target
+++ b/tooling-e45.target
@@ -7,11 +7,11 @@
 <repository location="http://builds.gradle.org:8000/eclipse/update-site/mirror/releases-mars/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.gradle.toolingapi" version="3.5.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.utils" version="0.19.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.client" version="0.19.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.model" version="0.19.0.v20170412105839"/>
-<repository location="jar:https://repo.gradle.org/gradle/tooling-libs-releases-local/com/gradleware/tooling/p2-repository/0.19.0/p2-repository-0.19.0.zip!/"/>
+<unit id="org.gradle.toolingapi" version="3.5.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.utils" version="0.20.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.client" version="0.20.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.model" version="0.20.0.v20170516152344"/>
+<repository location="jar:https://repo.gradle.org/gradle/tooling-libs-snapshots-local/com/gradleware/tooling/p2-repository/0.20.0-20170516152344/p2-repository-0.20.0-20170516152344.zip!/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.jetbrains.kotlin.feature.feature.group" version="0.8.2.v20170324-0008"/>

--- a/tooling-e46.target
+++ b/tooling-e46.target
@@ -7,11 +7,11 @@
 <repository location="http://builds.gradle.org:8000/eclipse/update-site/mirror/releases-neon/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.gradle.toolingapi" version="3.5.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.utils" version="0.19.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.client" version="0.19.0.v20170412105839"/>
-<unit id="com.gradleware.tooling.model" version="0.19.0.v20170412105839"/>
-<repository location="jar:https://repo.gradle.org/gradle/tooling-libs-releases-local/com/gradleware/tooling/p2-repository/0.19.0/p2-repository-0.19.0.zip!/"/>
+<unit id="org.gradle.toolingapi" version="3.5.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.utils" version="0.20.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.client" version="0.20.0.v20170516152344"/>
+<unit id="com.gradleware.tooling.model" version="0.20.0.v20170516152344"/>
+<repository location="jar:https://repo.gradle.org/gradle/tooling-libs-snapshots-local/com/gradleware/tooling/p2-repository/0.20.0-20170516152344/p2-repository-0.20.0-20170516152344.zip!/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.jetbrains.kotlin.feature.feature.group" version="0.8.2.v20170324-0008"/>

--- a/tooling-e47.target
+++ b/tooling-e47.target
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Buildship Eclipse Luna Target Platform" sequenceNumber="1">
+<?pde version="3.8"?><target name="Buildship Eclipse Neon Target Platform" sequenceNumber="1">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.sdk.ide" version="4.4.2.M20150204-1700"/>
-<unit id="org.eclipse.m2e.feature.feature.group" version="1.5.1.20150109-1820"/>
-<repository location="http://builds.gradle.org:8000/eclipse/update-site/mirror/releases-luna/"/>
+<unit id="org.eclipse.sdk.ide" version="4.7.0.I20170308-2000"/>
+<unit id="org.eclipse.m2e.feature.feature.group" version="1.8.0.20160921-2002"/>
+<repository location="http://builds.gradle.org:8000/eclipse/update-site/mirror/releases-oxygen/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.gradle.toolingapi" version="3.5.0.v20170516152344"/>
@@ -19,10 +19,10 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.gson" version="2.2.4.v201311231704"/>
-<unit id="com.google.guava" version="15.0.0.v201403281430"/>
-<unit id="org.junit" version="4.11.0.v201303080030"/>
+<unit id="com.google.guava" version="21.0.0.v20170206-1425"/>
+<unit id="org.junit" version="4.12.0.v201504281640"/>
 <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
-<repository location="http://builds.gradle.org:8000/eclipse/update-site/mirror/orbit-mars/"/>
+<repository location="http://builds.gradle.org:8000/eclipse/update-site/mirror/orbit-oxygen-m7/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.2.1.201402241301"/>
@@ -30,7 +30,7 @@
 <repository location="http://builds.gradle.org:8000/eclipse/update-site/mirror/swtbot/release/"/>
 </location>
 </locations>
-<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+<targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 <launcherArgs>
 <vmArgs>-XX:MaxPermSize=128M</vmArgs>
 </launcherArgs>


### PR DESCRIPTION
This change introduce a new Eclipse Oxygen build which uses Guava 21.0.

Once the change is approved I'll update our CI configuration to publish e47 builds.