### PR TITLE
Do string substitution for program arguments in run configuration

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/configuration/internal/DefaultConfigurationManager.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/configuration/internal/DefaultConfigurationManager.java
@@ -175,7 +175,7 @@ public class DefaultConfigurationManager implements ConfigurationManager {
                   attributes.getGradleUserHome(),
                   attributes.getJavaHome(),
                   attributes.getJvmArguments(),
-                  attributes.getArgumentExpressions(),
+                  attributes.getArguments(),
                   attributes.isShowConsoleView(),
                   attributes.isShowExecutionView(),
                   attributes.isOverrideBuildSettings(),


### PR DESCRIPTION
The RunConfiguration instances are expected to do string substitution
for the following parameters:
 - working directory
 - Gradle user home
 - Java home
 - program arguments
 - JVM arguments

The program arguments were accidentally instantiated with the raw
values skipping the string substitution. This commit fixes the
problem and adds code coverage to avoid further regressions.