### PR TITLE
#514 and #560

### DIFF
--- a/org.eclipse.buildship.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.ui/META-INF/MANIFEST.MF
@@ -22,6 +22,7 @@ Require-Bundle: org.eclipse.buildship.core,
  org.eclipse.jface.text,
  com.ibm.icu,
  com.google.guava,
+ org.eclipse.ui.genericeditor,
  com.gradleware.tooling.model;bundle-version="[0.19.2,0.20.0)",
  com.gradleware.tooling.client;bundle-version="[0.19.2,0.20.0)",
  com.gradleware.tooling.utils;bundle-version="[0.19.2,0.20.0)"

--- a/org.eclipse.buildship.ui/plugin.xml
+++ b/org.eclipse.buildship.ui/plugin.xml
@@ -65,12 +65,13 @@
     <extension
             point="org.eclipse.ui.editors">
       <editor
-            id="org.eclipse.buildship.ui.gradlebuildscripteditor"
-            class="org.eclipse.ui.editors.text.TextEditor"
-            icon="icons/full/obj16/gradle_file.png"
-            name="Gradle Build Script Editor"
+            class="org.eclipse.ui.internal.genericeditor.ExtensionBasedTextEditor"
+            contributorClass="org.eclipse.buildship.ui.editor.GradleEditorContributor"
             default="false"
-            extensions="gradle">
+            extensions="gradle"
+            icon="icons/full/obj16/gradle_file.png"
+            id="org.eclipse.buildship.ui.gradlebuildscripteditor"
+            name="Gradle Build Script Editor">
       </editor>
     </extension>
 
@@ -534,6 +535,12 @@
              id="org.eclipse.buildship.ui.preferences"
              name="Gradle">
        </page>
+       <page
+             category="org.eclipse.buildship.ui.preferences"
+             class="org.eclipse.buildship.ui.preferences.GradleEditorPreferencePage"
+             id="org.eclipse.buildship.ui.preferences.GradleEditorPreferencePage"
+             name="Editor">
+       </page>
     </extension>
 
     <!-- Add the "Gradle" menu to the project preferences -->
@@ -549,5 +556,18 @@
            </adapt>
          </enabledWhen>
        </page>
+    </extension>
+    <extension
+          point="org.eclipse.core.runtime.preferences">
+       <initializer
+             class="org.eclipse.buildship.ui.preferences.GradleEditorPreferenceInitializer">
+       </initializer>
+    </extension>
+    <extension
+          point="org.eclipse.ui.genericeditor.presentationReconcilers">
+       <presentationReconciler
+             class="org.eclipse.buildship.ui.editor.GradlePresentationReconciler"
+             contentType="org.eclipse.jdt.groovy.core.gradleScript">
+       </presentationReconciler>
     </extension>
 </plugin>

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/PluginImages.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/PluginImages.java
@@ -14,16 +14,15 @@ package org.eclipse.buildship.ui;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.base.Function;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
+import org.eclipse.buildship.ui.util.image.ImageUtils;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
 import org.eclipse.swt.graphics.Image;
 
