### PR TITLE
Don't fail if root project is closed during synchronization

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/ImportRootProjectOperation.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/ImportRootProjectOperation.java
@@ -96,6 +96,10 @@ public final class ImportRootProjectOperation {
 
         if (projectOrNull.isPresent()) {
             IProject project = projectOrNull.get();
+            if (!project.isAccessible()) {
+                return;
+            }
+
             project.refreshLocal(IResource.DEPTH_INFINITE, progress.newChild(1));
             CorePlugin.workspaceOperations().addNature(project, GradleProjectNature.ID, progress.newChild(1));
             this.newProjectHandler.afterProjectImported(project);


### PR DESCRIPTION
Currently, the project import fails if the root project is in the workspace and it's closed. This is a regression compared to Buildship 2.x where this use-case worked correctly. This PR changes `ImportRootProjectOperation` operation to skip the changes that require an accessible project. The project preferences are still persisted correctly as they fall back to raw file modifications.