### PR TITLE
Project configuration can read absolute root project locations again

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/configuration/internal/ProjectConfigurationTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/configuration/internal/ProjectConfigurationTest.groovy
@@ -1,5 +1,7 @@
 package org.eclipse.buildship.core.configuration.internal
 
+import spock.lang.Issue
+
 import com.gradleware.tooling.toolingclient.GradleDistribution
 
 import org.eclipse.core.resources.IProject
@@ -235,6 +237,43 @@ class ProjectConfigurationTest extends ProjectSynchronizationSpecification {
 
         then:
         thrown RuntimeException
+    }
+
+    @Issue('https://github.com/eclipse/buildship/issues/528')
+    def "can save and load project configuration if settings file contains absolute path"() {
+        setup:
+        configurationManager.buildConfigurationPersistence.savePathToRoot(project, rootProjectDir.absolutePath)
+
+        when:
+        ProjectConfiguration projectConfig = configurationManager.loadProjectConfiguration(project)
+
+        then:
+        projectConfig.buildConfiguration.rootProjectDirectory == rootProjectDir
+
+        when:
+        configurationManager.saveProjectConfiguration(projectConfig)
+
+        then:
+        configurationManager.buildConfigurationPersistence.readPathToRoot(project) == "../$rootProjectDir.name"
+    }
+
+    @Issue('https://github.com/eclipse/buildship/issues/528')
+    def "can save and load project configuration if project is clased and settings file contains absolute path"() {
+        setup:
+        project.close(new NullProgressMonitor())
+        configurationManager.buildConfigurationPersistence.savePathToRoot(projectDir, rootProjectDir.absolutePath)
+
+        when:
+        ProjectConfiguration projectConfig = configurationManager.loadProjectConfiguration(projectDir)
+
+        then:
+        projectConfig.buildConfiguration.rootProjectDirectory == rootProjectDir
+
+        when:
+        configurationManager.saveProjectConfiguration(projectConfig)
+
+        then:
+        configurationManager.buildConfigurationPersistence.readPathToRoot(projectDir) == "../$rootProjectDir.name"
     }
 
     private void setInvalidPreferenceOn(IProject project) {

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/configuration/internal/ProjectConfigurationTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/configuration/internal/ProjectConfigurationTest.groovy
@@ -258,7 +258,7 @@ class ProjectConfigurationTest extends ProjectSynchronizationSpecification {
     }
 
     @Issue('https://github.com/eclipse/buildship/issues/528')
-    def "can save and load project configuration if project is clased and settings file contains absolute path"() {
+    def "can save and load project configuration if project is closed and settings file contains absolute path"() {
         setup:
         project.close(new NullProgressMonitor())
         configurationManager.buildConfigurationPersistence.savePathToRoot(projectDir, rootProjectDir.absolutePath)

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/configuration/internal/DefaultConfigurationManager.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/configuration/internal/DefaultConfigurationManager.java
@@ -210,7 +210,8 @@ public class DefaultConfigurationManager implements ConfigurationManager {
 
     private static File relativePathToProjectRoot(IPath projectPath, String path) {
         IPath pathToRoot = new Path(path);
-        return canonicalize(RelativePathUtils.getAbsolutePath(projectPath, pathToRoot).toFile());
+        IPath absolutePathToRoot = pathToRoot.isAbsolute() ? pathToRoot : RelativePathUtils.getAbsolutePath(projectPath, pathToRoot);
+        return canonicalize(absolutePathToRoot.toFile());
     }
 
     private static File canonicalize(File file) {


### PR DESCRIPTION
Until 2.1 Buildship accepted absolute root project location in the
import preferences.