### PR TITLE
Don't show error dialog when GradleConnectionException is received

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/ConnectionAwareLauncherProxy.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/ConnectionAwareLauncherProxy.java
@@ -10,6 +10,7 @@ package org.eclipse.buildship.core.workspace.internal;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.net.URL;
@@ -154,6 +155,12 @@ final class ConnectionAwareLauncherProxy implements InvocationHandler {
     private Object invokeRun(Method m) throws Throwable {
         try {
             return m.invoke(this.launcher);
+        } catch (InvocationTargetException e) {
+            if (e.getCause() != null) {
+                throw e.getCause();
+            } else {
+                throw e;
+            }
         } finally {
             closeConnection();
         }


### PR DESCRIPTION
The build launcher proxies used for executing builds produce
InvocationTargetException when a GradleConnectionException is
received from the TAPI. This exception is unknown to the
ToolingApiInvoker, therefore a general error dialog is displayed
for the user.

To make the exception handling behave correctly, this commit safely
unwraps and rethrows the root cause of the InvocationTargetException.