### PR TITLE
Remove Maven nature when Gradle project imported

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/ProjectNatureUpdaterTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/ProjectNatureUpdaterTest.groovy
@@ -1,5 +1,7 @@
 package org.eclipse.buildship.core.workspace.internal
 
+import spock.lang.Issue
+
 import com.google.common.base.Optional
 
 import com.gradleware.tooling.toolingmodel.OmniEclipseProjectNature
@@ -108,6 +110,23 @@ class ProjectNatureUpdaterTest extends WorkspaceSpecification {
 
         then:
         hasNature(project, 'org.eclipse.pde.UpdateSiteNature')
+    }
+
+    @Issue("https://github.com/eclipse/buildship/issues/617")
+    def "M2E nature is never preserved"() {
+        given:
+        IProject project = newProject('sample-project')
+        IProjectDescription description = project.description
+        List manualNatures = ['org.eclipse.m2e.core.maven2Nature']
+        description.setNatureIds(manualNatures as String[])
+        project.setDescription(description, new NullProgressMonitor())
+        PersistentModelBuilder persistentModel = persistentModelBuilder(project)
+
+        when:
+        executeProjectNatureUpdater(project, persistentModel)
+
+        then:
+        !hasNature(project, 'org.eclipse.m2e.core.maven2Nature')
     }
 
     private void executeProjectNatureUpdaterWithAbsentModel(IProject project) {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/ProjectNatureUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/ProjectNatureUpdater.java
@@ -41,6 +41,7 @@ final class ProjectNatureUpdater {
     public static void update(IProject project, Optional<List<OmniEclipseProjectNature>> projectNatures, PersistentModelBuilder persistentModel, IProgressMonitor monitor) throws CoreException {
         PersistentModel previousPersistentModel = persistentModel.getPrevious();
         Set<String> managedNatures = previousPersistentModel.isPresent() ? Sets.newLinkedHashSet(previousPersistentModel.getManagedNatures()) : Sets.<String>newLinkedHashSet();
+        managedNatures.add("org.eclipse.m2e.core.maven2Nature");
 
         Set<String> modelNatures = toNatures(projectNatures);
         IProjectDescription description = project.getDescription();


### PR DESCRIPTION
An Eclipse project should be either Gradle or Maven project but
not both at the same time. If both natures were present, the plugins
would compete on how to calculate the classpath for the associated
run configurations. To resolve this situation, Buildship now
actively removes the Maven nature during the Gradle synchronization.