### PR TITLE
Further improvements on the Executions view performance

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/view/execution/ExecutionPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/view/execution/ExecutionPage.java
@@ -93,6 +93,7 @@ public final class ExecutionPage extends BasePage<FilteredTree> implements NodeS
         this.filteredTree.setShowFilterControls(false);
         this.filteredTree.getViewer().getTree().setHeaderVisible(true);
         this.filteredTree.getViewer().setContentProvider(new ExecutionPageContentProvider());
+        this.filteredTree.getViewer().setUseHashlookup(true);
 
         this.nameColumn = new TreeViewerColumn(this.filteredTree.getViewer(), SWT.NONE);
         this.nameColumn.getColumn().setText(ExecutionViewMessages.Tree_Column_Operation_Name_Text);

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/view/execution/ExecutionProgressListener.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/view/execution/ExecutionProgressListener.java
@@ -70,10 +70,10 @@ public final class ExecutionProgressListener implements org.gradle.tooling.event
         if (null == operationItem) {
             operationItem = new OperationItem((StartEvent) progressEvent);
             this.executionItemMap.put(descriptor, operationItem);
-            this.updateExecutionPageJob.addOperationItem(operationItem);
+            this.updateExecutionPageJob.startOperationItem(operationItem);
         } else {
             operationItem.setFinishEvent((FinishEvent) progressEvent);
-            this.updateExecutionPageJob.removeOperationItem(operationItem);
+            this.updateExecutionPageJob.stopOperationItem(operationItem);
             if (isJvmTestSuite(descriptor) && operationItem.getChildren().isEmpty()) {
                 // do not display test suite nodes that have no children (unwanted artifacts from Gradle)
                 OperationItem parentOperationItem = this.executionItemMap.get(findFirstNonExcludedParent(descriptor));


### PR DESCRIPTION
I did some final testing for the 2.1.0 release and found that the Executions view was still not performant enough for larger projects. I've added two changes to the implementation which drastically improves the situation. The details are in the individual commits' messages.

I think we should include these changes for the release to provide a smoother experience in the release.