### PR TITLE
Execution view processes all build operations

### DIFF
--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/BaseExecutionViewTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/BaseExecutionViewTest.groovy
@@ -2,7 +2,11 @@ package org.eclipse.buildship.ui.view.execution
 
 import com.gradleware.tooling.toolingclient.GradleDistribution
 
+import org.eclipse.core.runtime.jobs.Job
+import org.eclipse.debug.core.DebugPlugin
+import org.eclipse.debug.core.ILaunch
 import org.eclipse.debug.core.ILaunchConfiguration
+import org.eclipse.debug.core.ILaunchConfigurationType
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy
 import org.eclipse.debug.core.ILaunchManager
 import org.eclipse.swt.widgets.Tree
@@ -15,6 +19,8 @@ import org.eclipse.ui.console.IConsoleManager
 
 import org.eclipse.buildship.core.CorePlugin
 import org.eclipse.buildship.core.launch.GradleRunConfigurationAttributes
+import org.eclipse.buildship.core.launch.GradleRunConfigurationDelegate
+import org.eclipse.buildship.core.launch.RunGradleBuildLaunchRequestJob
 import org.eclipse.buildship.core.util.gradle.GradleDistributionSerializer
 import org.eclipse.buildship.ui.console.GradleConsole
 import org.eclipse.buildship.ui.external.viewer.FilteredTree
