### PR TITLE
Use correct project dir when executing tasks

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/configuration/internal/RunConfigurationTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/configuration/internal/RunConfigurationTest.groovy
@@ -1,10 +1,5 @@
 package org.eclipse.buildship.core.configuration.internal
 
-import java.io.File
-import java.util.List
-
-import spock.lang.Shared
-
 import com.gradleware.tooling.toolingclient.GradleDistribution
 
 import org.eclipse.debug.core.DebugPlugin
@@ -12,9 +7,7 @@ import org.eclipse.debug.core.ILaunchConfiguration
 import org.eclipse.debug.core.ILaunchConfigurationType
 import org.eclipse.debug.core.ILaunchManager
 
-import org.eclipse.buildship.core.CorePlugin
 import org.eclipse.buildship.core.configuration.BuildConfiguration
-import org.eclipse.buildship.core.configuration.ConfigurationManager
 import org.eclipse.buildship.core.configuration.RunConfiguration
 import org.eclipse.buildship.core.launch.GradleRunConfigurationAttributes
 import org.eclipse.buildship.core.launch.GradleRunConfigurationDelegate
@@ -65,15 +58,16 @@ class RunConfigurationTest extends ProjectSynchronizationSpecification {
         runConfig.showExecutionView == showExecutionView
         runConfig.buildScansEnabled == expectedRunConfigBuildScansEnabled
         runConfig.offlineMode == expectedRunConfigOfflineMode
-        runConfig.buildConfiguration.rootProjectDirectory == rootDir
-        runConfig.buildConfiguration.gradleDistribution == GradleDistribution.fromBuild()
-        runConfig.buildConfiguration.gradleUserHome == buildGradleUserHome
-        runConfig.buildConfiguration.overrideWorkspaceSettings == true
-        runConfig.buildConfiguration.buildScansEnabled == buildBuildScansEnabled
-        runConfig.buildConfiguration.offlineMode == buildOfflineMode
-        runConfig.buildConfiguration.workspaceConfiguration.gradleUserHome == null
-        runConfig.buildConfiguration.workspaceConfiguration.gradleIsOffline == false
-        runConfig.buildConfiguration.workspaceConfiguration.buildScansEnabled == false
+        runConfig.projectConfiguration.projectDir == rootDir
+        runConfig.projectConfiguration.buildConfiguration.rootProjectDirectory == rootDir
+        runConfig.projectConfiguration.buildConfiguration.gradleDistribution == GradleDistribution.fromBuild()
+        runConfig.projectConfiguration.buildConfiguration.gradleUserHome == buildGradleUserHome
+        runConfig.projectConfiguration.buildConfiguration.overrideWorkspaceSettings == true
+        runConfig.projectConfiguration.buildConfiguration.buildScansEnabled == buildBuildScansEnabled
+        runConfig.projectConfiguration.buildConfiguration.offlineMode == buildOfflineMode
+        runConfig.projectConfiguration.buildConfiguration.workspaceConfiguration.gradleUserHome == null
+        runConfig.projectConfiguration.buildConfiguration.workspaceConfiguration.gradleIsOffline == false
+        runConfig.projectConfiguration.buildConfiguration.workspaceConfiguration.buildScansEnabled == false
 
         where:
         buildBuildScansEnabled | buildOfflineMode | runConfigOverride | runConfigBuildScansEnabled | runConfigOfflineMode | expectedRunConfigBuildScansEnabled | expectedRunConfigOfflineMode
@@ -95,14 +89,15 @@ class RunConfigurationTest extends ProjectSynchronizationSpecification {
         runConfig.jvmArguments == []
         runConfig.showExecutionView == true
         runConfig.showConsoleView == true
-        runConfig.buildConfiguration.rootProjectDirectory.path == new File('').canonicalPath
-        runConfig.buildConfiguration.gradleDistribution == GradleDistribution.fromBuild()
-        runConfig.buildConfiguration.overrideWorkspaceSettings == false
-        runConfig.buildConfiguration.buildScansEnabled == false
-        runConfig.buildConfiguration.offlineMode == false
-        runConfig.buildConfiguration.workspaceConfiguration.gradleUserHome == null
-        runConfig.buildConfiguration.workspaceConfiguration.gradleIsOffline == false
-        runConfig.buildConfiguration.workspaceConfiguration.buildScansEnabled == false
+        runConfig.projectConfiguration.projectDir.path == new File('').canonicalPath
+        runConfig.projectConfiguration.buildConfiguration.rootProjectDirectory.path == new File('').canonicalPath
+        runConfig.projectConfiguration.buildConfiguration.gradleDistribution == GradleDistribution.fromBuild()
+        runConfig.projectConfiguration.buildConfiguration.overrideWorkspaceSettings == false
+        runConfig.projectConfiguration.buildConfiguration.buildScansEnabled == false
+        runConfig.projectConfiguration.buildConfiguration.offlineMode == false
+        runConfig.projectConfiguration.buildConfiguration.workspaceConfiguration.gradleUserHome == null
+        runConfig.projectConfiguration.buildConfiguration.workspaceConfiguration.gradleIsOffline == false
+        runConfig.projectConfiguration.buildConfiguration.workspaceConfiguration.buildScansEnabled == false
     }
 
     def "load custom settings"() {
@@ -142,14 +137,15 @@ class RunConfigurationTest extends ProjectSynchronizationSpecification {
         runConfig.jvmArguments == jvmArguments
         runConfig.showConsoleView == showConsoleView
         runConfig.showExecutionView == showExecutionView
-        runConfig.buildConfiguration.rootProjectDirectory == rootDir
-        runConfig.buildConfiguration.gradleDistribution == distribution
-        runConfig.buildConfiguration.overrideWorkspaceSettings == overrideBuildSettings
-        runConfig.buildConfiguration.buildScansEnabled == buildScansEnabled
-        runConfig.buildConfiguration.offlineMode == offlineMode
-        runConfig.buildConfiguration.workspaceConfiguration.gradleUserHome == null
-        runConfig.buildConfiguration.workspaceConfiguration.gradleIsOffline == false
-        runConfig.buildConfiguration.workspaceConfiguration.buildScansEnabled == false
+        runConfig.projectConfiguration.projectDir == rootDir
+        runConfig.projectConfiguration.buildConfiguration.rootProjectDirectory == rootDir
+        runConfig.projectConfiguration.buildConfiguration.gradleDistribution == distribution
+        runConfig.projectConfiguration.buildConfiguration.overrideWorkspaceSettings == overrideBuildSettings
+        runConfig.projectConfiguration.buildConfiguration.buildScansEnabled == buildScansEnabled
+        runConfig.projectConfiguration.buildConfiguration.offlineMode == offlineMode
+        runConfig.projectConfiguration.buildConfiguration.workspaceConfiguration.gradleUserHome == null
+        runConfig.projectConfiguration.buildConfiguration.workspaceConfiguration.gradleIsOffline == false
+        runConfig.projectConfiguration.buildConfiguration.workspaceConfiguration.buildScansEnabled == false
     }
 
     private ILaunchConfiguration emptyLaunchConfig() {

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/launch/RunGradleTestLaunchRequestJobComplexTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/launch/RunGradleTestLaunchRequestJobComplexTest.groovy
@@ -103,17 +103,17 @@ class RunGradleTestLaunchRequestJobComplexTest extends ProjectSynchronizationSpe
     private def executeCleanTestAndWait(RunConfiguration runConfig) {
         GradleRunConfigurationAttributes attributes = new GradleRunConfigurationAttributes(
             runConfig.tasks,
-            runConfig.buildConfiguration.rootProjectDirectory.absolutePath,
-            GradleDistributionSerializer.INSTANCE.serializeToString(runConfig.buildConfiguration.gradleDistribution),
+            runConfig.projectConfiguration.buildConfiguration.rootProjectDirectory.absolutePath,
+            GradleDistributionSerializer.INSTANCE.serializeToString(runConfig.projectConfiguration.buildConfiguration.gradleDistribution),
             runConfig.gradleUserHome,
             runConfig.javaHome,
             runConfig.jvmArguments,
             runConfig.arguments,
             runConfig.showExecutionView,
             runConfig.showConsoleView,
-            runConfig.buildConfiguration.overrideWorkspaceSettings,
-            runConfig.buildConfiguration.offlineMode,
-            runConfig.buildConfiguration.buildScansEnabled)
+            runConfig.projectConfiguration.buildConfiguration.overrideWorkspaceSettings,
+            runConfig.projectConfiguration.buildConfiguration.offlineMode,
+            runConfig.projectConfiguration.buildConfiguration.buildScansEnabled)
         ILaunch launch = Mock()
         launch.getLaunchConfiguration() >> CorePlugin.gradleLaunchConfigurationManager().getOrCreateRunConfiguration(attributes)
         RunGradleBuildLaunchRequestJob job = new RunGradleBuildLaunchRequestJob(launch)

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/configuration/RunConfiguration.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/configuration/RunConfiguration.java
@@ -20,7 +20,7 @@ import com.gradleware.tooling.toolingclient.GradleDistribution;
  */
 public interface RunConfiguration {
 
-    BuildConfiguration getBuildConfiguration();
+    ProjectConfiguration getProjectConfiguration();
 
     List<String> getTasks();
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/configuration/internal/DefaultRunConfiguration.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/configuration/internal/DefaultRunConfiguration.java
@@ -15,27 +15,26 @@ import com.google.common.base.Objects;
 
 import com.gradleware.tooling.toolingclient.GradleDistribution;
 
-import org.eclipse.buildship.core.configuration.BuildConfiguration;
 import org.eclipse.buildship.core.configuration.GradleArguments;
+import org.eclipse.buildship.core.configuration.ProjectConfiguration;
 import org.eclipse.buildship.core.configuration.RunConfiguration;
-import org.eclipse.buildship.core.configuration.WorkspaceConfiguration;
 
 /**
  * Default implementation for {@link RunConfiguration}.
  */
 public class DefaultRunConfiguration implements RunConfiguration {
 
-    private final BuildConfiguration buildConfiguration;
+    private final ProjectConfiguration projectConfiguration;
     private final RunConfigurationProperties properties;
 
-    public DefaultRunConfiguration(WorkspaceConfiguration workspaceConfiguration, DefaultBuildConfigurationProperties buildProperties, RunConfigurationProperties properties) {
-        this.buildConfiguration = new DefaultBuildConfiguration(buildProperties, workspaceConfiguration);
+    public DefaultRunConfiguration(ProjectConfiguration projectConfiguration, RunConfigurationProperties properties) {
+        this.projectConfiguration = projectConfiguration;
         this.properties = properties;
     }
 
     @Override
-    public BuildConfiguration getBuildConfiguration() {
-        return this.buildConfiguration;
+    public ProjectConfiguration getProjectConfiguration() {
+        return this.projectConfiguration;
     }
 
     @Override
@@ -48,7 +47,7 @@ public class DefaultRunConfiguration implements RunConfiguration {
         if (this.properties.isOverrideBuildSettings()) {
             return this.properties.getGradleDistribution();
         } else {
-            return this.buildConfiguration.getGradleDistribution();
+            return this.projectConfiguration.getBuildConfiguration().getGradleDistribution();
         }
     }
 
@@ -57,7 +56,7 @@ public class DefaultRunConfiguration implements RunConfiguration {
         if (this.properties.isOverrideBuildSettings()) {
             return this.properties.getGradleUserHome();
         } else {
-            return this.buildConfiguration.getGradleUserHome();
+            return this.projectConfiguration.getBuildConfiguration().getGradleUserHome();
         }
     }
 
@@ -80,7 +79,7 @@ public class DefaultRunConfiguration implements RunConfiguration {
         if (this.properties.isOverrideBuildSettings()) {
             return this.properties.isBuildScansEnabled();
         } else {
-            return this.buildConfiguration.isBuildScansEnabled();
+            return this.projectConfiguration.getBuildConfiguration().isBuildScansEnabled();
         }
     }
 
@@ -88,7 +87,7 @@ public class DefaultRunConfiguration implements RunConfiguration {
         if (this.properties.isOverrideBuildSettings()) {
             return this.properties.isOfflineMode();
         } else {
-            return this.buildConfiguration.isOfflineMode();
+            return this.projectConfiguration.getBuildConfiguration().isOfflineMode();
         }
     }
 
@@ -106,7 +105,7 @@ public class DefaultRunConfiguration implements RunConfiguration {
     public boolean equals(Object obj) {
         if (obj instanceof DefaultRunConfiguration) {
             DefaultRunConfiguration other = (DefaultRunConfiguration) obj;
-            return Objects.equal(this.buildConfiguration, other.buildConfiguration)
+            return Objects.equal(this.projectConfiguration, other.projectConfiguration)
                     && Objects.equal(this.properties, other.properties);
         }
         return false;
@@ -114,12 +113,12 @@ public class DefaultRunConfiguration implements RunConfiguration {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.buildConfiguration, this.properties);
+        return Objects.hashCode(this.projectConfiguration, this.properties);
     }
 
     @Override
     public GradleArguments toGradleArguments() {
-        return GradleArguments.from(getBuildConfiguration().getRootProjectDirectory(),
+        return GradleArguments.from(getProjectConfiguration().getProjectDir(),
             getGradleDistribution(),
             getGradleUserHome(),
             getJavaHome(),

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/BaseLaunchRequestJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/BaseLaunchRequestJob.java
@@ -69,7 +69,7 @@ public abstract class BaseLaunchRequestJob<T extends LongRunningOperation> exten
         // TODO (donat) configWriter and TransientRequestAttributes should be merged into a new type
         OutputStreamWriter configWriter = new OutputStreamWriter(processStreams.getConfiguration());
 
-        GradleBuild gradleBuild = CorePlugin.gradleWorkspaceManager().getGradleBuild(runConfig.getBuildConfiguration());
+        GradleBuild gradleBuild = CorePlugin.gradleWorkspaceManager().getGradleBuild(runConfig.getProjectConfiguration().getBuildConfiguration());
         T launcher = createLaunch(gradleBuild, runConfig, transientAttributes, configWriter, processDescription);
 
         writeExtraConfigInfo(configWriter);

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleBuildLaunchRequestJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleBuildLaunchRequestJob.java
@@ -65,7 +65,7 @@ public final class RunGradleBuildLaunchRequestJob extends BaseLaunchRequestJob<B
 
     @Override
     protected ProcessDescription createProcessDescription() {
-        String processName = createProcessName(this.runConfig.getTasks(), this.runConfig.getBuildConfiguration().getRootProjectDirectory(), this.launch.getLaunchConfiguration().getName());
+        String processName = createProcessName(this.runConfig.getTasks(), this.runConfig.getProjectConfiguration().getProjectDir(), this.launch.getLaunchConfiguration().getName());
         return new BuildLaunchProcessDescription(processName);
     }
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleJvmTestLaunchRequestJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleJvmTestLaunchRequestJob.java
@@ -61,7 +61,7 @@ public final class RunGradleJvmTestLaunchRequestJob extends BaseLaunchRequestJob
 
     @Override
     protected ProcessDescription createProcessDescription() {
-        String processName = createProcessName(this.runConfig.getBuildConfiguration().getRootProjectDirectory());
+        String processName = createProcessName(this.runConfig.getProjectConfiguration().getProjectDir());
         return new TestLaunchProcessDescription(processName);
     }
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleTestLaunchRequestJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/RunGradleTestLaunchRequestJob.java
@@ -66,7 +66,7 @@ public final class RunGradleTestLaunchRequestJob extends BaseLaunchRequestJob<Te
 
     @Override
     protected ProcessDescription createProcessDescription() {
-        String processName = createProcessName(this.runConfig.getBuildConfiguration().getRootProjectDirectory());
+        String processName = createProcessName(this.runConfig.getProjectConfiguration().getProjectDir());
         return new TestLaunchProcessDescription(processName);
     }
 

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/ExecutionsViewPerformanceTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/ExecutionsViewPerformanceTest.groovy
@@ -67,10 +67,6 @@ class ExecutionsViewPerformanceTest extends ProjectSynchronizationSpecification 
         type.newInstance(null, "launch-config-name")
     }
 
-    private void runOnUiThread(Closure closure) {
-        PlatformUI.workbench.display.syncExec closure as Runnable
-    }
-
     private ProgressEvent progressEvent() {
         ProgressEvent event = Mock(StartEvent)
         event.displayName >> 'progress event display name'

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/OpenBuildScanActionTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/OpenBuildScanActionTest.groovy
@@ -8,7 +8,6 @@ import org.eclipse.debug.core.ILaunchConfigurationType
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy
 import org.eclipse.debug.core.ILaunchManager
 import org.eclipse.ui.IWorkbenchPage
-import org.eclipse.ui.PlatformUI
 import org.eclipse.ui.console.ConsolePlugin
 import org.eclipse.ui.console.IConsole
 import org.eclipse.ui.console.IConsoleListener
@@ -31,7 +30,6 @@ class OpenBuildScanActionTest extends ProjectSynchronizationSpecification {
     }
 
     void cleanup() {
-        runOnUiThread { view.removeAllPages() }
         ConsolePlugin.default.consoleManager.removeConsoleListener(consoleListener)
     }
 
@@ -147,21 +145,6 @@ class OpenBuildScanActionTest extends ProjectSynchronizationSpecification {
 
     private void waitForPendingConsoleOutput() {
         waitFor { consoleListener.activeConsole.partitioner.pendingPartitions.empty }
-    }
-
-    private void waitFor(int timeout = 5000, Closure condition) {
-        long start = System.currentTimeMillis()
-        while (!condition.call()) {
-            long elapsed = System.currentTimeMillis() - start
-            if (elapsed > timeout) {
-                throw new RuntimeException('timeout')
-            }
-            Thread.sleep(100)
-        }
-    }
-
-    private void runOnUiThread(Closure closure) {
-        PlatformUI.workbench.display.syncExec closure as Runnable
     }
 
     private ILaunch createLaunch(String task, File rootDir, List<String> arguments) {

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/task/TaskExecutionTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/task/TaskExecutionTest.groovy
@@ -1,0 +1,167 @@
+package org.eclipse.buildship.ui.view.task
+
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem
+import org.eclipse.ui.IWorkbenchPage
+import org.eclipse.ui.console.ConsolePlugin
+import org.eclipse.ui.console.IConsole
+import org.eclipse.ui.console.IConsoleConstants
+import org.eclipse.ui.console.IConsoleListener
+import org.eclipse.ui.console.IConsoleManager
+
+import org.eclipse.buildship.ui.console.GradleConsole
+import org.eclipse.buildship.ui.test.fixtures.SwtBotSpecification
+import org.eclipse.buildship.ui.util.workbench.WorkbenchUtils
+
+class TaskExecutionTest extends SwtBotSpecification {
+
+    ConsoleListener consoleListener
+
+    TaskView view
+    SWTBotTree tree
+
+    boolean originalProjectTasksVisible
+    boolean originalTaskSelectorsVisible
+
+    def setup() {
+        runOnUiThread {
+            view = WorkbenchUtils.showView(TaskView.ID, null, IWorkbenchPage.VIEW_ACTIVATE)
+            tree = new SWTBotTree(view.treeViewer.tree)
+
+            originalProjectTasksVisible = view.state.projectTasksVisible
+            originalTaskSelectorsVisible = view.state.taskSelectorsVisible
+            view.state.projectTasksVisible = true
+            view.state.taskSelectorsVisible = true
+
+            WorkbenchUtils.showView(IConsoleConstants.ID_CONSOLE_VIEW, null, IWorkbenchPage.VIEW_ACTIVATE)
+            ConsolePlugin.default.consoleManager.addConsoleListener(consoleListener = new ConsoleListener())
+        }
+        waitForTaskView()
+    }
+
+    def cleanup() {
+        view.state.projectTasksVisible = originalProjectTasksVisible
+        view.state.taskSelectorsVisible = originalTaskSelectorsVisible
+
+        ConsolePlugin.default.consoleManager.removeConsoleListener(consoleListener)
+        removeCloseableGradleConsoles()
+    }
+
+    def "Project task executes task on target project only"() {
+        setup:
+        def project = sampleProject()
+        importAndWait(project)
+
+        when:
+        bot.viewByTitle('Gradle Tasks').show()
+        tree.setFocus()
+        SWTBotTreeItem groupNode = tree.expandNode('sub', 'custom')
+
+        then:
+        groupNode.items.size() == 2
+
+        when:
+        groupNode.items[0].select()
+        groupNode.items[0].doubleClick()
+
+        waitForConsoleOutput()
+        String consoleOutput = consoleListener.activeConsole.document.get()
+
+        then:
+        consoleOutput.contains("Working Directory: ${project.canonicalPath}${File.separator}sub")
+        !consoleOutput.contains("Running task on project root")
+        consoleOutput.contains("Running task on project sub")
+        !consoleOutput.contains("Running task on project ss1")
+        !consoleOutput.contains("Running task on project ss2")
+    }
+
+    def "Task selector executes task on target project and on all subprojects"() {
+        setup:
+        def project = sampleProject()
+        importAndWait(project)
+
+        when:
+        bot.viewByTitle('Gradle Tasks').show()
+        tree.setFocus()
+        SWTBotTreeItem groupNode = tree.expandNode('sub', 'custom')
+
+        then:
+        groupNode.items.size() == 2
+
+        when:
+        groupNode.items[1].select()
+        groupNode.items[1].doubleClick()
+
+        waitForConsoleOutput()
+        String consoleOutput = consoleListener.activeConsole.document.get()
+
+        then:
+        consoleOutput.contains("Working Directory: ${project.canonicalPath}${File.separator}sub")
+        !consoleOutput.contains("Running task on project root")
+        consoleOutput.contains("Running task on project sub")
+        consoleOutput.contains("Running task on project ss1")
+        consoleOutput.contains("Running task on project ss2")
+    }
+
+    private File sampleProject() {
+        dir("root") {
+            file 'settings.gradle', """
+                include 'sub', 'sub:ss1', 'sub:ss2'
+            """
+
+            file 'build.gradle', """
+                allprojects {
+                    task foo() {
+                        group = 'custom'
+
+                        doLast {
+                            println "Running task on project \$project.name"
+                        }
+                    }
+                }
+            """
+
+            dir ('sub') {
+                dir('ss1')
+                dir('ss2')
+            }
+        }
+    }
+
+    /*
+     * The task view is refreshed whenever a project is added/removed.
+     * So first we need to wait for this addition/removal event.
+     * The task view starts a synchronization job to get the latest model and that job then synchronously updates the view.
+     * We need to wait for that job to finish before the task view is guaranteed to be up-to-date.
+     */
+    private waitForTaskView() {
+        waitForResourceChangeEvents()
+        waitForGradleJobsToFinish()
+    }
+
+    private void waitForConsoleOutput() {
+        waitFor {
+            GradleConsole console = consoleListener.activeConsole
+            console != null && console.isCloseable() && console.isTerminated() && console.partitioner.pendingPartitions.empty
+        }
+    }
+
+    public void removeCloseableGradleConsoles() {
+        IConsoleManager consoleManager = ConsolePlugin.default.consoleManager
+        List<GradleConsole> gradleConsoles = consoleManager.consoles.findAll { console -> console instanceof GradleConsole && console.isCloseable() }
+        consoleManager.removeConsoles(gradleConsoles as IConsole[])
+    }
+
+    class ConsoleListener implements IConsoleListener {
+        GradleConsole activeConsole
+
+        @Override
+        public void consolesAdded(IConsole[] consoles) {
+            activeConsole = consoles[0]
+        }
+
+        @Override
+        public void consolesRemoved(IConsole[] consoles) {
+        }
+    }
+}

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/task/TaskViewContentSpec.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/task/TaskViewContentSpec.groovy
@@ -32,7 +32,7 @@ class TaskViewContentSpec extends ProjectSynchronizationSpecification {
     TreeViewer tree
 
     void setup() {
-        PlatformUI.workbench.display.syncExec {
+        runOnUiThread {
             view = WorkbenchUtils.showView(TaskView.ID, null, IWorkbenchPage.VIEW_ACTIVATE)
             tree = view.treeViewer
         }
@@ -154,7 +154,7 @@ class TaskViewContentSpec extends ProjectSynchronizationSpecification {
 
     private def getTaskTree() {
         def taskTree
-        PlatformUI.workbench.display.syncExec {
+        runOnUiThread {
             tree.expandAll()
             def root = tree.tree
             taskTree = getChildren(root)

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/view/execution/OpenTestSourceFileJob.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/view/execution/OpenTestSourceFileJob.java
@@ -157,7 +157,7 @@ public final class OpenTestSourceFileJob extends ToolingApiWorkspaceJob {
     }
 
     private List<IProject> findProjectContainingTest(Path projectPath, IProgressMonitor monitor) {
-        File workingDir = this.runConfig.getBuildConfiguration().getRootProjectDirectory();
+        File workingDir = this.runConfig.getProjectConfiguration().getProjectDir();
         Optional<IProject> project = CorePlugin.workspaceOperations().findProjectByLocation(workingDir);
         if (!project.isPresent()) {
             return Collections.emptyList();


### PR DESCRIPTION
This commit fixes a regression introduced in Buildship 2.1. The
new preferences API ignored the project location and always
executed all tasks on the root project. As a result, task selectors
were always executed on all projects, even if they were started from
a subproject.

The fix changes the RunConfiguration interface such that it references
a project config as opposed to a build configuration.

This commit fixes https://github.com/eclipse/buildship/issues/520