-import org.eclipse.buildship.ui.util.image.ImageUtils;
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 /**
  * Enumerates all the images used in this plugin. Uses the {@link ImageRegistry} provided by the
@@ -64,7 +63,8 @@ public enum PluginImages implements PluginImage {
     PROJECT(ImmutableMap.of(ImageState.ENABLED, "icons/full/obj16/project.png")),
     JAVA_PROJECT(ImmutableMap.of(ImageState.ENABLED, "icons/full/obj16/java_project.png")),
     FAULTY_PROJECT(ImmutableMap.of(ImageState.ENABLED, "icons/full/obj16/faulty_project.png")),
-    BUILD_SCAN(ImmutableMap.of(ImageState.ENABLED, "icons/full/obj16/build_scan.png", ImageState.DISABLED, "icons/full/obj16/build_scan_disabled.png"));
+    BUILD_SCAN(ImmutableMap.of(ImageState.ENABLED, "icons/full/obj16/build_scan.png", ImageState.DISABLED, "icons/full/obj16/build_scan_disabled.png")),
+	GRADLE_FILE(ImmutableMap.of(ImageState.ENABLED, "icons/full/obj16/gradle_file.png"));
     // @formatter:on
 
     private final ImmutableMap<ImageState, String> images;

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/editor/GradleEditorContributor.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/editor/GradleEditorContributor.java
@@ -1,0 +1,29 @@
+package org.eclipse.buildship.ui.editor;
+
+import org.eclipse.buildship.ui.PluginImage;
+import org.eclipse.buildship.ui.PluginImages;
+import org.eclipse.buildship.ui.UiPlugin;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IToolBarManager;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.ui.handlers.IHandlerService;
+import org.eclipse.ui.part.EditorActionBarContributor;
+
+public class GradleEditorContributor extends EditorActionBarContributor {
+	private static final String REFRESHPROJECT_COMMAND_ID = "org.eclipse.buildship.ui.commands.refreshproject";
+
+	@Override
+	public void contributeToToolBar(IToolBarManager toolBarManager) {
+		toolBarManager.add(new Action("Refresh Gradle Project", PluginImages.REFRESH.withState(PluginImage.ImageState.ENABLED).getImageDescriptor()) {
+			@Override
+			public void runWithEvent(Event event) {
+				IHandlerService service=getActionBars().getServiceLocator().getService(IHandlerService.class);
+				try {
+					service.executeCommand(REFRESHPROJECT_COMMAND_ID, event);
+				} catch (Exception e) {
+					UiPlugin.logger().error("Failed to invoke command "+REFRESHPROJECT_COMMAND_ID, e);
+				}
+			}
+		});
+	}
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/editor/GradlePresentationReconciler.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/editor/GradlePresentationReconciler.java
@@ -1,0 +1,167 @@
+package org.eclipse.buildship.ui.editor;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.buildship.ui.UiPlugin;
+import org.eclipse.buildship.ui.editor.highlight.EditorColors;
+import org.eclipse.buildship.ui.preferences.GradleEditorConstants;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.TextAttribute;
+import org.eclipse.jface.text.presentation.PresentationReconciler;
+import org.eclipse.jface.text.rules.DefaultDamagerRepairer;
+import org.eclipse.jface.text.rules.EndOfLineRule;
+import org.eclipse.jface.text.rules.IRule;
+import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.IWhitespaceDetector;
+import org.eclipse.jface.text.rules.IWordDetector;
+import org.eclipse.jface.text.rules.MultiLineRule;
+import org.eclipse.jface.text.rules.NumberRule;
+import org.eclipse.jface.text.rules.RuleBasedScanner;
+import org.eclipse.jface.text.rules.SingleLineRule;
+import org.eclipse.jface.text.rules.Token;
+import org.eclipse.jface.text.rules.WhitespaceRule;
+import org.eclipse.jface.text.rules.WordRule;
+import org.eclipse.swt.SWT;
+
+public class GradlePresentationReconciler extends PresentationReconciler {
+	private static final List<String> GRADLE_IDENTIFIERS=Arrays.asList(
+			// Java keywords
+	        "assert",
+	        "if", "else",
+	        "void", "null",
+	        "new", "return",
+	        "try", "catch", 
+	        
+	        // Groovy stuff
+	        "def", 
+
+			// Gradle DSL http://gradle.org/docs/current/dsl/ {
+	        // Build script blocks
+			//        allprojects { }
+			//        artifacts { }
+			//        buildscript { }
+			//        configurations { }
+			//        dependencies { }
+			//        repositories { }
+			//        sourceSets { }
+			//        subprojects { }
+			//        publishing { }
+	        "allprojects", "artifacts", "buildscript", "configurations",
+	        "dependencies", "repositories", "sourceSets", "subprojects", "publishing",
+	        //?
+			"task", "apply", "sourceCompatibility", "targetCompatibility",
+	        "test",
+//	        "version","group", "name",
+	        
+	        "project",
+	        "ext", 
+	        "plugins", //since 2.1
+	        //}
+	        
+	        // apply plugin: 'java'
+	        // apply plugin: 'com.github.johnrengelman.shadow'
+	        "jar", "shadowJar", 
+	        
+	        // Android plugin
+//	        defaultConfig {v}	
+//	        The default configuration, inherited by all build flavors (if any are defined).
+//	        sourceSets {v}	
+//	        Configures the source sets. Note that the Android plugin uses its own implementation of source sets, AndroidSourceSet.
+//	        buildTypes {v}	
+//	        Configures the build types.
+//	        signingConfigs {v}	
+//	        Configures the signing configs.
+//	        productFlavors {v}	
+//	        Configures the product flavors.
+//	        testOptions {v}	
+//	        Configures the test options.
+//	        aaptOptions {v}	
+//	        Configures aapt options.
+//	        lintOptions {v}	
+//	        Configure lint options.
+//	        dexOptions {v}	
+//	        Configures dex options.
+//	        compileOptions {v}	
+//	        Configures compile options.
+//	        packagingOptions {v}	
+//	        Configures packaging options.
+//	        jacoco {v}	
+//	        Configures JaCoCo options.
+//	        splits {v}	
+//	        Configures APK splits.        
+	        "android", "compileOptions", 
+	        "compileSdkVersion", "buildToolsVersion",//
+	        "sourceSets", "main", "manifest",//
+	        "srcFile", "srcDirs", "setRoot",//
+	        "defaultConfig", "signingConfigs", "buildTypes",//
+	        "productFlavors", "debug", "release",//
+	        "lintOptions", "packagingOptions",
+	        "aaptOptions", "dexOptions", "adbOptions",
+	        "testOptions",
+	        "jacoco", "splits"	
+	);
+
+	private final TextAttribute commentAttribute = new TextAttribute(EditorColors.getColor(GradleEditorConstants.KEY_COLOR_COMMENT), null, SWT.NORMAL);
+	private final TextAttribute docAttribute = new TextAttribute(EditorColors.getColor(GradleEditorConstants.KEY_COLOR_DOC), null, SWT.NORMAL);
+	private final TextAttribute keywordAttribute = new TextAttribute(EditorColors.getColor(GradleEditorConstants.KEY_COLOR_KEYWORD), null, 
+			UiPlugin.getInstance().getPreferenceStore().getBoolean(GradleEditorConstants.KEY_BOLD_KEYWORD) ? SWT.BOLD : SWT.NORMAL);
+	private final TextAttribute stringAttribute = new TextAttribute(EditorColors.getColor(GradleEditorConstants.KEY_COLOR_STRING), null, SWT.NORMAL);
+	private final TextAttribute numberAttribute = new TextAttribute(EditorColors.getColor(GradleEditorConstants.KEY_COLOR_NUMBER), null, SWT.NORMAL);
+	private final TextAttribute normalAttribute = new TextAttribute(EditorColors.getColor(GradleEditorConstants.KEY_COLOR_NORMAL), null, SWT.NORMAL);
+
+	private final IToken keywordToken = new Token(keywordAttribute);
+	private final IToken docToken = new Token(docAttribute);
+	private final IToken quoteToken = new Token(stringAttribute);
+	private final IToken numberToken = new Token(numberAttribute);
+	private final IToken commentToken = new Token(commentAttribute);
+	private final IToken normalToken = new Token(normalAttribute);
+
+	public GradlePresentationReconciler() {
+		RuleBasedScanner scanner = new RuleBasedScanner();
+		scanner.setRules(new IRule[] {
+				new EndOfLineRule("//", commentToken),//$NON-NLS-2$
+				new KeywordRule(keywordToken),
+				new MultiLineRule("/**", "*/", docToken, (char) 0, false), //$NON-NLS-2$
+				new MultiLineRule("/*", "*/", commentToken, (char) 0, false), //$NON-NLS-2$
+				new SingleLineRule("\"","\"", quoteToken),
+				new SingleLineRule("'", "'", quoteToken),
+				new WhitespaceRule(new IWhitespaceDetector() {
+                    @Override
+					public boolean isWhitespace(char c) {
+                        return Character.isWhitespace(c);
+                    }
+                }),
+				new WordRule(new WordDetector(), normalToken),
+                new NumberRule(numberToken),
+		});
+
+		DefaultDamagerRepairer dr = new DefaultDamagerRepairer(scanner);
+		this.setDamager(dr, IDocument.DEFAULT_CONTENT_TYPE);
+		this.setRepairer(dr, IDocument.DEFAULT_CONTENT_TYPE);
+	}
+	
+	private static class KeywordRule extends WordRule {
+
+        public KeywordRule(IToken token) {
+            super(new WordDetector());
+            for (String word : GRADLE_IDENTIFIERS) {
+                addWord(word, token);
+            }
+        }
+    }
+
+    private static class WordDetector implements IWordDetector {
+
+        @Override
+		public boolean isWordPart(char c) {
+            return Character.isJavaIdentifierPart(c);
+        }
+
+        @Override
+		public boolean isWordStart(char c) {
+            return Character.isJavaIdentifierStart(c);
+        }
+
+    }
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/preferences/GradleEditorConstants.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/preferences/GradleEditorConstants.java
@@ -1,0 +1,29 @@
+package org.eclipse.buildship.ui.preferences;
+
+import org.eclipse.swt.graphics.RGB;
+
+/*
+ * @author Benjamin gurok
+ * @author Paul Verest
+ */
+public class GradleEditorConstants {
+
+	public static final String PREFERENCES_PAGE = "org.nodeclipse.ui.preferences.NodePreferencePage";
+
+	public static final String KEY_COLOR_COMMENT = "color_comment";
+	public static final String KEY_COLOR_DOC = "color_doc";
+	public static final String KEY_COLOR_KEYWORD = "color_keyword";
+	public static final String KEY_COLOR_STRING = "color_string";
+	public static final String KEY_COLOR_NUMBER = "color_number";
+	public static final String KEY_COLOR_NORMAL = "color_normal";
+	
+	public static final String KEY_BOLD_KEYWORD = "bold_keyword";
+	
+	public static final RGB DEFAULT_COLOR_COMMENT = new RGB(63, 127, 95);
+	public static final RGB DEFAULT_COLOR_DOC = new RGB(127, 127, 159);
+	public static final RGB DEFAULT_COLOR_KEYWORD = new RGB(127, 0, 85);
+	public static final RGB DEFAULT_COLOR_STRING = new RGB(42, 0, 255);
+	public static final RGB DEFAULT_COLOR_NUMBER = new RGB(80, 80, 80);
+	public static final RGB DEFAULT_COLOR_NORMAL = new RGB(0, 0, 0);
+
+}	

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/preferences/GradleEditorPreferenceInitializer.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/preferences/GradleEditorPreferenceInitializer.java
@@ -1,0 +1,26 @@
+package org.eclipse.buildship.ui.preferences;
+
+import org.eclipse.buildship.ui.UiPlugin;
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceConverter;
+
+/*
+ * @author Benjamin gurok
+ * @author Paul Verest
+ */
+public class GradleEditorPreferenceInitializer extends AbstractPreferenceInitializer {
+
+	@Override
+	public void initializeDefaultPreferences() {
+		IPreferenceStore store = UiPlugin.getInstance().getPreferenceStore();
+        PreferenceConverter.setDefault(store, GradleEditorConstants.KEY_COLOR_COMMENT, GradleEditorConstants.DEFAULT_COLOR_COMMENT);
+        PreferenceConverter.setDefault(store, GradleEditorConstants.KEY_COLOR_DOC, GradleEditorConstants.DEFAULT_COLOR_DOC);
+        PreferenceConverter.setDefault(store, GradleEditorConstants.KEY_COLOR_KEYWORD, GradleEditorConstants.DEFAULT_COLOR_KEYWORD);
+        PreferenceConverter.setDefault(store, GradleEditorConstants.KEY_COLOR_STRING, GradleEditorConstants.DEFAULT_COLOR_STRING);
+        PreferenceConverter.setDefault(store, GradleEditorConstants.KEY_COLOR_NUMBER, GradleEditorConstants.DEFAULT_COLOR_NUMBER);
+        PreferenceConverter.setDefault(store, GradleEditorConstants.KEY_COLOR_NORMAL, GradleEditorConstants.DEFAULT_COLOR_NORMAL);
+        store.setDefault(GradleEditorConstants.KEY_BOLD_KEYWORD, true);	}
+
+}
+

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/preferences/GradleEditorPreferencePage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/preferences/GradleEditorPreferencePage.java
@@ -1,0 +1,68 @@
+package org.eclipse.buildship.ui.preferences;
+
+import org.eclipse.buildship.ui.PluginImage.ImageState;
+import org.eclipse.buildship.ui.PluginImages;
+import org.eclipse.buildship.ui.UiPlugin;
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.ColorFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+/**
+ * @author Benjamin gurok
+ * @author Paul Verest
+ */
+public class GradleEditorPreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+	private ColorFieldEditor colorComment;
+    private ColorFieldEditor colorDoc;
+    private ColorFieldEditor colorKeyword;
+    private ColorFieldEditor colorString;
+    private ColorFieldEditor colorNumber;
+    private ColorFieldEditor colorNormal;
+    private BooleanFieldEditor boldAttributeKeyword;
+    
+    public GradleEditorPreferencePage() {
+        super(GRID);
+        IPreferenceStore store = UiPlugin.getInstance().getPreferenceStore();
+        setPreferenceStore(store);
+        setDescription("Gradle Editor Settings");
+        setImageDescriptor(PluginImages.GRADLE_FILE.withState(ImageState.ENABLED).getImageDescriptor());
+    }
+    
+	@Override
+	public void init(IWorkbench workbench) {
+	}
+
+	@Override
+	protected void createFieldEditors() {
+		
+	    Composite parent = getFieldEditorParent();
+
+        colorComment = new ColorFieldEditor(GradleEditorConstants.KEY_COLOR_COMMENT, "Comment color:", parent);
+        addField(colorComment);
+
+        colorDoc = new ColorFieldEditor(GradleEditorConstants.KEY_COLOR_DOC, "Doc color:", parent);
+        addField(colorDoc);
+
+        colorKeyword = new ColorFieldEditor(GradleEditorConstants.KEY_COLOR_KEYWORD, "Keyword color:", parent);
+        addField(colorKeyword);
+
+        boldAttributeKeyword = new BooleanFieldEditor(GradleEditorConstants.KEY_BOLD_KEYWORD, "Bold keywords", parent);
+        addField(boldAttributeKeyword);
+
+        colorString = new ColorFieldEditor(GradleEditorConstants.KEY_COLOR_STRING, "String color:", parent);
+        addField(colorString);
+
+        colorNumber = new ColorFieldEditor(GradleEditorConstants.KEY_COLOR_NUMBER, "Number color:", parent);
+        addField(colorNumber);
+
+        colorNormal = new ColorFieldEditor(GradleEditorConstants.KEY_COLOR_NORMAL, "Normal text color:", parent);
+        addField(colorNormal);
+	}
+
+
+}


### PR DESCRIPTION
I have used the genericeditor. It was almost too simple :)

Appart from the joke, I wanted to use a more sophisticated highlighter rules... For example "task" is defined as a keyword but it is not. It is related to Gradle DSL.... So if you invoke a task like for instance:
> myTask task: 'anotherTask'
task will be highlighted :( It seems we need some kind of semantic parser to do that. I tried (https://github.com/danielsun1106/groovy-parser), but I am not sure parsing the document for highlight syntax is good (I think I can imagine the answer :D ).

If you of someone else have experience on that, I am very interested with these problematic :)

I know Gradle DSL is complex, and it is probably the reason why there is not bundled Gradle editor in Eclipse :D Even if Eclipse seem to bet more on Kotlin DSL to provide an editor, I don't think it will be quickly the most used editor...

It is why I kept it simple so far :)

I also took the opportunity to add a EditorContributor for #560 :)