### PR TITLE
Always populate Executions view when it's opened

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/workbench/WorkbenchUtils.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/workbench/WorkbenchUtils.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.buildship.ui.internal.util.workbench;
 
+import java.util.Optional;
+
 import org.eclipse.ui.IViewPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
@@ -47,4 +49,13 @@ public final class WorkbenchUtils {
         }
     }
 
+    /**
+     * Returns the view with the given ID.
+     */
+    public static <T extends IViewPart> Optional<T> findView(String viewId) {
+        IWorkbenchWindow activeWorkbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+        @SuppressWarnings("unchecked")
+        T result = (T) activeWorkbenchWindow.getActivePage().findView(viewId);
+        return Optional.ofNullable(result);
+    }
 }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/execution/ExecutionShowingLaunchRequestListener.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/execution/ExecutionShowingLaunchRequestListener.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.buildship.ui.internal.view.execution;
 
+import java.util.Optional;
+
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 
@@ -39,20 +41,20 @@ public final class ExecutionShowingLaunchRequestListener implements EventListene
     }
 
     private void handleLaunchRequest(final ExecuteLaunchRequestEvent event) {
-        // call synchronously to make sure we do not miss any progress events
-        if (event.getProcessDescription().getRunConfig().isShowExecutionView()) {
+            // call synchronously to make sure we do not miss any progress events
             PlatformUI.getWorkbench().getDisplay().syncExec(new Runnable() {
 
                 @Override
                 public void run() {
-                    ProcessDescription processDescription = event.getProcessDescription();
-
-                    ExecutionsView view = WorkbenchUtils.showView(ExecutionsView.ID, null, IWorkbenchPage.VIEW_ACTIVATE);
-
-                    // show the launched build in a new page of the Executions View
-                    view.addExecutionPage(processDescription, event.getOperation());
+                    Optional<ExecutionsView> view = event.getProcessDescription().getRunConfig().isShowExecutionView() ?
+                        Optional.of(WorkbenchUtils.showView(ExecutionsView.ID, null, IWorkbenchPage.VIEW_ACTIVATE)) :
+                        WorkbenchUtils.findView(ExecutionsView.ID);
+                    if (view.isPresent()) {
+                        // show the launched build in a new page of the Executions View
+                        ProcessDescription processDescription = event.getProcessDescription();
+                        view.get().addExecutionPage(processDescription, event.getOperation());
+                    }
                 }
             });
-        }
     }
 }


### PR DESCRIPTION
Before this commit the executions view was only populated when the
`Show executions view` preference was enabled. This was not correct
as the preference should only make the view visible on each Gradle
invocation. The correct behavior is to populate the view on each
incocation when visible on the UI.