### PR TITLE
Fix dark theme for preferences UI

### DIFF
--- a/org.eclipse.buildship.ui/css/dark-theme.css
+++ b/org.eclipse.buildship.ui/css/dark-theme.css
@@ -1,4 +1,4 @@
-GradleProjectSettingsComposite, GradleDistributionGroup, GradleUserHomeGroup {
+GradleProjectSettingsComposite, GradleDistributionGroup, AdvancedOptionsGroup {
     background-color:#515658;
     color:#eeeeee;
 }


### PR DESCRIPTION
After adding UI for all Gradle configuration options we forgot to
adjust the class names in the dark theme css file.

Resolves https://github.com/eclipse/buildship/issues/858