### PR TITLE
Make synchronization more robust

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/ImportingProjectInDefaultLocation.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/ImportingProjectInDefaultLocation.groovy
@@ -57,4 +57,37 @@ class ImportingProjectInDefaultLocation extends ProjectSynchronizationSpecificat
         1 * notification.errorOccurred(*_)
     }
 
+    def "Disallow importing the workspace root"() {
+        setup:
+        Logger logger = Mock(Logger)
+        UserNotification notification = Mock(UserNotification)
+        environment.registerService(Logger, logger)
+        environment.registerService(UserNotification, notification)
+
+        when:
+        synchronizeAndWait(workspaceDir)
+
+        then:
+        1 * logger.warn(*_)
+        1 * notification.errorOccurred(*_)
+    }
+
+    def "Disallow importing any modules located at the workspace root"() {
+        setup:
+        Logger logger = Mock(Logger)
+        UserNotification notification = Mock(UserNotification)
+        environment.registerService(Logger, logger)
+        environment.registerService(UserNotification, notification)
+        File rootProject = workspaceDir('sample2') {
+            file 'settings.gradle', "include '..'"
+        }
+
+        when:
+        synchronizeAndWait(workspaceDir)
+
+        then:
+        1 * logger.warn(*_)
+        1 * notification.errorOccurred(*_)
+    }
+
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/i18n/CoreMessages.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/i18n/CoreMessages.java
@@ -59,6 +59,7 @@ public final class CoreMessages extends NLS {
     public static String ErrorMessage_0_MustBeSpecified;
     public static String ErrorMessage_0_MustBeDirectory;
     public static String ErrorMessage_0_AlreadyExists;
+    public static String ErrorMessage_0_WorkspaceDirectory;
 
     public static String Preference_Label_GradleUserHome;
     public static String Preference_Label_OfflineMode;

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/binding/Validators.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/util/binding/Validators.java
@@ -88,6 +88,21 @@ public final class Validators {
         };
     }
 
