### PR TITLE
Ensure workspace project is in sync with filesystem before updating preferences

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/test/fixtures/LegacyEclipseSpockTestHelper.java
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/test/fixtures/LegacyEclipseSpockTestHelper.java
@@ -29,4 +29,7 @@ public abstract class LegacyEclipseSpockTestHelper {
         return ResourcesPlugin.getWorkspace();
     }
 
+    public static Object getAutoRefreshJobFamily() {
+        return ResourcesPlugin.FAMILY_AUTO_REFRESH;
+    }
 }

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/ImportingProjectWithExistingDescriptor.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/ImportingProjectWithExistingDescriptor.groovy
@@ -1,9 +1,20 @@
 package org.eclipse.buildship.core.workspace.internal
 
+import com.google.common.base.Optional
+
 import org.eclipse.core.resources.IProject
+import org.eclipse.core.resources.IProjectDescription
+import org.eclipse.core.resources.ResourcesPlugin
+import org.eclipse.core.runtime.ILogListener
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.core.runtime.Platform
+import org.eclipse.core.runtime.jobs.Job
 import org.eclipse.jdt.core.JavaCore
 
 import org.eclipse.buildship.core.CorePlugin
+import org.eclipse.buildship.core.Logger
+import org.eclipse.buildship.core.notification.UserNotification
+import org.eclipse.buildship.core.test.fixtures.LegacyEclipseSpockTestHelper
 import org.eclipse.buildship.core.workspace.GradleClasspathContainer
 
 class ImportingProjectWithExistingDescriptor extends SingleProjectSynchronizationSpecification {
@@ -43,6 +54,41 @@ class ImportingProjectWithExistingDescriptor extends SingleProjectSynchronizatio
         JavaCore.create(project).rawClasspath.any { it.path == GradleClasspathContainer.CONTAINER_PATH }
     }
 
