### PR TITLE
Fix could not load Ant definition file problem

### DIFF
--- a/buildSrc/src/main/groovy/eclipsebuild/mavenize/DeployMavenAntTaskExecutor.groovy
+++ b/buildSrc/src/main/groovy/eclipsebuild/mavenize/DeployMavenAntTaskExecutor.groovy
@@ -29,7 +29,7 @@ class DeployMavenAntTaskExecutor {
      */
     DeployMavenAntTaskExecutor(AntBuilder ant, File target) {
         this.ant = ant
-        this.ant.taskdef(resource: 'org/apache/maven/artifact/ant/antlib.xml', classpath: Mvn.class.getProtectionDomain().getCodeSource().getLocation())
+        this.ant.taskdef(resource: 'org/apache/maven/artifact/ant/antlib.xml', classpath: new File(Mvn.class.getProtectionDomain().getCodeSource().getLocation().toURI()))
         this.target = target
         this.workFolder = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString())
     }


### PR DESCRIPTION
Hi all,
    I am working on converting Eclipse OSGI plugin into gradle project recently and thanks Buildship bring this solution to me.
    And there a bug that bothers me a few days, when I run ./gradlew installTargertPlatform in buildship source folder the error happened: 
```
> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy
> Task :buildSrc:processResources NO-SOURCE
> Task :buildSrc:classes
> Task :buildSrc:jar
> Task :buildSrc:assemble
> Task :buildSrc:compileTestJava NO-SOURCE
> Task :buildSrc:compileTestGroovy NO-SOURCE
> Task :buildSrc:processTestResources NO-SOURCE
> Task :buildSrc:testClasses UP-TO-DATE
> Task :buildSrc:test NO-SOURCE
> Task :buildSrc:check UP-TO-DATE
> Task :buildSrc:build

> Task :installTargetPlatform
[ant:taskdef] Could not load definitions from resource org/apache/maven/artifact/ant/antlib.xml. It could not be found.

> Task :installTargetPlatform FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':installTargetPlatform'.
> Problem: failed to create task or type pom
  Cause: The name is undefined.
  Action: Check the spelling.
  Action: Check that any custom tasks/types have been declared.
  Action: Check that any <presetdef>/<macrodef> declarations have taken place.
```
Then I found the same problem from google https://github.com/akhikhl/wuff/issues/3
### Why this pull request can fix?
After debugging into where exception throwing

- Current the classpath url is `file:/C:/Users/User/.gradle/caches/***` that can't be transformed into ` AntClassloader` libs' path and throwing the messages above.

- Change to `C:/Users/User/.gradle/caches/***` that works