### PR TITLE
Introduce GradleBuild.withConnection()

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/GradleBuildConnectionProgressTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/GradleBuildConnectionProgressTest.groovy
@@ -1,0 +1,24 @@
+package org.eclipse.buildship.core
+
+import java.util.function.Function
+
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.model.GradleProject
+
+import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
+
+class GradleBuildConnectionProgressTest extends ProjectSynchronizationSpecification {
+
+    def "Null monitor can be used when no progress is desired"() {
+       setup:
+       File location = dir('GradleBuildConnectionProgressTest')
+
+       when:
+       GradleBuild gradleBuild = gradleBuildFor(location)
+       Function query = { ProjectConnection c -> c.model(GradleProject).get() }
+       GradleProject model = gradleBuild.withConnection(query, null)
+
+       then:
+       model
+    }
+}

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/GradleBuildConnectionTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/GradleBuildConnectionTest.groovy
@@ -1,0 +1,35 @@
+package org.eclipse.buildship.core
+
+import java.util.function.Function
+
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.model.GradleProject
+
+import org.eclipse.core.runtime.NullProgressMonitor
+
+import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
+
+class GradleBuildConnectionTest extends ProjectSynchronizationSpecification {
+
+    def "Cannot run null action"() {
+        when:
+        GradleBuild gradleBuild = gradleBuildFor(dir('GradleBuildConnectionTest'))
+        gradleBuild.withConnection(null, new NullProgressMonitor())
+
+        then:
+        thrown NullPointerException
+    }
+
+   def "Can query a model"() {
+       setup:
+       File location = dir('GradleBuildConnectionTest')
+
+       when:
+       GradleBuild gradleBuild = gradleBuildFor(location)
+       Function query = { ProjectConnection c -> c.model(GradleProject).get() }
+       GradleProject model = gradleBuild.withConnection(query, new NullProgressMonitor())
+
+       then:
+       model.projectDirectory == location.canonicalFile
+   }
+}

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/GradleBuild.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/GradleBuild.java
@@ -8,6 +8,10 @@
 
 package org.eclipse.buildship.core;
 
+import java.util.function.Function;
+
+import org.gradle.tooling.ProjectConnection;
+
 import org.eclipse.core.runtime.IProgressMonitor;
 
 /**
@@ -55,4 +59,21 @@ public interface GradleBuild {
      * @return the synchronization result
      */
     SynchronizationResult synchronize(IProgressMonitor monitor);
+
+    /**
+     * Executes an action in the Gradle runtime.
+     * <p>
+     * TODO (donat) explain how the action is executed (refer to Tooling API documentation)
+     * TODO (donat) explain common use-cases: task execution, test execution, and model loading
+     * TODO (donat) explain how the project connection is preconfigured: outputs and outputs to IDE console, progress and cancellation are wired to the monitor object
+     * TODO (donat) document exception handling
+     * TODO (donat) document scheduling rules
+     * TODO (donat) document how to load custom models (here or link to external documentation)
+     *
+     * @param action the action to execute
+     * @param monitor the monitor to report progress on, or {@code null} if progress reporting is not desired
+     * @return the result of the action
+     * @throws Exception when the action fails
+     */
+    <T> T withConnection(Function<ProjectConnection, ? extends T> action, IProgressMonitor monitor) throws Exception;
 }


### PR DESCRIPTION
This commit adds a basic API to access Gradle via Tooling API. The
implementation doesn't do anything special yet, as the configuration of
the operations will be done in subsequent stories.