### PR TITLE
Fix broken import when project already defines Gradle classpath conta…

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerInitializerTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerInitializerTest.groovy
@@ -1,0 +1,57 @@
+package org.eclipse.buildship.core.internal.workspace
+
+import org.gradle.tooling.model.eclipse.EclipseExternalDependency
+import org.gradle.tooling.model.eclipse.EclipseProject
+import org.gradle.tooling.model.eclipse.EclipseProjectDependency
+import spock.lang.Issue
+
+import org.eclipse.core.resources.IResource
+import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.core.runtime.Path
+import org.eclipse.core.runtime.jobs.IJobChangeEvent
+import org.eclipse.core.runtime.jobs.Job
+import org.eclipse.core.runtime.jobs.JobChangeAdapter
+import org.eclipse.jdt.core.IClasspathEntry
+import org.eclipse.jdt.core.IJavaProject
+import org.eclipse.jdt.core.JavaCore
+
+import org.eclipse.buildship.core.GradleDistribution
+import org.eclipse.buildship.core.internal.CorePlugin
+import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
+import org.eclipse.buildship.core.internal.test.fixtures.WorkspaceSpecification
+import org.eclipse.buildship.core.internal.util.gradle.HierarchicalElementUtils
+import org.eclipse.buildship.core.internal.util.gradle.ModelUtils
+import org.eclipse.buildship.core.internal.workspace.GradleClasspathContainer
+import org.eclipse.buildship.core.internal.workspace.GradleClasspathContainerUpdater
+import org.eclipse.buildship.core.internal.workspace.PersistentModelBuilder
+
+class GradleClasspathContainerInitializerTest extends ProjectSynchronizationSpecification {
+
+
+    @Issue('https://github.com/eclipse/buildship/issues/893')
+    def "Gradle classpath container initializer should not schedule another synchronization with different import properties"() {
+        given:
+        def location = dir("gradle-cp-container-init-test") {
+            file "build.gradle", """
+                plugins {
+                    id 'java-library'
+                }
+
+                repositories.jcenter()
+
+                dependencies {
+                    compile 'com.google.guava:guava:21.0'
+                }
+            """
+        }
+        importAndWait(location, GradleDistribution.forVersion('5.4'))
+        findProject(location.name).delete(false, true, new NullProgressMonitor())
+
+
+        when:
+        importAndWait(location, GradleDistribution.forVersion('5.3'))
+
+        then:
+        CorePlugin.configurationManager().loadBuildConfiguration(location).gradleDistribution == GradleDistribution.forVersion('5.3')
+    }
+}


### PR DESCRIPTION
…iner

GradleBuild has a static map keeping tabs on the currently running
synchronization, where the map keys are the GradleBuild instances.
Consequently, calling isSynchronizing() will return true even though a
synchronization is already running with different attributes.

This problem occurs in the following use-case:
- The project being imported already contains the Gradle classpath
  container
- During the import, the user specifies custom import settings.
If the classpath container is present, its initializer tries to check
if the Gradle build is already synchronizing before scheduling a
synchronization. The initializer, however, reads the import properties
from the disk which defaults to inheriting workspace defaults.

The fix the issue, the running synchronization operations are tracked
by the root project location.