### PR TITLE
Use package import for SLF4J

### DIFF
--- a/org.eclipse.buildship.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.core/META-INF/MANIFEST.MF
@@ -16,11 +16,11 @@ Require-Bundle: org.eclipse.core.expressions,
  org.eclipse.jdt.junit.core,
  org.eclipse.jdt.launching,
  org.eclipse.debug.core,
- org.slf4j.api;bundle-version="1.7.2",
  org.gradle.toolingapi;bundle-version="[5.4.0,5.5.0)";visibility:=reexport,
  com.google.guava;bundle-version="[21.0.0,22.0.0)",
  com.google.gson;bundle-version="[2.7.0,3.0.0)"
 Bundle-ActivationPolicy: lazy
+Import-Package: org.slf4j;version="1.7.2"
 Export-Package: org.eclipse.buildship.core,
  org.eclipse.buildship.core.internal;x-friends:="org.eclipse.buildship.ui,org.eclipse.buildship.kotlin",
  org.eclipse.buildship.core.internal.configuration;x-friends:="org.eclipse.buildship.ui,org.eclipse.buildship.kotlin",

--- a/org.eclipse.buildship.core/build.gradle
+++ b/org.eclipse.buildship.core/build.gradle
@@ -5,3 +5,7 @@ tasks.processResources.doFirst {
     def buildshipRunimeProperties = file('src/main/resources/org/eclipse/buildship/core/internal/gradle/buildship-runtime.properties')
     buildshipRunimeProperties.text = "ToolingApiVersion=$toolingApiVersion"
 }
+
+dependencies {
+    compile 'org.slf4j:slf4j-api:1.7.2'
+}

--- a/org.eclipse.buildship.kotlin/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.kotlin/META-INF/MANIFEST.MF
@@ -13,8 +13,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,
  org.eclipse.jdt.core,
  org.eclipse.buildship.core,
- org.slf4j.api;bundle-version="1.7.2",
  org.jetbrains.kotlin.bundled-compiler;bundle-version="[0.8.5,0.9.0)",
  org.jetbrains.kotlin.core;bundle-version="[0.8.5,0.9.0)",
  com.google.guava;bundle-version="[21.0.0,22.0.0)",
-  org.gradle.toolingapi;bundle-version="[5.4.0,5.5.0)"
+ org.gradle.toolingapi;bundle-version="[5.4.0,5.5.0)"
+Import-Package: org.slf4j;version="1.7.2"

--- a/org.eclipse.buildship.kotlin/build.gradle
+++ b/org.eclipse.buildship.kotlin/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: eclipsebuild.BundlePlugin
 
-dependencies { compile 'org.gradle:gradle-kotlin-dsl-tooling-models:+' }
+dependencies {
+    compile 'org.gradle:gradle-kotlin-dsl-tooling-models:+'
+    compile 'org.slf4j:slf4j-api:1.7.2'
+}
 
 task updateKotlinModelJar(type: Copy) {
     into '.'

--- a/org.gradle.toolingapi/META-INF/MANIFEST.MF
+++ b/org.gradle.toolingapi/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-Vendor: Gradle Inc.
 Bundle-SymbolicName: org.gradle.toolingapi
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.slf4j.api;bundle-version="1.7.2"
+Import-Package: org.slf4j;version="1.7.2"
 Export-Package: org.gradle.api;version="5.4.0",
  org.gradle.cli;version="5.4.0",
  org.gradle.scripts;version="5.4.0",

--- a/org.gradle.toolingapi/resources/template/manifest-template.txt
+++ b/org.gradle.toolingapi/resources/template/manifest-template.txt
@@ -5,4 +5,4 @@ Bundle-Vendor: Gradle Inc.
 Bundle-SymbolicName: org.gradle.toolingapi
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Require-Bundle: org.slf4j.api;bundle-version="1.7.2"
+Import-Package: org.slf4j;version="1.7.2"


### PR DESCRIPTION
Having an explicit dependency to the `org.slf4j.api` bundle can be restricting as it might pull in the dependency if slf4j is packaged in a different way (see the [corresponding m2e bug](https://bugs.eclipse.org/bugs/show_bug.cgi?id=506473)).  To leverage that, this PR replaces the bundle dependency with a package import.

Our build scripts are not prepared for resolving this type of dependencies so I added an explicit dependency to the `build.gradle` files.