### PR TITLE
Allowed refresh gradle project with shortcut key

### DIFF
--- a/org.eclipse.buildship.ui/plugin.xml
+++ b/org.eclipse.buildship.ui/plugin.xml
@@ -254,6 +254,12 @@
     <extension
           point="org.eclipse.ui.bindings">
        <key
+             commandId="org.eclipse.buildship.ui.commands.refreshproject"
+             contextId="org.eclipse.ui.contexts.window"
+             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+             sequence="M1+F5">
+       </key>
+       <key
              commandId="org.eclipse.buildship.ui.commands.refreshtaskview"
              contextId="org.eclipse.buildship.ui.contexts.taskview"
              schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"


### PR DESCRIPTION
As a high frequency action when developing gradle projects. It would be better if we have default shortcut key.