### PR TITLE
Add test coverage for project synchronization API

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationCancellationTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationCancellationTest.groovy
@@ -1,0 +1,79 @@
+package org.eclipse.buildship.core
+
+import java.util.concurrent.CountDownLatch
+
+import org.eclipse.core.resources.IProject
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.core.runtime.IStatus
+import org.eclipse.core.runtime.jobs.Job
+
+import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
+
+class SynchronizationCancellationTest extends ProjectSynchronizationSpecification {
+
+    File location
+
+    def setup() {
+        location = dir('app') {
+            file 'build.gradle', '''
+                Thread.sleep(300)
+            '''
+        }
+    }
+
+    def "Can cancel import"() {
+        setup:
+        CountDownLatch latch = new CountDownLatch(1)
+        Job job = new SyncJob(latch, location)
+
+        when:
+        job.schedule()
+        latch.await()
+        job.cancel()
+        job.join()
+
+        then:
+        job.result.severity == IStatus.CANCEL
+    }
+
+    def "Can cancel synchronization"() {
+        setup:
+        importAndWait(location)
+        CountDownLatch latch = new CountDownLatch(1)
+        Job job = new SyncJob(latch, findProject('app'))
+
+        when:
+        job.schedule()
+        latch.await()
+        job.cancel()
+        job.join()
+
+        then:
+        job.result.severity == IStatus.CANCEL
+    }
+
+    class SyncJob extends Job {
+
+        CountDownLatch latch
+        GradleBuild gradleBuild
+
+        private SyncJob(CountDownLatch latch, File location) {
+            this(latch, gradleBuildFor(location))
+        }
+
+        private SyncJob(CountDownLatch latch, IProject project) {
+            this(latch, gradleBuildFor(project))
+        }
+
+        private SyncJob(CountDownLatch latch, GradleBuild gradleBuild) {
+            super("Test sync job")
+            this.latch = latch
+            this.gradleBuild = gradleBuild
+        }
+
+        IStatus run(IProgressMonitor monitor) {
+            latch.countDown()
+            gradleBuild.synchronize(monitor).status
+        }
+    }
+}

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationConcurrencyTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationConcurrencyTest.groovy
@@ -1,0 +1,96 @@
+package org.eclipse.buildship.core
+
+import org.eclipse.core.resources.IResource
+import org.eclipse.core.runtime.ICoreRunnable
+import org.eclipse.core.runtime.IProgressMonitor
+import org.eclipse.core.runtime.IStatus
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.core.runtime.Status
+import org.eclipse.core.runtime.jobs.Job
+
+import org.eclipse.buildship.core.internal.CorePlugin
+import org.eclipse.buildship.core.internal.event.Event
+import org.eclipse.buildship.core.internal.event.EventListener
+import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
+import org.eclipse.buildship.core.internal.workspace.ProjectCreatedEvent
+
+class SynchronizationConcurrencyTest extends ProjectSynchronizationSpecification {
+
+    def "Concurrently executed synchronizations runs sequencially"() {
+        setup:
+        List<Job> syncJobs = (1..5).collect {
+            new SyncJob(dir("location_$it") { file "build.gradle", "Thread.sleep(500)" })
+        }
+        ProjectCreationTracker tracker = new ProjectCreationTracker()
+        CorePlugin.listenerRegistry().addEventListener(tracker)
+
+        when:
+        syncJobs.each { it.schedule() }
+        syncJobs.each { it.join() }
+
+        then:
+        tracker.assertTimeBetweenProjectCreationsHigherThan(500)
+
+        cleanup:
+        CorePlugin.listenerRegistry().removeEventListener(tracker)
+    }
+
+    def "Synchronization requires workspace rule"() {
+        setup:
+        // import a sample project
+        File location = dir('SynchronizationConcurrencyTest')
+        importAndWait(location)
+
+        Job syncJob = new SyncJob(location)
+        when:
+        // start and wait for synchronization with workspace root rule already used
+        Closure synOperation = {
+            syncJob.schedule()
+            assert !syncJob.join(1000, new NullProgressMonitor())
+        }
+        workspace.run(synOperation as ICoreRunnable, workspace.root, IResource.NONE, new NullProgressMonitor())
+
+        then:
+        // synchronization won't start until the job with the workspace rule finishes
+        syncJob.join(1000, new NullProgressMonitor())
+    }
+
+    class SyncJob extends Job {
+
+        File location
+
+        SyncJob(File location) {
+            super('synchronization job')
+            this.location = location;
+        }
+
+        protected IStatus run(IProgressMonitor monitor) {
+            importAndWait(location)
+            Status.OK_STATUS
+        }
+    }
+
+    class ProjectCreationTracker implements EventListener {
+
+        List durationsBetweenNewProjectEvents = []
+        long lastEvent = -1
+
+        @Override
+        public void onEvent(Event event) {
+             if (event instanceof ProjectCreatedEvent) {
+                 long now = System.currentTimeMillis()
+                 if (lastEvent < 0) {
+                     lastEvent = now
+                 } else {
+                     durationsBetweenNewProjectEvents += (now - lastEvent)
+                     lastEvent = now
+                 }
+             }
+        }
+
+        def assertTimeBetweenProjectCreationsHigherThan(long diff) {
+            assert !durationsBetweenNewProjectEvents.empty
+            durationsBetweenNewProjectEvents.each { assert it > diff }
+        }
+    }
+}

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationConcurrencyTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationConcurrencyTest.groovy
@@ -16,7 +16,7 @@ import org.eclipse.buildship.core.internal.workspace.ProjectCreatedEvent
 
 class SynchronizationConcurrencyTest extends ProjectSynchronizationSpecification {
 
-    def "Concurrently executed synchronizations runs sequencially"() {
+    def "Concurrently executed synchronizations runs sequentially"() {
         setup:
         List<Job> syncJobs = (1..5).collect {
             new SyncJob(dir("location_$it") { file "build.gradle", "Thread.sleep(500)" })
@@ -44,11 +44,11 @@ class SynchronizationConcurrencyTest extends ProjectSynchronizationSpecification
         Job syncJob = new SyncJob(location)
         when:
         // start and wait for synchronization with workspace root rule already used
-        Closure synOperation = {
+        ICoreRunnable syncOperation = {
             syncJob.schedule()
             assert !syncJob.join(1000, new NullProgressMonitor())
         }
-        workspace.run(synOperation as ICoreRunnable, workspace.root, IResource.NONE, new NullProgressMonitor())
+        workspace.run(syncOperation, workspace.root, IResource.NONE, new NullProgressMonitor())
 
         then:
         // synchronization won't start until the job with the workspace rule finishes

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationInvalidLocationTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationInvalidLocationTest.groovy
@@ -1,0 +1,32 @@
+package org.eclipse.buildship.core
+
+import org.eclipse.core.runtime.IStatus
+
+import org.eclipse.buildship.core.internal.operation.ToolingApiStatus.ToolingApiStatusType
+import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
+
+class SynchronizationInvalidLocationTest extends ProjectSynchronizationSpecification {
+
+   def "Can import a nonexistent location"() {
+       setup:
+       File location = new File('nonexistent')
+
+       when:
+       SynchronizationResult result = tryImportAndWait(location)
+
+       then:
+       result.status.isOK()
+   }
+
+   def "Cannot import a plain file"() {
+       setup:
+       File location = file('nonexistent.file')
+
+       when:
+       SynchronizationResult result = tryImportAndWait(location)
+
+       then:
+       result.status.severity == IStatus.WARNING
+       ToolingApiStatusType.IMPORT_ROOT_DIR_FAILED.matches(result.status)
+   }
+}

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationProgressTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationProgressTest.groovy
@@ -1,0 +1,40 @@
+package org.eclipse.buildship.core
+
+import org.eclipse.core.runtime.IProgressMonitor
+
+import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
+
+class SynchronizationProgressTest extends ProjectSynchronizationSpecification {
+
+   def "Null monitor can be used when no progress is desired"() {
+       setup:
+       File location = dir('SynchronizationProgressTest')
+
+       when:
+       GradleBuild gradleBuild = gradleBuildFor(location)
+       SynchronizationResult result = gradleBuild.synchronize(null)
+
+       then:
+       result.status.isOK()
+
+       when:
+       gradleBuild = gradleBuildFor(findProject('SynchronizationProgressTest'))
+       result = gradleBuild.synchronize(null)
+
+       then:
+       result.status.isOK()
+   }
+
+   def "Progress reported to the monitor"() {
+       setup:
+       File location = dir('SynchronizationProgressTest')
+       GradleBuild gradleBuild = gradleBuildFor(location)
+       IProgressMonitor monitor = Mock(IProgressMonitor)
+
+       when:
+       gradleBuild.synchronize(monitor)
+
+       then:
+       (10.._) * monitor.internalWorked(_)
+   }
+}

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/marker/GradleErrorMarkerTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/marker/GradleErrorMarkerTest.groovy
@@ -19,10 +19,9 @@ class GradleErrorMarkerTest extends ProjectSynchronizationSpecification {
         when:
         File buildFile = new File(projectDir, 'build.gradle')
         buildFile.text = 'I_AM_ERROR'
-        synchronizeAndWait(projectDir)
+        trySynchronizeAndWait(projectDir)
 
         then:
-        thrown BuildException
         numOfGradleErrorMarkers == 1
     }
 
@@ -36,15 +35,14 @@ class GradleErrorMarkerTest extends ProjectSynchronizationSpecification {
         buildFile.text = 'I_AM_ERROR'
 
         when:
-        synchronizeAndWait(projectDir)
+        trySynchronizeAndWait(projectDir)
 
         then:
-        thrown BuildException
         numOfGradleErrorMarkers == 1
 
         when:
         buildFile.text = ''
-        synchronizeAndWait(projectDir)
+        trySynchronizeAndWait(projectDir)
 
         then:
         numOfGradleErrorMarkers == 0
@@ -66,22 +64,20 @@ class GradleErrorMarkerTest extends ProjectSynchronizationSpecification {
         buildFile2.text = 'I_AM_ERROR'
 
         when:
-        synchronizeAndWait(projectDir1)
+        trySynchronizeAndWait(projectDir1)
 
         then:
-        thrown BuildException
         numOfGradleErrorMarkers == 1
 
         when:
-        synchronizeAndWait(projectDir2)
+        trySynchronizeAndWait(projectDir2)
 
         then:
-        thrown BuildException
         numOfGradleErrorMarkers == 2
 
         when:
         buildFile1.text = ''
-        synchronizeAndWait(projectDir1)
+        trySynchronizeAndWait(projectDir1)
 
         then:
         numOfGradleErrorMarkers == 1
@@ -102,15 +98,14 @@ class GradleErrorMarkerTest extends ProjectSynchronizationSpecification {
         subBuildFile.text = 'I_AM_ERROR'
 
         when:
-        synchronizeAndWait(projectDir)
+        trySynchronizeAndWait(projectDir)
 
         then:
-        thrown BuildException
         numOfGradleErrorMarkers == 1
 
         when:
         settingsFile.text = ''
-        synchronizeAndWait(projectDir)
+        trySynchronizeAndWait(projectDir)
 
         then:
         findProject('sub')

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/test/fixtures/ProjectSynchronizationSpecification.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/test/fixtures/ProjectSynchronizationSpecification.groovy
@@ -1,12 +1,13 @@
 package org.eclipse.buildship.core.internal.test.fixtures
 
+import java.util.function.Supplier
+
 import com.google.common.base.Optional
 import com.google.common.base.Preconditions
 
 import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.IResource
 import org.eclipse.core.resources.IWorkspaceRunnable
-import org.eclipse.core.runtime.IStatus
 import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.core.runtime.jobs.Job
 
@@ -37,12 +38,12 @@ abstract class ProjectSynchronizationSpecification extends WorkspaceSpecificatio
 
     protected void synchronizeAndWait(File location) {
         SynchronizationResult result = trySynchronizeAndWait(location)
-        assert result.status.severity == IStatus.OK
+        assert result.status.isOK()
     }
 
     protected void synchronizeAndWait(IProject project) {
         SynchronizationResult result = trySynchronizeAndWait(project)
-        assert result.status.severity == IStatus.OK
+        assert result.status.isOK()
     }
 
     protected SynchronizationResult tryImportAndWait(File location, GradleDistribution gradleDistribution = GradleDistribution.fromBuild()) {
@@ -55,7 +56,7 @@ abstract class ProjectSynchronizationSpecification extends WorkspaceSpecificatio
 
     protected void importAndWait(File location, GradleDistribution gradleDistribution = GradleDistribution.fromBuild()) {
         SynchronizationResult result = tryImportAndWait(location, gradleDistribution)
-        assert result.status.severity == IStatus.OK
+        assert result.status.isOK()
     }
 
     protected static GradleBuild gradleBuildFor(File location, GradleDistribution gradleDistribution = GradleDistribution.fromBuild()) {
@@ -67,7 +68,7 @@ abstract class ProjectSynchronizationSpecification extends WorkspaceSpecificatio
     }
 
     protected static GradleBuild gradleBuildFor(IProject project) {
-        GradleCore.workspace.getBuild(project).get()
+        GradleCore.workspace.getBuild(project).orElseGet({ throw new RuntimeException("No Gradle build for $project") } as Supplier)
     }
     protected def waitForGradleJobsToFinish() {
         Job.jobManager.join(CorePlugin.GRADLE_JOB_FAMILY, null)

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/test/fixtures/ProjectSynchronizationSpecification.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/test/fixtures/ProjectSynchronizationSpecification.groovy
@@ -68,7 +68,7 @@ abstract class ProjectSynchronizationSpecification extends WorkspaceSpecificatio
     }
 
     protected static GradleBuild gradleBuildFor(IProject project) {
-        GradleCore.workspace.getBuild(project).orElseGet({ throw new RuntimeException("No Gradle build for $project") } as Supplier)
+        GradleCore.workspace.getBuild(project).orElseThrow({ new RuntimeException("No Gradle build for $project") })
     }
     protected def waitForGradleJobsToFinish() {
         Job.jobManager.join(CorePlugin.GRADLE_JOB_FAMILY, null)

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingBrokenProject.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingBrokenProject.groovy
@@ -23,10 +23,9 @@ class ImportingBrokenProject extends ProjectSynchronizationSpecification {
 
     def "can import the root project of a broken build"() {
         when:
-        boolean result = importAndWait(projectDir)
+        boolean result = tryImportAndWait(projectDir)
 
         then:
-        thrown(BuildException)
         findProject('broken-project')
         !findProject('sub')
     }
@@ -34,10 +33,9 @@ class ImportingBrokenProject extends ProjectSynchronizationSpecification {
     def "if the root project of a broken build is already part of the workspace then the Gradle nature is assigned to it"() {
         when:
         newProject('broken-project')
-        importAndWait(projectDir)
+        tryImportAndWait(projectDir)
 
         then:
-        thrown(BuildException)
         CorePlugin.workspaceOperations().allProjects.size() == 1
         GradleProjectNature.isPresentOn(findProject('broken-project'))
     }
@@ -50,19 +48,17 @@ class ImportingBrokenProject extends ProjectSynchronizationSpecification {
         }
 
         when:
-        importAndWait(projectDir)
+        tryImportAndWait(projectDir)
 
         then:
-        thrown(BuildException)
         findProject("broken-project_").location.toFile() == projectDir.canonicalFile
     }
 
     def "importing the root project of a broken build fails if the root dir is the workspace root"() {
         when:
-        importAndWait(getWorkspaceDir())
+        tryImportAndWait(getWorkspaceDir())
 
         then:
-        thrown(ImportRootProjectException)
         allProjects().empty
     }
 }

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingHierarchicalMultiProjectBuild.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingHierarchicalMultiProjectBuild.groovy
@@ -1,7 +1,10 @@
 package org.eclipse.buildship.core.internal.workspace
 
 import org.eclipse.core.resources.IProject
+import org.eclipse.core.runtime.IStatus
 import org.eclipse.core.runtime.Path
+
+import org.eclipse.buildship.core.SynchronizationResult
 import org.eclipse.buildship.core.internal.CorePlugin
 import org.eclipse.buildship.core.internal.Logger
 import org.eclipse.buildship.core.internal.configuration.GradleProjectNature

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingMultipleBuildsWithClashingNames.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingMultipleBuildsWithClashingNames.groovy
@@ -1,5 +1,8 @@
 package org.eclipse.buildship.core.internal.workspace
 
+import org.eclipse.core.runtime.IStatus
+
+import org.eclipse.buildship.core.SynchronizationResult
 import org.eclipse.buildship.core.internal.UnsupportedConfigurationException
 import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
 
@@ -12,10 +15,9 @@ class ImportingMultipleBuildsWithClashingNames extends ProjectSynchronizationSpe
 
         when:
         importAndWait(firstProject)
-        importAndWait(secondProject)
+        tryImportAndWait(secondProject)
 
         then:
-        thrown(UnsupportedConfigurationException)
         allProjects().size() == 2
         findProject('root')
         findProject('second')
@@ -44,9 +46,10 @@ class ImportingMultipleBuildsWithClashingNames extends ProjectSynchronizationSpe
         findProject('subsub')
 
         when:
-        importAndWait(secondProject)
+        SynchronizationResult result = tryImportAndWait(secondProject)
 
         then:
-        thrown(UnsupportedConfigurationException)
+        result.status.severity == IStatus.WARNING
+        result.status.exception instanceof UnsupportedConfigurationException
     }
 }

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingProjectInDefaultLocation.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingProjectInDefaultLocation.groovy
@@ -1,5 +1,8 @@
 package org.eclipse.buildship.core.internal.workspace
 
+import org.eclipse.core.runtime.IStatus
+
+import org.eclipse.buildship.core.SynchronizationResult
 import org.eclipse.buildship.core.internal.ImportRootProjectException
 import org.eclipse.buildship.core.internal.UnsupportedConfigurationException
 import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
@@ -22,10 +25,11 @@ class ImportingProjectInDefaultLocation extends ProjectSynchronizationSpecificat
         }
 
         when:
-        importAndWait(rootProject)
+        SynchronizationResult result = tryImportAndWait(rootProject)
 
         then:
-        thrown(UnsupportedConfigurationException)
+        result.status.severity == IStatus.WARNING
+        result.status.exception instanceof UnsupportedConfigurationException
     }
 
     def "Disallow synchornizing projects located in workspace folder and with custom root name"() {
@@ -35,18 +39,20 @@ class ImportingProjectInDefaultLocation extends ProjectSynchronizationSpecificat
 
         when:
         new File(rootProject, 'settings.gradle') << "rootProject.name = 'my-project-name-is-different-than-the-folder'"
-        importAndWait(rootProject)
+        SynchronizationResult result = tryImportAndWait(rootProject)
 
         then:
-        thrown(UnsupportedConfigurationException)
+        result.status.severity == IStatus.WARNING
+        result.status.exception instanceof UnsupportedConfigurationException
     }
 
     def "Disallow importing the workspace root"() {
         when:
-        importAndWait(workspaceDir)
+        SynchronizationResult result = tryImportAndWait(workspaceDir)
 
         then:
-        thrown(ImportRootProjectException)
+        result.status.severity == IStatus.WARNING
+        result.status.exception instanceof ImportRootProjectException
     }
 
     def "Disallow importing any modules located at the workspace root"() {
@@ -56,10 +62,11 @@ class ImportingProjectInDefaultLocation extends ProjectSynchronizationSpecificat
         }
 
         when:
-        importAndWait(workspaceDir)
+        SynchronizationResult result = tryImportAndWait(workspaceDir)
 
         then:
-        thrown(ImportRootProjectException)
+        result.status.severity == IStatus.WARNING
+        result.status.exception instanceof ImportRootProjectException
     }
 
 }

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingProjectWithCustomName.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingProjectWithCustomName.groovy
@@ -18,15 +18,16 @@ import org.gradle.tooling.model.gradle.GradleBuild
 import com.google.common.util.concurrent.FutureCallback
 
 import org.eclipse.core.resources.IProject
+import org.eclipse.core.runtime.IStatus
 import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.jdt.core.IJavaProject
 import org.eclipse.jdt.core.JavaCore
 
+import org.eclipse.buildship.core.SynchronizationResult
 import org.eclipse.buildship.core.internal.CorePlugin
 import org.eclipse.buildship.core.internal.UnsupportedConfigurationException
 import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
 import org.eclipse.buildship.core.internal.util.gradle.Pair
-import org.eclipse.buildship.core.internal.workspace.FetchStrategy
 
 class ImportingProjectWithCustomName extends ProjectSynchronizationSpecification {
 
@@ -64,10 +65,11 @@ class ImportingProjectWithCustomName extends ProjectSynchronizationSpecification
         }
 
         when:
-        importAndWait(location)
+        SynchronizationResult result = tryImportAndWait(location)
 
         then:
-        thrown(UnsupportedConfigurationException)
+        result.status.severity == IStatus.WARNING
+        result.status.exception instanceof UnsupportedConfigurationException
         findProject('app')
     }
 

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/MergingSynchronizeGradleBuildsJobs.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/MergingSynchronizeGradleBuildsJobs.groovy
@@ -79,11 +79,4 @@ class MergingSynchronizeGradleBuildsJobs extends ProjectSynchronizationSpecifica
         then:
         jobs.findAll { it.result != null }.size() == 2
     }
-
-    private def gradleBuildFor(File projectLocation) {
-        def buildConfiguration = BuildConfiguration.forRootProjectDirectory(projectLocation)
-                .overrideWorkspaceConfiguration(true)
-                .build()
-        GradleCore.workspace.createBuild(buildConfiguration)
-    }
 }

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/SynchronizingRenamedProject.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/SynchronizingRenamedProject.groovy
@@ -11,6 +11,7 @@
 
 package org.eclipse.buildship.core.internal.workspace
 
+import org.eclipse.buildship.core.SynchronizationResult
 import org.eclipse.buildship.core.internal.UnsupportedConfigurationException
 import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
 
@@ -43,10 +44,10 @@ class SynchronizingRenamedProject extends ProjectSynchronizationSpecification {
 
         when:
         renameInGradle(sample, "already-there")
-        synchronizeAndWait(sample)
+        SynchronizationResult result = trySynchronizeAndWait(sample)
 
         then:
-        thrown(UnsupportedConfigurationException)
+        result.status.exception instanceof UnsupportedConfigurationException
         findProject('already-there') == alreadyThere
     }
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/GradleBuild.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/GradleBuild.java
@@ -48,7 +48,7 @@ public interface GradleBuild {
      * The result of the synchronization - let it be a success or a failure - is described by the returned
      * {@link SynchronizationResult} instance.
      *
-     * @param monitor the monitor to report progress on
+     * @param monitor the monitor to report progress on, or {@code null} if progress reporting is not desired
      * @return the synchronization result
      */
     SynchronizationResult synchronize(IProgressMonitor monitor);

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/operation/ToolingApiStatus.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/operation/ToolingApiStatus.java
@@ -33,7 +33,7 @@ public final class ToolingApiStatus extends Status implements IStatus {
      */
     public static enum ToolingApiStatusType {
 
-        BUILD_CANCELLED(IStatus.CANCEL, "%s"),
+        BUILD_CANCELLED(IStatus.CANCEL, "%s cancelled."),
         IMPORT_ROOT_DIR_FAILED(IStatus.WARNING, "%s failed due to an error while importing the root project."),
         BUILD_FAILED(IStatus.WARNING, "%s failed due to an error in the referenced Gradle build."),
         CONNECTION_FAILED(IStatus.WARNING, "%s failed due to an error connecting to the Gradle build."),

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/operation/ToolingApiStatus.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/operation/ToolingApiStatus.java
@@ -33,7 +33,7 @@ public final class ToolingApiStatus extends Status implements IStatus {
      */
     public static enum ToolingApiStatusType {
 
-        BUILD_CANCELLED(IStatus.CANCEL, "%s cancelled."),
+        BUILD_CANCELLED(IStatus.CANCEL, "%s was cancelled."),
         IMPORT_ROOT_DIR_FAILED(IStatus.WARNING, "%s failed due to an error while importing the root project."),
         BUILD_FAILED(IStatus.WARNING, "%s failed due to an error in the referenced Gradle build."),
         CONNECTION_FAILED(IStatus.WARNING, "%s failed due to an error connecting to the Gradle build."),

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/ImportRootProjectOperation.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/ImportRootProjectOperation.java
@@ -20,6 +20,7 @@ import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.SubMonitor;
 
 import org.eclipse.buildship.core.internal.CorePlugin;
@@ -48,7 +49,7 @@ public final class ImportRootProjectOperation {
         try {
             runInWorkspace(monitor);
         } catch (Exception e) {
-            throw new ImportRootProjectException(e);
+            throw e instanceof OperationCanceledException ? (OperationCanceledException) e : new ImportRootProjectException(e);
         }
     }
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/SynchronizationJob.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/SynchronizationJob.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.runtime.jobs.Job;
 
 import org.eclipse.buildship.core.GradleBuild;
+import org.eclipse.buildship.core.SynchronizationResult;
 import org.eclipse.buildship.core.internal.CorePlugin;
 import org.eclipse.buildship.core.internal.DefaultGradleBuild;
 import org.eclipse.buildship.core.internal.operation.ToolingApiJob;
@@ -64,7 +65,10 @@ public final class SynchronizationJob extends ToolingApiJob<Void> {
             if (monitor.isCanceled()) {
                 throw new OperationCanceledException();
             }
-            ((DefaultGradleBuild)build).synchronize(SynchronizationJob.this.newProjectHandler, tokenSource, progress.newChild(1));
+            SynchronizationResult result = ((DefaultGradleBuild)build).synchronize(SynchronizationJob.this.newProjectHandler, tokenSource, progress.newChild(1));
+            if (result.getStatus().getException() instanceof Exception) {
+                throw (Exception) result.getStatus().getException();
+            }
         }
 
         return null;

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/internal/launch/TestLaunchShortcutValidatorTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/internal/launch/TestLaunchShortcutValidatorTest.groovy
@@ -14,14 +14,12 @@ class TestLaunchShortcutValidatorTest extends ProjectSynchronizationSpecificatio
         setup:
         importAndWait(projectWithSources, GradleDistribution.forVersion(gradleVersion))
 
-        expect:
-        numOfGradleErrorMarkers == 0
-
         when:
         IJavaProject project = findJavaProject('project-with-sources')
         IType type = project.findType('LibrarySpec')
 
         then:
+        type != null
         testLaunchShortcutEnabledOn(type)
 
         where:
@@ -32,14 +30,12 @@ class TestLaunchShortcutValidatorTest extends ProjectSynchronizationSpecificatio
         setup:
         importAndWait(projectWithSources, GradleDistribution.forVersion(gradleVersion))
 
-        expect:
-        numOfGradleErrorMarkers == 0
-
         when:
         IJavaProject project = findJavaProject('project-with-sources')
         IType type = project.findType('Library')
 
         then:
+        type != null
         !testLaunchShortcutEnabledOn(type)
 
         where:
@@ -50,14 +46,12 @@ class TestLaunchShortcutValidatorTest extends ProjectSynchronizationSpecificatio
         setup:
         importAndWait(projectWithSources)
 
-        expect:
-        numOfGradleErrorMarkers == 0
-
         when:
         IJavaProject project = findJavaProject('project-with-sources')
         IType type = project.findType('com.google.common.base.Predicate')
 
         then:
+        type != null
         !testLaunchShortcutEnabledOn(type)
     }
 

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/internal/wizard/project/ProjectImportWizardUiTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/internal/wizard/project/ProjectImportWizardUiTest.groovy
@@ -85,7 +85,7 @@ class ProjectImportWizardUiTest extends SwtBotSpecification {
     class FaultyWorkspaceOperations {
         @Delegate WorkspaceOperations delegate = CorePlugin.workspaceOperations()
 
-        void addNature(IProject project, String natureId, IProgressMonitor monitor) {
+        IProject createProject(String name, File location, List<String> natureIds, IProgressMonitor monitor) {
             throw new UnsupportedConfigurationException('test')
         }
     }


### PR DESCRIPTION
This PR adds the missing test coverage for the new synchronization API.

The existing tests are changed so that they check the outcome of the synchronization (i.e. I added assertions for `SynchronizationResult` in the base test class).

The production code has also changed a bit to get proper progress monitoring, cancellation, and concurrency handling