+    def "Can import an existing Buildship project using with generic wizard"() {
+        setup:
+        def projectDir = dir('sample-project') {
+            file 'build.gradle', "apply plugin: 'java'"
+        }
+        synchronizeAndWait(projectDir)
+        deleteAllProjects(false)
+
+        Logger logger = Mock(Logger)
+        UserNotification notification = Mock(UserNotification)
+        environment.registerService(Logger, logger)
+        environment.registerService(UserNotification, notification)
+
+        ILogListener logListener = Mock(ILogListener)
+        Platform.addLogListener(logListener)
+
+        expect:
+        !findProject('sample-project')
+
+        when:
+        Optional<IProjectDescription> description = CorePlugin.workspaceOperations().findProjectDescriptor(projectDir, new NullProgressMonitor());
+        CorePlugin.workspaceOperations().includeProject(description.get(), [], new NullProgressMonitor())
+        waitForRefreshToFinish()
+
+        then:
+        findProject('sample-project')
+        0 * logger.warn(*_)
+        0 * logger.error(*_)
+        0 * notification.errorOccurred(*_)
+        0 * logListener.logging(*_)
+
+        cleanup:
+        Platform.removeLogListener(logListener)
+    }
+
     @Override
     protected void prepareProject(String name) {
         def project = newProject(name)
@@ -53,5 +99,9 @@ class ImportingProjectWithExistingDescriptor extends SingleProjectSynchronizatio
     protected void prepareJavaProject(String name) {
         def project = newJavaProject(name).project
         project.delete(false, true, null)
+    }
+
+    private void waitForRefreshToFinish() {
+        Job.jobManager.join(LegacyEclipseSpockTestHelper.getAutoRefreshJobFamily(), null)
     }
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultWorkspaceOperations.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/DefaultWorkspaceOperations.java
@@ -113,7 +113,7 @@ public class DefaultWorkspaceOperations implements WorkspaceOperations {
             project.create(projectDescription, progress.newChild(1));
 
             // open the project
-            project.open(IResource.BACKGROUND_REFRESH, progress.newChild(1));
+            project.open(IResource.NONE, progress.newChild(1));
 
             // add project natures separately to trigger IProjectNature#configure
             // the project needs to be open while the natures are added
@@ -145,7 +145,7 @@ public class DefaultWorkspaceOperations implements WorkspaceOperations {
             project.create(projectDescription, progress.newChild(1));
 
             // open the project
-            project.open(IResource.BACKGROUND_REFRESH, progress.newChild(1));
+            project.open(IResource.NONE, progress.newChild(1));
 
             // add project natures separately to trigger IProjectNature#configure
             // the project needs to be open while the natures are added

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SynchronizeGradleBuildOperation.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SynchronizeGradleBuildOperation.java
@@ -189,17 +189,21 @@ final class SynchronizeGradleBuildOperation implements IWorkspaceRunnable {
 
     private void synchronizeWorkspaceProject(OmniEclipseProject project, IProject workspaceProject, SubMonitor progress) throws CoreException {
         if (workspaceProject.isAccessible()) {
-            synchronizeOpenWorkspaceProject(project, workspaceProject, progress);
+            synchronizeOpenWorkspaceProject(project, workspaceProject, true, progress);
         } else {
             synchronizeClosedWorkspaceProject(progress);
         }
     }
 
-    private void synchronizeOpenWorkspaceProject(OmniEclipseProject project, IProject workspaceProject, SubMonitor progress) throws CoreException {
+    private void synchronizeOpenWorkspaceProject(OmniEclipseProject project, IProject workspaceProject, boolean refreshNeeded, SubMonitor progress) throws CoreException {
         progress.setWorkRemaining(10);
 
         //currently lots of our synchronization logic assumes that the whole resource tree is readable.
-        CorePlugin.workspaceOperations().refreshProject(workspaceProject, progress.newChild(1));
+        if (refreshNeeded) {
+            CorePlugin.workspaceOperations().refreshProject(workspaceProject, progress.newChild(1));
+        } else {
+            progress.worked(1);
+        }
 
         workspaceProject = ProjectNameUpdater.updateProjectName(workspaceProject, project, this.allProjects, progress.newChild(1));
 
@@ -273,7 +277,7 @@ final class SynchronizeGradleBuildOperation implements IWorkspaceRunnable {
         progress.setWorkRemaining(3);
         ProjectNameUpdater.ensureProjectNameIsFree(project, this.allProjects, progress.newChild(1));
         IProject workspaceProject = CorePlugin.workspaceOperations().includeProject(projectDescription, ImmutableList.<String>of(), progress.newChild(1));
-        synchronizeOpenWorkspaceProject(project, workspaceProject, progress.newChild(1));
+        synchronizeOpenWorkspaceProject(project, workspaceProject, false, progress.newChild(1));
         return workspaceProject;
     }
 
@@ -281,7 +285,7 @@ final class SynchronizeGradleBuildOperation implements IWorkspaceRunnable {
         progress.setWorkRemaining(3);
         ProjectNameUpdater.ensureProjectNameIsFree(project, this.allProjects, progress.newChild(1));
         IProject workspaceProject = CorePlugin.workspaceOperations().createProject(project.getName(), project.getProjectDirectory(), ImmutableList.<String>of(), progress.newChild(1));
-        synchronizeOpenWorkspaceProject(project, workspaceProject, progress.newChild(1));
+        synchronizeOpenWorkspaceProject(project, workspaceProject, false, progress.newChild(1));
         return workspaceProject;
     }
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SynchronizeGradleBuildOperation.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/SynchronizeGradleBuildOperation.java
@@ -168,12 +168,6 @@ final class SynchronizeGradleBuildOperation implements IWorkspaceRunnable {
 
     private void synchronizeGradleProjectWithWorkspaceProject(OmniEclipseProject project, SubMonitor progress) throws CoreException {
         progress.setWorkRemaining(1);
-
-        // save the project configuration
-        ConfigurationManager configManager = CorePlugin.configurationManager();
-        ProjectConfiguration projectConfig = configManager.createProjectConfiguration(this.buildConfig, project.getProjectDirectory());
-        configManager.saveProjectConfiguration(projectConfig);
-
         progress.subTask(String.format("Synchronize Gradle project %s with workspace project", project.getName()));
         // check if a project already exists in the workspace at the location of the Gradle project to import
         Optional<IProject> workspaceProject = CorePlugin.workspaceOperations().findProjectByLocation(project.getProjectDirectory());
@@ -204,6 +198,12 @@ final class SynchronizeGradleBuildOperation implements IWorkspaceRunnable {
         } else {
             progress.worked(1);
         }
+
+        // save the project configuration; has to be called after workspace project is in sync with the file system
+        // otherwise the Eclipse preferences API will throw BackingStoreException
+        ConfigurationManager configManager = CorePlugin.configurationManager();
+        ProjectConfiguration projectConfig = configManager.createProjectConfiguration(this.buildConfig, project.getProjectDirectory());
+        configManager.saveProjectConfiguration(projectConfig);
 
         workspaceProject = ProjectNameUpdater.updateProjectName(workspaceProject, project, this.allProjects, progress.newChild(1));
 


### PR DESCRIPTION
Currently, we save the project preferences before the project files are synchronized with the file system. In some cases (when importing existing projects) it's even worse: a the file syncing starts in the background, then comes the preference save. As a result we see frequent, but random `BackingStoreException`s being raised.

This pull request fixes this problem as it makes all file sync happening synchronously and before the preferences are updated.