### PR TITLE
Show warning on UI only for specific usecases

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/GradleDistributionGroup.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/GradleDistributionGroup.java
@@ -16,6 +16,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 
+import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.osgi.util.NLS;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
@@ -41,7 +42,6 @@ import org.eclipse.buildship.ui.internal.i18n.UiMessages;
 import org.eclipse.buildship.ui.internal.util.file.DirectoryDialogSelectionListener;
 import org.eclipse.buildship.ui.internal.util.font.FontUtils;
 import org.eclipse.buildship.ui.internal.util.gradle.GradleDistributionViewModel;
-import org.eclipse.buildship.ui.internal.util.layout.LayoutUtils;
 import org.eclipse.buildship.ui.internal.util.widget.UiBuilder.UiBuilderFactory;
 
 /**
@@ -88,7 +88,7 @@ public final class GradleDistributionGroup extends Group {
 
     private void createWidgets() {
         setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false));
-        setLayout(LayoutUtils.newGridLayout(4));
+        GridLayoutFactory.swtDefaults().numColumns(4).applyTo(this);
 
         this.font = FontUtils.getDefaultDialogFont();
         UiBuilderFactory uiBuilder = new UiBuilder.UiBuilderFactory(this.font);
@@ -115,6 +115,9 @@ public final class GradleDistributionGroup extends Group {
         if (this.gradleVersionCombo.getItemCount() > 0) {
             this.gradleVersionCombo.select(0);
         }
+
+        uiBuilder.span(this);
+        uiBuilder.span(this);
     }
 
     private void updateEnablement() {

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/GradleDistributionGroup.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/GradleDistributionGroup.java
@@ -133,7 +133,17 @@ public final class GradleDistributionGroup extends Group {
     }
 
     private void updateWarningVisibility() {
-        this.localInstallationWarningLabel.setVisible(getEnabled() && !this.localInstallationDirText.getText().isEmpty());
+        boolean warningIsVisible = this.localInstallationWarningLabel.getVisible();
+        boolean warningShouldBeVisible = getEnabled() && this.useLocalInstallationDirOption.getSelection();
+        if (warningIsVisible != warningShouldBeVisible) {
+            this.localInstallationWarningLabel.setVisible(warningShouldBeVisible);
+            Object layoutData = this.localInstallationWarningLabel.getLayoutData();
+            if (layoutData instanceof GridData) {
+                GridData gridData = (GridData) layoutData;
+                gridData.widthHint = warningShouldBeVisible ? SWT.DEFAULT : 0;
+                requestLayout();
+            }
+        }
     }
 
     public GradleDistributionViewModel getDistribution() {

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/GradleDistributionGroup.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/GradleDistributionGroup.java
@@ -128,6 +128,12 @@ public final class GradleDistributionGroup extends Group {
         this.localInstallationDirBrowseButton.setEnabled(groupEnabled && this.useLocalInstallationDirOption.getSelection());
         this.remoteDistributionUriText.setEnabled(groupEnabled && this.useRemoteDistributionUriOption.getSelection());
         this.gradleVersionCombo.setEnabled(groupEnabled && this.useGradleVersionOption.getSelection());
+
+        updateWarningVisibility();
+    }
+
+    private void updateWarningVisibility() {
+        this.localInstallationWarningLabel.setVisible(getEnabled() && !this.localInstallationDirText.getText().isEmpty());
     }
 
     public GradleDistributionViewModel getDistribution() {
@@ -224,6 +230,8 @@ public final class GradleDistributionGroup extends Group {
         this.useLocalInstallationDirOption.addSelectionListener(listener);
         this.useRemoteDistributionUriOption.addSelectionListener(listener);
         this.useGradleVersionOption.addSelectionListener(listener);
+
+        this.localInstallationDirText.addModifyListener(l -> updateWarningVisibility());
     }
 
     public void addDistributionChangedListener(DistributionChangedListener listener) {

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/GradleUserHomeGroup.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/GradleUserHomeGroup.java
@@ -63,8 +63,8 @@ public final class GradleUserHomeGroup extends Group {
     }
 
     private void addListeners() {
-        this.gradleUserHomeBrowseButton
-                .addSelectionListener(new DirectoryDialogSelectionListener(this.getShell(), this.gradleUserHomeText, CoreMessages.Preference_Label_GradleUserHome));
+        this.gradleUserHomeText.addModifyListener(l -> updateWarningVisibility());
+        this.gradleUserHomeBrowseButton.addSelectionListener(new DirectoryDialogSelectionListener(this.getShell(), this.gradleUserHomeText, CoreMessages.Preference_Label_GradleUserHome));
     }
 
     public Text getGradleUserHomeText() {
@@ -86,6 +86,11 @@ public final class GradleUserHomeGroup extends Group {
         boolean groupEnabled = getEnabled();
         this.gradleUserHomeText.setEnabled(groupEnabled);
         this.gradleUserHomeBrowseButton.setEnabled(groupEnabled);
+        updateWarningVisibility();
+    }
+
+    private void updateWarningVisibility() {
+        this.warningLabel.setVisible(getEnabled() && !this.gradleUserHomeText.getText().isEmpty());
     }
 
     public File getGradleUserHome() {

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/GradleUserHomeGroup.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/GradleUserHomeGroup.java
@@ -90,7 +90,17 @@ public final class GradleUserHomeGroup extends Group {
     }
 
     private void updateWarningVisibility() {
-        this.warningLabel.setVisible(getEnabled() && !this.gradleUserHomeText.getText().isEmpty());
+        boolean warningIsVisible = this.warningLabel.getVisible();
+        boolean warningShouldBeVisible = getEnabled() && !this.gradleUserHomeText.getText().isEmpty();
+        if (warningIsVisible != warningShouldBeVisible) {
+            this.warningLabel.setVisible(warningShouldBeVisible);
+            Object layoutData = this.warningLabel.getLayoutData();
+            if (layoutData instanceof GridData) {
+                GridData gridData = (GridData) layoutData;
+                gridData.widthHint = warningShouldBeVisible ? SWT.DEFAULT : 0;
+                requestLayout();
+            }
+        }
     }
 
     public File getGradleUserHome() {

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/UiBuilder.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/widget/UiBuilder.java
@@ -174,7 +174,7 @@ public final class UiBuilder<T extends Control> {
          * @return the builder
          */
         public UiBuilder<Label> newLabel(Composite parent) {
-            UiBuilder<Label> builder = new UiBuilder<Label>(new Label(parent, SWT.NONE));
+            UiBuilder<Label> builder = new UiBuilder<>(new Label(parent, SWT.NONE));
             init(builder);
             return builder;
         }
