### PR TITLE
Lukeu/fix/more tests off runtime classpath

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/RuntimeClasspathTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/RuntimeClasspathTest.groovy
@@ -167,6 +167,8 @@ class RuntimeClasspathTest extends ProjectSynchronizationSpecification {
     @Issue("https://bugs.eclipse.org/bugs/show_bug.cgi?id=507206")
     def "Runtime classpath contains custom output folders"() {
         setup:
+        // Another non-custom source directory is required for the default-directory to be set
+        new File(location, 'a/src/test/java').mkdirs()
         buildFile << '''
             project(':a') {
                 apply plugin: 'eclipse'

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/RuntimeClasspathTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/workspace/internal/RuntimeClasspathTest.groovy
@@ -25,9 +25,9 @@ class RuntimeClasspathTest extends ProjectSynchronizationSpecification {
     def setup() {
         location = dir('sample-project') {
             file('settings.gradle') << "include 'a', 'b', 'c'"
-            dir('a/src/main/java').mkdirs()
-            dir('b/src/main/java').mkdirs()
-            dir('c/src/main/java').mkdirs()
+            dir('a/src/main/java')
+            dir('b/src/main/java')
+            dir('c/src/main/java')
             buildFile = file 'build.gradle', '''
                 subprojects {
                     apply plugin: 'java'
@@ -167,7 +167,6 @@ class RuntimeClasspathTest extends ProjectSynchronizationSpecification {
     @Issue("https://bugs.eclipse.org/bugs/show_bug.cgi?id=507206")
     def "Runtime classpath contains custom output folders"() {
         setup:
-        new File(location, 'a/src/main/java').mkdirs()
         buildFile << '''
             project(':a') {
                 apply plugin: 'eclipse'

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/internal/GradleClasspathProvider.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/launch/internal/GradleClasspathProvider.java
@@ -163,7 +163,7 @@ public final class GradleClasspathProvider extends StandardClasspathProvider imp
         return false;
     }
 
-    private static IRuntimeClasspathEntry[] resolveOutputLocations(IRuntimeClasspathEntry projectEntry, IJavaProject project, LaunchConfigurationScope configurationScopes)
+    public static IRuntimeClasspathEntry[] resolveOutputLocations(IRuntimeClasspathEntry projectEntry, IJavaProject project, LaunchConfigurationScope configurationScopes)
             throws CoreException {
         List<IPath> outputLocations = Lists.newArrayList();
         boolean hasSourceFolderWithoutCustomOutput = false;

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerRuntimeClasspathEntryResolver.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/workspace/internal/GradleClasspathContainerRuntimeClasspathEntryResolver.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.launching.IRuntimeClasspathEntryResolver;
 import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.JavaRuntime;
 
+import org.eclipse.buildship.core.launch.internal.GradleClasspathProvider;
 import org.eclipse.buildship.core.launch.internal.LaunchConfigurationScope;
 import org.eclipse.buildship.core.workspace.GradleClasspathContainer;
 
@@ -87,7 +88,7 @@ public class GradleClasspathContainerRuntimeClasspathEntryResolver implements IR
                         // add the project entry itself so that the source lookup can find the classes
                         // see https://github.com/eclipse/buildship/issues/383
                         result.add(projectRuntimeEntry);
-                        Collections.addAll(result, JavaRuntime.resolveRuntimeClasspathEntry(projectRuntimeEntry, dependencyProject));
+                        Collections.addAll(result, GradleClasspathProvider.resolveOutputLocations(projectRuntimeEntry, dependencyProject, configurationScopes));
                         collectContainerRuntimeClasspathIfPresent(dependencyProject, result, true, configurationScopes);
                     }
                 }


### PR DESCRIPTION
This change resolves the 'test resources in the runtime classpath' issue I was continuing to see following issue #354. I tested with my minimal example with Java 8 & 9, and my commercial workspace with Java 8 & both work as expected with this. However I really don't feel 'confident' with Eclipse or Buildship code yet, so I think this does need a good check - there seem to be quite a number of possibilities to consider.

(I spent some time trying to write an integration test for this based on RuntimeClasspathTest.groovy, but failed. I got as far as seeing that I'd need to construct a Jdt launch (rather than a Gradle launch) but that seemed to entail too much to set up, without some form of mocking or stubbing. There didn't seem to be something like that to emulate either?)

