### PR TITLE
Suppress error dialog when model synchronization is cancelled

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultModelProvider.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultModelProvider.java
@@ -154,7 +154,6 @@ final class DefaultModelProvider implements ModelProvider {
             return result;
         } catch (Exception e) {
             if (e instanceof UncheckedExecutionException && e.getCause() instanceof RuntimeException) {
-                // don't expose the cache in the stacktrace when the model loading fails (e.g. upon cancellation)
                 throw (RuntimeException)e.getCause();
             } else {
                 throw new GradlePluginsRuntimeException(e);

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultModelProvider.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultModelProvider.java
@@ -135,13 +135,11 @@ final class DefaultModelProvider implements ModelProvider {
             this.cache.invalidate(cacheKey);
         }
 
-        final AtomicBoolean modelLoaded = new AtomicBoolean(false);
         T value = getFromCache(cacheKey, new Callable<T>() {
 
             @Override
             public T call() {
                 T model = operation.get();
-                modelLoaded.set(true);
                 return model;
             }
         });


### PR DESCRIPTION
When the user cancels a project synchronization, then he is presented with an error dialog. The root cause is the Guava cache we use for the model loading which throws a wrapper exception unknown by `ToolingApiInvoker`.  This pull request fixes the issue by unwrapping the exception and rethrowing the root cause. 