+    public static Validator<File> nonWorkspaceFolderValidator(final String prefix) {
+        final File workspaceDir = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile();
+        return new Validator<File>() {
+
+            @Override
+            public Optional<String> validate(File file) {
+                if (workspaceDir.equals(file)) {
+                    return Optional.of(NLS.bind(CoreMessages.ErrorMessage_0_WorkspaceDirectory, prefix));
+                } else {
+                    return Optional.absent();
+                }
+            }
+        };
+    }
+
     public static Validator<String> uniqueWorkspaceProjectNameValidator(final String prefix) {
         return new Validator<String>() {
 
@@ -120,6 +135,16 @@ public final class Validators {
             @Override
             public Optional<String> validate(T value) {
                 return Boolean.FALSE.equals(condition.getValue()) ? validator.validate(value) : Optional.<String>absent();
+            }
+        };
+    }
+
+    public static <T> Validator<T> and(final Validator<T> a, final Validator<T> b) {
+        return new Validator<T>() {
+            @Override
+            public Optional<String> validate(T value) {
+                Optional<String> result = a.validate(value);
+                return result.isPresent() ? result : b.validate(value);
             }
         };
     }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleFolderUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleFolderUpdater.java
@@ -43,6 +43,8 @@ import org.eclipse.buildship.core.util.file.RelativePathUtils;
  */
 final class GradleFolderUpdater {
 
+    private static final String DEFAULT_BUILD_DIR_NAME = "build";
+
     private final IProject workspaceProject;
     private final OmniEclipseProject modelProject;
 
@@ -73,7 +75,7 @@ final class GradleFolderUpdater {
     private GradleFolderInfo collectFolderInfo(IProgressMonitor monitor) {
         IPath currentProjectPath = this.workspaceProject.getLocation();
 
-        IPath currentProjectBuildDirPath = null;
+        IPath currentProjectBuildDirPath = new Path(DEFAULT_BUILD_DIR_NAME);
         List<IPath> nestedProjectPaths = Lists.newArrayList();
         List<IPath> nestedBuildDirPaths = Lists.newArrayList();
 
@@ -134,7 +136,7 @@ final class GradleFolderUpdater {
         if (buildDirectory.isPresent() && buildDirectory.get() != null) {
             buildDirPath = normalizeBuildDirectoryPath(new Path(buildDirectory.get().getPath()));
         }
-        return buildDirPath != null ? buildDirPath : prefix.append("build");
+        return buildDirPath != null ? buildDirPath : prefix.append(DEFAULT_BUILD_DIR_NAME);
     }
 
     private IPath normalizeBuildDirectoryPath(IPath buildDirLocation) {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SynchronizeGradleBuildsJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SynchronizeGradleBuildsJob.java
@@ -77,8 +77,9 @@ public final class SynchronizeGradleBuildsJob extends ToolingApiJob {
     private void synchronizeBuild(GradleBuild build, SubMonitor progress) throws CoreException {
         BuildConfiguration buildConfig = build.getBuildConfig();
         progress.setTaskName((String.format("Synchronizing Gradle build at %s with workspace", buildConfig.getRootProjectDirectory())));
-        progress.setWorkRemaining(3);
+        progress.setWorkRemaining(4);
         Set<OmniEclipseProject> allProjects = fetchEclipseProjects(build, progress.newChild(1));
+        new ValidateProjectLocationOperation(allProjects).run(progress.newChild(1));
         new SynchronizeBuildConfigurationOperation(buildConfig).run(progress.newChild(1), getToken());
         new RunOnImportTasksOperation(allProjects, buildConfig).run(progress.newChild(1), getToken());
         new SynchronizeGradleBuildOperation(allProjects, buildConfig, SynchronizeGradleBuildsJob.this.newProjectHandler).run(progress.newChild(1));

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/ValidateProjectLocationOperation.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/ValidateProjectLocationOperation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.buildship.core.workspace.internal;
+
+import java.io.File;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
+import com.gradleware.tooling.toolingmodel.OmniEclipseProject;
+
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IProgressMonitor;
+
+import org.eclipse.buildship.core.UnsupportedConfigurationException;
+
+/**
+ * Verifies that none of the modules are located in the Eclipse workspace root.
+ *
+ * @author Donat Csikos
+ */
+public class ValidateProjectLocationOperation {
+
+    private static final File WORKSPACE_ROOT = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile();
+
+    private final Set<OmniEclipseProject> projects;
+
+    public ValidateProjectLocationOperation(Set<OmniEclipseProject> projects) {
+        this.projects = ImmutableSet.copyOf(projects);
+    }
+
+    public void run(IProgressMonitor monitor) {
+        for (OmniEclipseProject project : this.projects) {
+            if (project.getProjectDirectory().equals(WORKSPACE_ROOT)) {
+                throw new UnsupportedConfigurationException(String.format("Project %s location matches workspace root %s", project.getName(), WORKSPACE_ROOT.getAbsolutePath()));
+            }
+        }
+
+    }
+
+}

--- a/org.eclipse.buildship.core/src/main/resources/org/eclipse/buildship/core/i18n/CoreMessages.properties
+++ b/org.eclipse.buildship.core/src/main/resources/org/eclipse/buildship/core/i18n/CoreMessages.properties
@@ -48,6 +48,7 @@ ErrorMessage_0_IsNotValid={0} is not valid.
 ErrorMessage_0_MustBeSpecified={0} must be specified.
 ErrorMessage_0_MustBeDirectory={0} must be a directory.
 ErrorMessage_0_AlreadyExists={0} already exists.
+ErrorMessage_0_WorkspaceDirectory={0} is the workspace directory.
 
 Preference_Label_GradleUserHome=Gradle User Home
 Preference_Label_OfflineMode=Offline mode

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectImportWizardController.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/wizard/project/ProjectImportWizardController.java
@@ -65,7 +65,9 @@ public class ProjectImportWizardController {
 
     public ProjectImportWizardController(IWizard projectImportWizard) {
         // assemble configuration object that serves as the data model of the wizard
-        Validator<File> projectDirValidator = Validators.requiredDirectoryValidator(ProjectWizardMessages.Label_ProjectRootDirectory);
+        Validator<File> projectDirValidator = Validators.and(
+                Validators.requiredDirectoryValidator(ProjectWizardMessages.Label_ProjectRootDirectory),
+                Validators.nonWorkspaceFolderValidator(ProjectWizardMessages.Label_ProjectRootDirectory));
         Validator<GradleDistributionWrapper> gradleDistributionValidator = GradleDistributionValidator.gradleDistributionValidator();
         Validator<Boolean> applyWorkingSetsValidator = Validators.nullValidator();
         Validator<List<String>> workingSetsValidator = Validators.nullValidator();


### PR DESCRIPTION
The intent of this PR is to fix https://github.com/eclipse/buildship/issues/454 in two ways:
- Disallow importing and syncing projects with a subproject located at the workspace root
- Ensure that all project build directories has a non-null value.