### PR TITLE
Make debugging be able to look up sources from dependency project

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/RuntimeClasspathTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/RuntimeClasspathTest.groovy
@@ -158,7 +158,6 @@ class RuntimeClasspathTest extends ProjectSynchronizationSpecification {
         IRuntimeClasspathEntry[] classpath = projectRuntimeClasspath(javaProject)
 
         then:
-        classpath.length == 4
         classpath.find { it.type == IRuntimeClasspathEntry.PROJECT && it.path.lastSegment() == 'a' }
         classpath.find { it.type == IRuntimeClasspathEntry.PROJECT && it.path.lastSegment() == 'b' }
         classpath.find { it.type == IRuntimeClasspathEntry.ARCHIVE && it.path.lastSegment() == 'log4j-1.2.17.jar' }

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/SourcePathTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/SourcePathTest.groovy
@@ -1,0 +1,54 @@
+package org.eclipse.buildship.core.workspace.internal
+
+import com.gradleware.tooling.toolingclient.GradleDistribution
+
+import org.eclipse.core.resources.IProject
+import org.eclipse.debug.core.ILaunchConfiguration
+import org.eclipse.jdt.core.JavaCore
+import org.eclipse.jdt.launching.IRuntimeClasspathEntry
+import org.eclipse.jdt.launching.JavaRuntime
+
+import org.eclipse.buildship.core.launch.internal.SupportedLaunchConfigType
+import org.eclipse.buildship.core.test.fixtures.ProjectSynchronizationSpecification
+
+class SourcePathTest extends ProjectSynchronizationSpecification {
+
+    def "Source files available from project dependency"(String version) {
+         setup:
+         File projectDir = dir('root') {
+             file('settings.gradle') << 'include "p1","p2"'
+             file('build.gradle') << 'allprojects { apply plugin: "java" }'
+
+             dir('p1') {
+                 file('build.gradle') << 'dependencies { compile project(":p2") }'
+                 dir('src/main/java').mkdirs()
+             }
+
+             dir('p2') {
+                 file('build.gradle')
+                 dir('src/main/java').mkdirs()
+             }
+         }
+
+         when:
+         importAndWait(projectDir, GradleDistribution.forVersion(version))
+         IRuntimeClasspathEntry[] p1sources = sourceEntries(findProject('p1'))
+         IRuntimeClasspathEntry[] p2sources = sourceEntries(findProject('p2'))
+
+         then:
+         p1sources.find { IRuntimeClasspathEntry entry -> entry.path.toPortableString() == '/p1' }
+         p1sources.find { IRuntimeClasspathEntry entry -> entry.path.toPortableString() == '/p2' }
+         !p2sources.find { IRuntimeClasspathEntry entry -> entry.path.toPortableString() == '/p1' }
+         p2sources.find { IRuntimeClasspathEntry entry -> entry.path.toPortableString() == '/p2' }
+
+         where:
+         // Gradle 4.3 doesn't use separate output dir per source folder
+         version << ['4.3', '4.4']
+    }
+
+    private IRuntimeClasspathEntry[] sourceEntries(IProject project) {
+        ILaunchConfiguration launchConfig = createLaunchConfig(SupportedLaunchConfigType.JDT_JAVA_APPLICATION.id)
+        IRuntimeClasspathEntry[] unresolved = JavaRuntime.computeUnresolvedRuntimeClasspath(JavaCore.create(project))
+        JavaRuntime.resolveSourceLookupPath(unresolved, launchConfig)
+    }
+}

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerRuntimeClasspathEntryResolver.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerRuntimeClasspathEntryResolver.java
@@ -84,6 +84,9 @@ public class GradleClasspathContainerRuntimeClasspathEntryResolver implements IR
                     if (candidate.isPresent()) {
                         IJavaProject dependencyProject = JavaCore.create(candidate.get());
                         IRuntimeClasspathEntry projectRuntimeEntry = JavaRuntime.newProjectRuntimeClasspathEntry(dependencyProject);
+                        // add the project entry itself so that the source lookup can find the classes
+                        // see https://github.com/eclipse/buildship/issues/383
+                        result.add(projectRuntimeEntry);
                         Collections.addAll(result, JavaRuntime.resolveRuntimeClasspathEntry(projectRuntimeEntry, dependencyProject));
                         collectContainerRuntimeClasspathIfPresent(dependencyProject, result, true, configurationScopes);
                     }


### PR DESCRIPTION
The source lookup takes the values from the resolved runtime classpath. If the dependency project is missing from there, then the source lookup from that project will fail when debugging.