@@ -25,7 +31,6 @@ abstract class BaseExecutionViewTest extends SwtBotSpecification {
 
     ConsoleListener consoleListener
     ExecutionsView view
-    SWTBotTree tree
 
     def setup() {
         runOnUiThread {
@@ -45,29 +50,7 @@ abstract class BaseExecutionViewTest extends SwtBotSpecification {
 
     protected SWTBotTree getCurrentTree() {
         Tree filteredTree = ((FilteredTree)view.currentPage.getPageControl()).viewer.tree
-        tree = new SWTBotTree(filteredTree)
-    }
-
-    protected void launchTask(String projectLoc, String task) {
-        def attributes = new GradleRunConfigurationAttributes(
-                [task],
-                projectLoc,
-                GradleDistributionSerializer.INSTANCE.serializeToString(GradleDistribution.fromBuild()),
-                "",
-                null,
-                [],
-                [],
-                true,
-                true,
-                false,
-                false,
-                false);
-
-        ILaunchConfiguration configuration = CorePlugin.gradleLaunchConfigurationManager().getOrCreateRunConfiguration(attributes)
-        ILaunchConfigurationWorkingCopy launchConfigurationWC = configuration.getWorkingCopy()
-        launchConfigurationWC.doSave()
-
-        launchConfigurationWC.launch( ILaunchManager.RUN_MODE, null )
+        new SWTBotTree(filteredTree)
     }
 
     protected void removeCloseableGradleConsoles() {
@@ -77,9 +60,34 @@ abstract class BaseExecutionViewTest extends SwtBotSpecification {
     }
 
     protected void waitForConsoleOutput() {
-        waitFor {
-            activeConsole != null && activeConsole.isCloseable() && activeConsole.isTerminated() && activeConsole.partitioner.pendingPartitions.empty
-        }
+        waitFor { activeConsole != null && activeConsole.isCloseable() && activeConsole.isTerminated() && activeConsole.partitioner.pendingPartitions.empty }
+    }
+
+    protected void waitForExecutionFinished() {
+        waitFor { view.currentPage.progressListener.updateExecutionPageJob.state == Job.NONE }
+    }
+
+    protected void launchTaskAndWait(File projectDir, String task, List<String> arguments = []) {
+        launchTask(task, projectDir, arguments)
+        waitForExecutionFinished()
+    }
+
+    private void launchTask(String task, File projectDir, List<String> arguments) {
+        GradleRunConfigurationAttributes attributes = new GradleRunConfigurationAttributes(
+                [task],
+                projectDir.absolutePath,
+                GradleDistributionSerializer.INSTANCE.serializeToString(GradleDistribution.fromBuild()),
+                "",
+                null,
+                [],
+                arguments,
+                true,
+                true,
+                false,
+                false,
+                false);
+        ILaunchConfiguration configuration = CorePlugin.gradleLaunchConfigurationManager().getOrCreateRunConfiguration(attributes)
+        configuration.launch(ILaunchManager.RUN_MODE, null)
     }
 
     class ConsoleListener implements IConsoleListener {

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/ExecutionViewDoubleClickTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/ExecutionViewDoubleClickTest.groovy
@@ -1,18 +1,17 @@
 package org.eclipse.buildship.ui.view.execution
 
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem
 
 class ExecutionViewDoubleClickTest extends BaseExecutionViewTest {
 
     def "Double-clicking group nodes expand and collapse children"() {
         setup:
-        def project = sampleTestProject()
-        importAndWait(project)
-        launchTask(project.absolutePath, 'build')
-        waitForConsoleOutput()
+        File projectDir = sampleTestProject()
+        importAndWait(projectDir)
+        launchTaskAndWait(projectDir, 'build')
 
-        tree = getCurrentTree()
-
+        SWTBotTree tree = getCurrentTree()
         SWTBotTreeItem root = tree.getTreeItem('Run build')
 
         expect:
@@ -45,15 +44,15 @@ class ExecutionViewDoubleClickTest extends BaseExecutionViewTest {
 
     def "Double-clicking test class and method open editor"() {
         setup:
-        def project = sampleTestProject()
-        importAndWait(project)
-        launchTask(project.absolutePath, 'build')
-        waitForConsoleOutput()
+        File projectDir = sampleTestProject()
+        importAndWait(projectDir)
+        launchTaskAndWait(projectDir, 'build')
+        waitForGradleJobsToFinish()
 
-        tree = getCurrentTree()
+        SWTBotTree tree = getCurrentTree()
+        SWTBotTreeItem root = tree.getTreeItem('Run build')
 
         when:
-        SWTBotTreeItem root = tree.getTreeItem('Run build')
         root.expand()
         SWTBotTreeItem runNode = root.getNode('Run tasks')
         runNode.expand()

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/ExecutionViewExpandAndCollapseAllTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/ExecutionViewExpandAndCollapseAllTest.groovy
@@ -1,15 +1,16 @@
 package org.eclipse.buildship.ui.view.execution
 
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree
+
 class ExecutionViewExpandAndCollapseAllTest extends BaseExecutionViewTest {
 
     def "Expand and collapse all"() {
         setup:
-        def project = sampleProject()
-        importAndWait(project)
-        launchTask(project.absolutePath, 'foo')
-        waitForConsoleOutput()
+        File projectDir = sampleProject()
+        importAndWait(projectDir)
+        launchTaskAndWait(projectDir, 'foo')
 
-        tree = getCurrentTree()
+        SWTBotTree tree = getCurrentTree()
 
         expect:
         tree.getTreeItem('Run build').expanded
@@ -33,11 +34,6 @@ class ExecutionViewExpandAndCollapseAllTest extends BaseExecutionViewTest {
             file 'build.gradle', """
                 task foo() {
                     group = 'custom'
-                    // we need to declare a longer-running task until the following bug in the executions view is resolved:
-                    // https://github.com/eclipse/buildship/issues/586
-                    doLast {
-                        Thread.sleep(100)
-                    }
                 }
             """
         }

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/ExecutionViewTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/view/execution/ExecutionViewTest.groovy
@@ -1,0 +1,23 @@
+package org.eclipse.buildship.ui.view.execution
+
+import spock.lang.Issue
+
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem
+
+class ExecutionViewTest extends BaseExecutionViewTest {
+
+    @Issue('https://github.com/eclipse/buildship/issues/586')
+    def "Shows complete execution tree"() {
+        setup:
+        File projectDir = dir('project-without-build-scan') {
+            file 'build.gradle', 'task foo { }'
+        }
+
+        when:
+        synchronizeAndWait(projectDir)
+        launchTaskAndWait(projectDir, 'foo')
+
+        then:
+        !currentTree.allItems[0].cell(1).contains('Running')
+    }
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/view/execution/UpdateExecutionPageJob.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/view/execution/UpdateExecutionPageJob.java
@@ -53,7 +53,7 @@ public final class UpdateExecutionPageJob extends Job {
     @Override
     protected IStatus run(IProgressMonitor monitor) {
         RateLimiter rateLimiter = RateLimiter.create(MAX_UPDATES_PER_SECOND);
-        while(this.running) {
+        while(this.running || !this.queue.isEmpty()) {
             rateLimiter.acquire();
 
             List<ProgressEvent> events = Lists.newArrayList();


### PR DESCRIPTION
This commit fixes the execution view such that it won't omit
displaying the last build operations when the build finishes.

This change also cleans up the text fixtures in the
BaseExecutionViewTest class.