### PR TITLE
Viewer filter performance optimization

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/navigator/BuildFolderViewerFilter.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/navigator/BuildFolderViewerFilter.java
@@ -10,9 +10,7 @@ package org.eclipse.buildship.ui.navigator;
 
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
 
@@ -26,22 +24,15 @@ import org.eclipse.buildship.core.preferences.PersistentModel;
  */
 public final class BuildFolderViewerFilter extends ViewerFilter {
 
-    @SuppressWarnings({"cast", "RedundantCast"})
     @Override
     public boolean select(Viewer viewer, Object parentElement, Object element) {
-        IResource resource = (IResource) Platform.getAdapterManager().getAdapter(element, IResource.class);
-        return resource == null || !isBuildFolder(resource);
-    }
-
-    private boolean isBuildFolder(IResource resource) {
-        if (resource instanceof IFolder) {
-            return isBuildFolderInPerstentModel((IFolder) resource);
-        } else {
-            return false;
+        if (element instanceof IFolder) {
+            return !isBuildFolderInPersistentModel((IFolder) element);
         }
+        return true;
     }
 
-    public static boolean isBuildFolderInPerstentModel(IFolder folder) {
+    public static boolean isBuildFolderInPersistentModel(IFolder folder) {
         try {
             IProject project = folder.getProject();
             PersistentModel model = CorePlugin.modelPersistence().loadModel(project);


### PR DESCRIPTION
Viewer filter performance is essential for the Common Navigator (i.e.
package explorer) to remain responsive. Therefore test for folders using
simple instanceof instead of Adapters, which can load and initialize a
huge amount of classes as side effect. In
https://bugs.eclipse.org/bugs/show_bug.cgi?id=539470 there is an
example, where this filter was currently evaluated while eclipse was not
responsive.

I cannot guarantee that this change fixes the mentioned performance
issue (since I cannot reproduce it locally), but it is definitely a
performance improvement.

Signed-off-by: Michael Keppler <Michael.Keppler@gmx.de>