### PR TITLE
Fix npe in unregister 'UserNotification' service

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/UiPlugin.java
@@ -54,7 +54,6 @@ public final class UiPlugin extends AbstractUIPlugin {
     // search for -target jsr14 to find out more about this obscurity
     private ServiceRegistration loggerService;
     private ServiceRegistration processStreamsProviderService;
-    private ServiceRegistration dialogUserNotificationService;
     private ServiceRegistration gradleLaunchConfigurationService;
     private ConsoleShowingLaunchListener consoleShowingLaunchListener;
     private ExecutionShowingLaunchRequestListener executionShowingLaunchRequestListener;
@@ -109,7 +108,6 @@ public final class UiPlugin extends AbstractUIPlugin {
 
     private void unregisterServices() {
         this.gradleLaunchConfigurationService.unregister();
-        this.dialogUserNotificationService.unregister();
         this.processStreamsProviderService.unregister();
         this.loggerService.unregister();
     }


### PR DESCRIPTION
I found a NullPointerException in stoping eclipse when i was testing buildship 3.0,  a piece of code that was forgotten to be deleted.