@@ -186,7 +186,7 @@ public final class UiBuilder<T extends Control> {
          * @return the builder
          */
         public UiBuilder<Text> newText(Composite parent) {
-            UiBuilder<Text> builder = new UiBuilder<Text>(new Text(parent, SWT.BORDER));
+            UiBuilder<Text> builder = new UiBuilder<>(new Text(parent, SWT.BORDER));
             init(builder);
             return builder;
         }
@@ -198,7 +198,7 @@ public final class UiBuilder<T extends Control> {
          * @return the builder
          */
         public UiBuilder<Button> newButton(Composite parent) {
-            UiBuilder<Button> builder = new UiBuilder<Button>(new Button(parent, SWT.PUSH));
+            UiBuilder<Button> builder = new UiBuilder<>(new Button(parent, SWT.PUSH));
             init(builder);
             return builder;
         }
@@ -211,7 +211,7 @@ public final class UiBuilder<T extends Control> {
          * @return the builder
          */
         public UiBuilder<Button> newRadio(Composite parent) {
-            UiBuilder<Button> builder = new UiBuilder<Button>(new Button(parent, SWT.RADIO));
+            UiBuilder<Button> builder = new UiBuilder<>(new Button(parent, SWT.RADIO));
             init(builder);
             return builder;
         }
@@ -224,7 +224,7 @@ public final class UiBuilder<T extends Control> {
          * @return the builder
          */
         public UiBuilder<Button> newCheckbox(Composite parent) {
-            UiBuilder<Button> builder = new UiBuilder<Button>(new Button(parent, SWT.CHECK));
+            UiBuilder<Button> builder = new UiBuilder<>(new Button(parent, SWT.CHECK));
             init(builder);
             return builder;
         }
@@ -236,7 +236,7 @@ public final class UiBuilder<T extends Control> {
          * @return the builder
          */
         public UiBuilder<Combo> newCombo(Composite parent) {
-            UiBuilder<Combo> builder = new UiBuilder<Combo>(new Combo(parent, SWT.NONE));
+            UiBuilder<Combo> builder = new UiBuilder<>(new Combo(parent, SWT.NONE));
             init(builder);
             return builder;
         }
@@ -248,7 +248,7 @@ public final class UiBuilder<T extends Control> {
          * @return the builder
          */
         public UiBuilder<Tree> newTree(Composite parent) {
-            UiBuilder<Tree> builder = new UiBuilder<Tree>(new Tree(parent, SWT.NONE));
+            UiBuilder<Tree> builder = new UiBuilder<>(new Tree(parent, SWT.NONE));
             init(builder);
             return builder;
         }
@@ -260,7 +260,7 @@ public final class UiBuilder<T extends Control> {
          * @return the builder
          */
         public UiBuilder<Group> newGroup(Composite parent) {
-            UiBuilder<Group> builder = new UiBuilder<Group>(new Group(parent, SWT.NONE));
+            UiBuilder<Group> builder = new UiBuilder<>(new Group(parent, SWT.NONE));
             init(builder);
             return builder;
         }
@@ -272,9 +272,11 @@ public final class UiBuilder<T extends Control> {
          * @param parent the control having the {@link org.eclipse.swt.layout.GridLayout} having the next column to be empty
          */
         public void span(Composite parent) {
-            Button b = new Button(parent, SWT.NONE);
-            init(b);
-            b.setVisible(false);
+            Label label = new Label(parent, SWT.NONE);
+            GridData data = new GridData(0, 0);
+            label.setLayoutData(data);
+            init(label);
+            label.setVisible(false);
         }
 
         private void init(UiBuilder<?> builder) {


### PR DESCRIPTION
The new layout without warnings: 

<img width="616" alt="screen shot 2018-11-20 at 15 52 04" src="https://user-images.githubusercontent.com/419883/48782682-01641b00-ecdf-11e8-8926-d84968deed7a.png">

And with warnings:

<img width="614" alt="screen shot 2018-11-20 at 15 52 36" src="https://user-images.githubusercontent.com/419883/48782700-0de87380-ecdf-11e8-8090-26fdf7a21250.png">

The widgets are dynamically resized when the warning icon appears and disappears.