### PR TITLE
Compare canonical paths instead of File objects in some failing tests

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
@@ -62,7 +62,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
 
         then:
         resolvedClasspath[0].entryKind == IClasspathEntry.CPE_LIBRARY
-        resolvedClasspath[0].path.toFile() == dir("foo")
+        resolvedClasspath[0].path.toFile().canonicalPath.equals(dir("foo").canonicalPath)
     }
 
     def "Linked files can be added to the classpath"(String path) {

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/LinkedResourcesUpdaterTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/LinkedResourcesUpdaterTest.groovy
@@ -30,7 +30,7 @@ class LinkedResourcesUpdaterTest extends WorkspaceSpecification {
         linkedresources.size() == 1
         linkedresources[0].name == 'another'
         linkedresources[0].exists()
-        linkedresources[0].location.toFile().equals(externalDir)
+        linkedresources[0].location.toFile().canonicalPath.equals(externalDir.canonicalPath)
     }
 
     def "Can define a linked resource even if the resource does not exist"() {
@@ -48,7 +48,7 @@ class LinkedResourcesUpdaterTest extends WorkspaceSpecification {
             linkedResources.size() == 1
             linkedResources[0].name == 'another'
             linkedResources[0].exists()
-            linkedResources[0].location.toFile().equals(externalDir)
+            linkedResources[0].location.toFile().canonicalPath.equals(externalDir.canonicalPath)
     }
 
     def "Defining a linked resource is idempotent"() {
@@ -137,7 +137,7 @@ class LinkedResourcesUpdaterTest extends WorkspaceSpecification {
         linkedResources.size() == 1
         linkedResources[0].name == 'another2'
         linkedResources[0].exists()
-        linkedResources[0].location.toFile().equals(externalDirB)
+        linkedResources[0].location.toFile().canonicalPath.equals(externalDirB.canonicalPath)
 
         where:
         linkName << ['another', 'a/b/c']


### PR DESCRIPTION
Related to discussion in https://discuss.gradle.org/t/buildship-development-failing-unit-tests-in-master/32536/9, this branch changes some tests to compare canonical paths, rather than file objects.