### PR TITLE
Use "test" classpath attribute to separate main and test classpath

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/gradle/MissingFeaturesTest.java
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/gradle/MissingFeaturesTest.java
@@ -49,14 +49,14 @@ public class MissingFeaturesTest {
     public void someLimitationWhenUsingFinalVersionOf26() {
         MissingFeatures missingFeatures = new MissingFeatures(GradleVersion.version("2.6"));
         List<Pair<GradleVersion, String>> details = missingFeatures.getMissingFeatures();
-        assertEquals(details.size(), 10);
+        assertEquals(details.size(), 15);
     }
 
     @Test
     public void someLimitationWhenUsingSnapshotVersionOf26() {
         MissingFeatures missingFeatures = new MissingFeatures(GradleVersion.version("2.6-20150101053008+0000"));
         List<Pair<GradleVersion, String>> details = missingFeatures.getMissingFeatures();
-        assertEquals(details.size(), 10);
+        assertEquals(details.size(), 15);
     }
 
 }

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/launch/GradleClasspathProviderUpdateTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/launch/GradleClasspathProviderUpdateTest.groovy
@@ -1,14 +1,19 @@
 package org.eclipse.buildship.core.internal.launch
 
+import spock.lang.IgnoreIf
+import spock.lang.Requires
+
 import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.debug.core.ILaunchConfiguration
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy
 import org.eclipse.jdt.core.IJavaProject
 import org.eclipse.jdt.launching.IJavaLaunchConfigurationConstants
 
+import org.eclipse.buildship.core.GradleDistribution
 import org.eclipse.buildship.core.internal.CorePlugin
 import org.eclipse.buildship.core.internal.configuration.GradleProjectNature
 import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
+import org.eclipse.buildship.core.internal.util.eclipse.PlatformUtils
 
 class GradleClasspathProviderUpdateTest extends ProjectSynchronizationSpecification {
 
@@ -22,7 +27,8 @@ class GradleClasspathProviderUpdateTest extends ProjectSynchronizationSpecificat
         launchConfiguration = launchConfigWorkingCopy.doSave()
     }
 
-    def "Gradle classpath provider added when referenced project is a new Java project"() {
+    @Requires({ PlatformUtils.supportsTestAttributes() })
+    def "Classpath provider not used if Eclipse version supporting test attributes"() {
         setup:
         File projectDir = dir('project-name') {
             file 'build.gradle', "apply plugin: 'java'"
@@ -32,10 +38,23 @@ class GradleClasspathProviderUpdateTest extends ProjectSynchronizationSpecificat
         importAndWait(projectDir)
 
         then:
+        !hasGradleClasspathProvider(launchConfiguration)
+    }
+
+    def "Classpath provider added when referenced project is a new Java project"() {
+        setup:
+        File projectDir = dir('project-name') {
+            file 'build.gradle', "apply plugin: 'java'"
+        }
+
+        when:
+        importAndWait(projectDir, GradleDistribution.forVersion("5.5"))
+
+        then:
         hasGradleClasspathProvider(launchConfiguration)
     }
 
-    def "Gradle classpath provider not added for new non-Java project"() {
+    def "Classpath provider not added for new non-Java project"() {
         setup:
         File projectDir = dir('project-name')
 
@@ -46,7 +65,8 @@ class GradleClasspathProviderUpdateTest extends ProjectSynchronizationSpecificat
         !hasGradleClasspathProvider(launchConfiguration)
     }
 
-    def "Gradle classpath provider injected when Gradle project is moved under target name"() {
+    @IgnoreIf({ PlatformUtils.supportsTestAttributes() })
+    def "Gradle classpath provider injected when project is moved under target name"() {
         setup:
         File settingsFile
         File projectDir = dir('root-project') {
@@ -70,7 +90,33 @@ class GradleClasspathProviderUpdateTest extends ProjectSynchronizationSpecificat
         hasGradleClasspathProvider(launchConfiguration)
     }
 
-    def "Gradle classpath provider removed when project deleted"() {
+    def "Classpath provider injected when project using old Gradle version is moved under target name"() {
+        setup:
+        File settingsFile
+        File projectDir = dir('root-project') {
+             settingsFile = file 'settings.gradle', 'include "old-name"'
+             file 'build.gradle', 'allprojects { apply plugin: "java" }'
+             dir('old-name')
+             dir('project-name')
+        }
+        importAndWait(projectDir, GradleDistribution.forVersion("5.5"))
+
+        expect:
+        findProject('old-name')
+        !hasGradleClasspathProvider(launchConfiguration)
+
+
+        when:
+        settingsFile.text = 'include "project-name"'
+        synchronizeAndWait(projectDir)
+
+        then:
+        hasGradleClasspathProvider(launchConfiguration)
+    }
+
+
+    @IgnoreIf({ PlatformUtils.supportsTestAttributes() })
+    def "Classpath provider removed when project deleted"() {
         setup:
         File projectDir = dir('project-name') {
             file 'build.gradle', "apply plugin: 'java'"
@@ -87,7 +133,24 @@ class GradleClasspathProviderUpdateTest extends ProjectSynchronizationSpecificat
         !hasGradleClasspathProvider(launchConfiguration)
     }
 
-    def "Gradle classpath provider added when Gradle nature added"() {
+    def "Classpath provider removed when project using old Gradle version deleted"() {
+        setup:
+        File projectDir = dir('project-name') {
+            file 'build.gradle', "apply plugin: 'java'"
+        }
+        importAndWait(projectDir,  GradleDistribution.forVersion("5.5"))
+
+        expect:
+        hasGradleClasspathProvider(launchConfiguration)
+
+        when:
+        findProject('project-name').delete(false, new NullProgressMonitor())
+
+        then:
+        !hasGradleClasspathProvider(launchConfiguration)
+    }
+
+    def "Classpath provider added when Gradle nature added"() {
         setup:
         IJavaProject javaProject = newJavaProject('project-name')
 
@@ -101,7 +164,8 @@ class GradleClasspathProviderUpdateTest extends ProjectSynchronizationSpecificat
         hasGradleClasspathProvider(launchConfiguration)
     }
 
-    def "Gradle classpath provider removed when Gradle nature removed"() {
+    @IgnoreIf({ PlatformUtils.supportsTestAttributes() })
+    def "Classpath provider removed when Gradle nature removed"() {
         setup:
         File projectDir = dir('project-name') {
             file 'build.gradle', "apply plugin: 'java'"
@@ -118,11 +182,28 @@ class GradleClasspathProviderUpdateTest extends ProjectSynchronizationSpecificat
         !hasGradleClasspathProvider(launchConfiguration)
     }
 
+    def "Classpath provider removed when Gradle nature removed from project using Old Gradle version"() {
+        setup:
+        File projectDir = dir('project-name') {
+            file 'build.gradle', "apply plugin: 'java'"
+        }
+        importAndWait(projectDir, GradleDistribution.forVersion("5.5"))
+
+        expect:
+        hasGradleClasspathProvider(launchConfiguration)
+
+        when:
+        CorePlugin.workspaceOperations().removeNature(findProject('project-name'), GradleProjectNature.ID, new NullProgressMonitor())
+
+        then:
+        !hasGradleClasspathProvider(launchConfiguration)
+    }
+
     private boolean hasGradleClasspathProvider(ILaunchConfiguration configuration) {
         getClasspathProvider(configuration) == GradleClasspathProvider.ID
     }
 
     private String getClasspathProvider(ILaunchConfiguration configuration) {
-        configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_CLASSPATH_PROVIDER, (String)null)
+        configuration.getAttribute(IJavaLaunchConfigurationConstants.ATTR_CLASSPATH_PROVIDER, (String) null)
     }
 }

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/preferences/DefaultModelPersistenceTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/preferences/DefaultModelPersistenceTest.groovy
@@ -9,6 +9,8 @@ import org.eclipse.jdt.core.JavaCore
 
 import org.eclipse.buildship.core.internal.CorePlugin
 import org.eclipse.buildship.core.internal.test.fixtures.WorkspaceSpecification
+import org.eclipse.buildship.core.internal.util.gradle.GradleVersion
+import org.eclipse.buildship.core.internal.util.gradle.GradleVersionTest
 
 class DefaultModelPersistenceTest extends WorkspaceSpecification {
 
@@ -53,8 +55,9 @@ class DefaultModelPersistenceTest extends WorkspaceSpecification {
         command.setBuilderName('custom-command')
         def managedBuilders = [command]
         def hasAutoBuildTasks = true
+        def gradleVersion = GradleVersion.version('5.6')
 
-        PersistentModel model = new DefaultPersistentModel(project, buildDir, buildScriptPath, subProjectPaths, classpath, derivedResources, linkedResources, managedNatures, managedBuilders, hasAutoBuildTasks)
+        PersistentModel model = new DefaultPersistentModel(project, buildDir, buildScriptPath, subProjectPaths, classpath, derivedResources, linkedResources, managedNatures, managedBuilders, hasAutoBuildTasks, gradleVersion)
 
         when:
         CorePlugin.modelPersistence().saveModel(model)
@@ -83,8 +86,9 @@ class DefaultModelPersistenceTest extends WorkspaceSpecification {
         command.setBuilderName('custom-command')
         def managedBuilders = [command]
         def hasAutoBuildTasks = false
+        def gradleVersion = GradleVersion.version('5.6')
 
-        PersistentModel model = new DefaultPersistentModel(project, buildDir, buildScriptPath, subProjectPaths, classpath, derivedResources, linkedResources, managedNatures, managedBuilders, hasAutoBuildTasks)
+        PersistentModel model = new DefaultPersistentModel(project, buildDir, buildScriptPath, subProjectPaths, classpath, derivedResources, linkedResources, managedNatures, managedBuilders, hasAutoBuildTasks, gradleVersion)
         CorePlugin.modelPersistence().saveModel(model)
 
         when:
@@ -108,8 +112,9 @@ class DefaultModelPersistenceTest extends WorkspaceSpecification {
         command.setBuilderName('custom-command')
         def managedBuilders = [command]
         def hasAutoBuildTasks = true
+        def gradleVersion = GradleVersion.version('5.6')
 
-        PersistentModel model = new DefaultPersistentModel(project, buildDir, buildScriptPath, subProjectPaths, classpath, derivedResources, linkedResources, managedNatures, managedBuilders, hasAutoBuildTasks)
+        PersistentModel model = new DefaultPersistentModel(project, buildDir, buildScriptPath, subProjectPaths, classpath, derivedResources, linkedResources, managedNatures, managedBuilders, hasAutoBuildTasks, gradleVersion)
         CorePlugin.modelPersistence().saveModel(model)
 
         when:

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/preferences/DefaultModelPersistenceTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/preferences/DefaultModelPersistenceTest.groovy
@@ -55,7 +55,7 @@ class DefaultModelPersistenceTest extends WorkspaceSpecification {
         command.setBuilderName('custom-command')
         def managedBuilders = [command]
         def hasAutoBuildTasks = true
-        def gradleVersion = GradleVersion.version('5.6')
+        def gradleVersion = GradleVersion.current()
 
         PersistentModel model = new DefaultPersistentModel(project, buildDir, buildScriptPath, subProjectPaths, classpath, derivedResources, linkedResources, managedNatures, managedBuilders, hasAutoBuildTasks, gradleVersion)
 

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/test/fixtures/WorkspaceSpecification.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/test/fixtures/WorkspaceSpecification.groovy
@@ -42,6 +42,7 @@ import org.eclipse.buildship.core.internal.launch.GradleRunConfigurationDelegate
 import org.eclipse.buildship.core.internal.marker.GradleErrorMarker
 import org.eclipse.buildship.core.internal.preferences.DefaultPersistentModel
 import org.eclipse.buildship.core.internal.preferences.PersistentModel
+import org.eclipse.buildship.core.internal.util.gradle.GradleVersion
 import org.eclipse.buildship.core.GradleDistribution
 import org.eclipse.buildship.core.internal.workspace.PersistentModelBuilder
 import org.eclipse.buildship.core.internal.workspace.WorkspaceOperations
@@ -208,11 +209,11 @@ abstract class WorkspaceSpecification extends Specification {
     }
 
     protected PersistentModelBuilder persistentModelBuilder(IProject project) {
-        new PersistentModelBuilder(emptyPersistentModel(project))
+        new PersistentModelBuilder(samplePersistentModel(project))
     }
 
-    protected PersistentModel emptyPersistentModel(IProject project) {
-        new DefaultPersistentModel(project, new Path("build"), new Path("build.gradle"), [], [], [], [], [], [], false)
+    protected PersistentModel samplePersistentModel(IProject project) {
+        new DefaultPersistentModel(project, new Path("build"), new Path("build.gradle"), [], [], [], [], [], [], false, GradleVersion.version('5.6'))
     }
 
     protected ILaunchConfigurationWorkingCopy createLaunchConfig(String id, String name = 'launch-config') {

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/PersistentModelBuilderTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/PersistentModelBuilderTest.groovy
@@ -6,6 +6,7 @@ import org.eclipse.jdt.core.JavaCore
 
 import org.eclipse.buildship.core.internal.preferences.DefaultPersistentModel
 import org.eclipse.buildship.core.internal.test.fixtures.WorkspaceSpecification
+import org.eclipse.buildship.core.internal.util.gradle.GradleVersion
 import org.eclipse.buildship.core.internal.workspace.PersistentModelBuilder
 
 class PersistentModelBuilderTest extends WorkspaceSpecification {
@@ -29,8 +30,9 @@ class PersistentModelBuilderTest extends WorkspaceSpecification {
         command.setBuilderName('custom-command')
         def managedBuilders = [command]
         def hasAutoBuildTasks = true
+        def gradleVersion = GradleVersion.version('5.6')
 
-        def previous = new DefaultPersistentModel(project, buildDir, buildScriptPath, subProjectPaths, classpath, derivedResources, linkedResources, managedNatures, managedBuilders, hasAutoBuildTasks)
+        def previous = new DefaultPersistentModel(project, buildDir, buildScriptPath, subProjectPaths, classpath, derivedResources, linkedResources, managedNatures, managedBuilders, hasAutoBuildTasks, gradleVersion)
         def model = new PersistentModelBuilder(previous).build()
 
         expect:
@@ -43,6 +45,7 @@ class PersistentModelBuilderTest extends WorkspaceSpecification {
         model.linkedResources == linkedResources
         model.managedNatures == managedNatures
         model.managedBuilders == managedBuilders
+        model.gradleVersion == gradleVersion
     }
 
 
@@ -59,8 +62,9 @@ class PersistentModelBuilderTest extends WorkspaceSpecification {
         command.setBuilderName('custom-command')
         def managedBuilders = [command]
         def hasAutoBuildTasks = false
+        def gradleVersion = GradleVersion.version('5.6')
 
-        def previous = new DefaultPersistentModel(project, buildDir, buildScriptPath, subProjectPaths, classpath, derivedResources, linkedResources, managedNatures, managedBuilders, hasAutoBuildTasks)
+        def previous = new DefaultPersistentModel(project, buildDir, buildScriptPath, subProjectPaths, classpath, derivedResources, linkedResources, managedNatures, managedBuilders, hasAutoBuildTasks, gradleVersion)
         def builder = new PersistentModelBuilder(previous)
         builder."${method}"(null)
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/GradleArguments.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/GradleArguments.java
@@ -137,10 +137,7 @@ public final class GradleArguments {
     }
 
     private static String buildScanArgumentFor(BuildEnvironment environment) {
-        GradleVersion currentVersion = GradleVersion.version(environment.getGradle().getGradleVersion());
-        GradleVersion supportsDashDashScanVersion = GradleVersion.version("3.5");
-
-        if (supportsDashDashScanVersion.compareTo(currentVersion) <= 0) {
+        if (GradleVersion.version(environment.getGradle().getGradleVersion()).supportsDashDashScan()) {
             return "--scan";
         } else {
             return "-Dscan";

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/gradle/MissingFeatures.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/gradle/MissingFeatures.java
@@ -41,6 +41,11 @@ public final class MissingFeatures {
         addIfNeeded("2.14", "WTP deployment attributes defined for web projects", missingFeatures);
         addIfNeeded("3.0", "Output location, classpath containers, source folder excludes-includes and JRE name are set on Java projects", missingFeatures);
         addIfNeeded("3.0", "Java classpath customization done in 'eclipse.classpath.file.whenMerged' is synchronized", missingFeatures);
+        addIfNeeded("3.3", "Support for composite builds", missingFeatures);
+        addIfNeeded("5.4", "Run tasks upon synchronization", missingFeatures);
+        addIfNeeded("5.5", "Import projects with overlapping names", missingFeatures);
+        addIfNeeded("5.6", "Receive compile-time error when referencing test source in main source set", missingFeatures);
+        addIfNeeded("5.6", "Substitute closed project references with their publications", missingFeatures);
         return missingFeatures.build();
     }
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/preferences/AbsentPersistentModel.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/preferences/AbsentPersistentModel.java
@@ -18,6 +18,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathEntry;
 
+import org.eclipse.buildship.core.internal.util.gradle.GradleVersion;
+
 /**
  * Marker PersistentModel implementation for missing models.
  *
@@ -83,6 +85,11 @@ final class AbsentPersistentModel implements PersistentModel {
 
     @Override
     public boolean hasAutoBuildTasks() {
+        throw new IllegalStateException("Absent persistent model");
+    }
+
+    @Override
+    public GradleVersion getGradleVersion() {
         throw new IllegalStateException("Absent persistent model");
     }
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/preferences/DefaultPersistentModel.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/preferences/DefaultPersistentModel.java
@@ -20,6 +20,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathEntry;
 
+import org.eclipse.buildship.core.internal.util.gradle.GradleVersion;
+
 /**
  * Default PersistentModel implementation.
  *
@@ -37,12 +39,13 @@ public final class DefaultPersistentModel implements PersistentModel {
     private final List<String> managedNatures;
     private final List<ICommand> managedBuilders;
     private final boolean hasAutoBuildTasks;
+    private final GradleVersion gradleVersion;
 
     public DefaultPersistentModel(IProject project, IPath buildDir, IPath buildScriptPath,
                                   Collection<IPath> subprojectPaths, List<IClasspathEntry> classpath,
                                   Collection<IPath> derivedResources, Collection<IPath> linkedResources,
                                   Collection<String> managedNatures, Collection<ICommand> managedBuilders,
-                                  boolean hasAutoBuildTasks) {
+                                  boolean hasAutoBuildTasks, GradleVersion gradleVersion) {
         this.project = Preconditions.checkNotNull(project);
         this.buildDir = Preconditions.checkNotNull(buildDir);
         this.buildScriptPath = Preconditions.checkNotNull(buildScriptPath);
@@ -53,6 +56,7 @@ public final class DefaultPersistentModel implements PersistentModel {
         this.managedNatures = ImmutableList.copyOf(managedNatures);
         this.managedBuilders = ImmutableList.copyOf(managedBuilders);
         this.hasAutoBuildTasks = hasAutoBuildTasks;
+        this.gradleVersion = gradleVersion;
     }
 
     @Override
@@ -111,6 +115,11 @@ public final class DefaultPersistentModel implements PersistentModel {
     }
 
     @Override
+    public GradleVersion getGradleVersion() {
+        return this.gradleVersion;
+    }
+
+    @Override
     public boolean equals(final Object obj) {
         if (!(obj instanceof DefaultPersistentModel)) {
             return false;
@@ -124,12 +133,13 @@ public final class DefaultPersistentModel implements PersistentModel {
                 && Objects.equal(this.linkedResources, that.linkedResources)
                 && Objects.equal(this.managedNatures, that.managedNatures)
                 && Objects.equal(this.managedBuilders, that.managedBuilders)
-                && Objects.equal(this.hasAutoBuildTasks, that.hasAutoBuildTasks);
+                && Objects.equal(this.hasAutoBuildTasks, that.hasAutoBuildTasks)
+                && Objects.equal(this.gradleVersion, that.gradleVersion);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.project, this.buildDir, this.subprojectPaths, this.classpath, this.derivedResources, this.linkedResources, this.managedNatures, this.managedBuilders, this.hasAutoBuildTasks);
+        return Objects.hashCode(this.project, this.buildDir, this.subprojectPaths, this.classpath, this.derivedResources, this.linkedResources, this.managedNatures, this.managedBuilders, this.hasAutoBuildTasks, this.gradleVersion);
     }
 
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/preferences/PersistentModel.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/preferences/PersistentModel.java
@@ -16,6 +16,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathEntry;
 
+import org.eclipse.buildship.core.internal.util.gradle.GradleVersion;
+
 /**
  * Contract how to read Gradle model elements stored in the workspace plugin state area.
  *
@@ -43,4 +45,6 @@ public interface PersistentModel {
     List<ICommand> getManagedBuilders();
 
     boolean hasAutoBuildTasks();
+
+    GradleVersion getGradleVersion();
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/eclipse/PlatformUtils.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/eclipse/PlatformUtils.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019 the original author or authors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.eclipse.buildship.core.internal.util.eclipse;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Version;
+
+import org.eclipse.core.runtime.Platform;
+
+/**
+ * Provides convenience calculations related to the Eclipse platform.
+ */
+public class PlatformUtils {
+    public static boolean supportsTestAttributes() {
+        Bundle platformBundle = Platform.getBundle("org.eclipse.platform");
+        if (platformBundle == null) {
+            return false;
+        }
+        Version platform = platformBundle.getVersion();
+        Version eclipseLuna = new Version(4, 8, 0);
+        return platform.compareTo(eclipseLuna) >= 0;
+    }
+}

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/gradle/GradleVersion.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/gradle/GradleVersion.java
@@ -8,6 +8,10 @@
 
 package org.eclipse.buildship.core.internal.util.gradle;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Properties;
@@ -16,11 +20,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.eclipse.buildship.core.internal.GradlePluginsRuntimeException;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.net.URLConnection;
 
 /**
  * Represents a released version of Gradle
@@ -232,6 +231,30 @@ public final class GradleVersion implements Comparable<GradleVersion> {
 
     public boolean isValid() {
         return this.versionPart != null;
+    }
+
+    public boolean supportsCompositeBuilds() {
+        return getBaseVersion().compareTo(GradleVersion.version("3.3")) >= 0;
+    }
+
+    public boolean supportsDashDashScan() {
+        return getBaseVersion().compareTo(GradleVersion.version("3.5")) >= 0;
+    }
+
+    public boolean supportsSyncTasksInEclipsePluginConfig() {
+        return getBaseVersion().compareTo(GradleVersion.version("5.4")) >= 0;
+    }
+
+    public boolean supportsSendingReservedProjects() {
+        return getBaseVersion().compareTo(GradleVersion.version("5.5")) >= 0;
+    }
+
+    public boolean supportsTestAttributes() {
+        return getBaseVersion().compareTo(GradleVersion.version("5.6")) >= 0;
+    }
+
+    public boolean supportsClosedProjectDependencySubstitution() {
+        return getBaseVersion().compareTo(GradleVersion.version("5.6")) >= 0;
     }
 
     /**

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/DefaultModelProvider.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/DefaultModelProvider.java
@@ -57,7 +57,7 @@ public final class DefaultModelProvider implements ModelProvider {
             DefaultModelProvider.this.gradleBuild.withConnection(connection -> {
                 BuildEnvironment buildEnvironment = connection.getModel(BuildEnvironment.class);
                 GradleVersion gradleVersion = GradleVersion.version(buildEnvironment.getGradle().getGradleVersion());
-                if (supportsCompositeBuilds(gradleVersion)) {
+                if (gradleVersion.supportsCompositeBuilds()) {
                     return queryCompositeModel(model, connection);
                 } else {
                     return ImmutableList.of(queryModel(model, connection));
@@ -103,9 +103,6 @@ public final class DefaultModelProvider implements ModelProvider {
                 throw new GradlePluginsRuntimeException(e);
             }
         }
-    }
-    private static boolean supportsCompositeBuilds(GradleVersion gradleVersion) {
-        return gradleVersion.getBaseVersion().compareTo(GradleVersion.version("3.3")) >= 0;
     }
 
     private static <T> Collection<T> queryCompositeModel(Class<T> model, ProjectConnection connection) {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/EclipseModelUtils.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/EclipseModelUtils.java
@@ -43,9 +43,9 @@ public final class EclipseModelUtils {
     public static Collection<EclipseProject> queryModels(ProjectConnection connection) {
         BuildEnvironment buildEnvironment = connection.getModel(BuildEnvironment.class);
         GradleVersion gradleVersion = GradleVersion.version(buildEnvironment.getGradle().getGradleVersion());
-        if (supportsSendingReservedProjects(gradleVersion)) {
+        if (gradleVersion.supportsSendingReservedProjects()) {
             return queryCompositeModelWithRuntimInfo(connection, gradleVersion);
-        } else if (supportsCompositeBuilds(gradleVersion)) {
+        } else if (gradleVersion.supportsCompositeBuilds()) {
             return queryCompositeModel(EclipseProject.class, connection);
         } else {
             return ImmutableList.of(queryModel(EclipseProject.class, connection));
@@ -55,11 +55,11 @@ public final class EclipseModelUtils {
     public static Collection<EclipseProject> runTasksAndQueryModels(ProjectConnection connection) {
         BuildEnvironment buildEnvironment = connection.getModel(BuildEnvironment.class);
         GradleVersion gradleVersion = GradleVersion.version(buildEnvironment.getGradle().getGradleVersion());
-        if (supportsSendingReservedProjects(gradleVersion)) {
+        if (gradleVersion.supportsSendingReservedProjects()) {
             return runTasksAndQueryCompositeModelWithRuntimInfo(connection, gradleVersion);
-        } else if (supportsSyncTasksInEclipsePluginConfig(gradleVersion)) {
+        } else if (gradleVersion.supportsSyncTasksInEclipsePluginConfig()) {
             return runTasksAndQueryCompositeModel(connection, gradleVersion);
-        } else if (supportsCompositeBuilds(gradleVersion)) {
+        } else if (gradleVersion.supportsCompositeBuilds()) {
             return queryCompositeModel(EclipseProject.class, connection);
         } else {
             return ImmutableList.of(queryModel(EclipseProject.class, connection));
@@ -73,27 +73,12 @@ public final class EclipseModelUtils {
         return new EclipseRuntimeConfigurer(new DefaultEclipseWorkspace(ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile(), projects));
     }
 
-    private static boolean supportsClosedProjectDependencySubstitution(GradleVersion gradleVersion) {
-        return gradleVersion.getBaseVersion().compareTo(GradleVersion.version("5.6")) >= 0;
-    }
-
-    private static boolean supportsSendingReservedProjects(GradleVersion gradleVersion) {
-        return gradleVersion.getBaseVersion().compareTo(GradleVersion.version("5.5")) >= 0;
-    }
-
-    private static boolean supportsSyncTasksInEclipsePluginConfig(GradleVersion gradleVersion) {
-        return gradleVersion.getBaseVersion().compareTo(GradleVersion.version("5.4")) >= 0;
-    }
-
-    private static boolean supportsCompositeBuilds(GradleVersion gradleVersion) {
-        return gradleVersion.getBaseVersion().compareTo(GradleVersion.version("3.3")) >= 0;
-    }
 
     private static Collection<EclipseProject> runTasksAndQueryCompositeModelWithRuntimInfo(ProjectConnection connection, GradleVersion gradleVersion) {
         EclipseRuntimeConfigurer buildEclipseRuntimeConfigurer = buildEclipseRuntimeConfigurer();
         try {
             BuildAction<Void> runSyncTasksAction = IdeFriendlyClassLoading.loadClass(TellGradleToRunSynchronizationTasks.class);
-            if (supportsClosedProjectDependencySubstitution(gradleVersion)) {
+            if (gradleVersion.supportsClosedProjectDependencySubstitution()) {
                 // use a composite query to run substitute tasks in included builds too
                 BuildAction<?> runClosedProjectTasksAction = new CompositeModelQuery<>(RunClosedProjectBuildDependencies.class, EclipseRuntime.class, buildEclipseRuntimeConfigurer);
                 BuildActionSequence projectsLoadedAction = new BuildActionSequence(runSyncTasksAction, runClosedProjectTasksAction);

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
@@ -159,7 +159,7 @@ public final class GradleClasspathContainerRuntimeClasspathEntryResolver impleme
 
     private boolean hasTestAttribute(IClasspathEntry entry) {
         for (IClasspathAttribute a : entry.getExtraAttributes()) {
-            if ("test".equals(a.getName()) && "true".equals(a.getValue())) {
+            if ("test".equals(a.getName()) && Boolean.valueOf(a.getValue())) {
                 return true;
             }
         }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
@@ -8,6 +8,7 @@
 
 package org.eclipse.buildship.core.internal.workspace;
 
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 
@@ -18,6 +19,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
@@ -27,8 +29,12 @@ import org.eclipse.jdt.launching.IRuntimeClasspathEntryResolver;
 import org.eclipse.jdt.launching.IVMInstall;
 import org.eclipse.jdt.launching.JavaRuntime;
 
+import org.eclipse.buildship.core.internal.CorePlugin;
+import org.eclipse.buildship.core.internal.GradlePluginsRuntimeException;
 import org.eclipse.buildship.core.internal.launch.GradleClasspathProvider;
 import org.eclipse.buildship.core.internal.launch.LaunchConfigurationScope;
+import org.eclipse.buildship.core.internal.preferences.PersistentModel;
+import org.eclipse.buildship.core.internal.util.eclipse.PlatformUtils;
 
 /**
  * {@link IRuntimeClasspathEntryResolver} implementation to resolve Gradle classpath container
@@ -44,36 +50,56 @@ public final class GradleClasspathContainerRuntimeClasspathEntryResolver impleme
             return new IRuntimeClasspathEntry[0];
         }
         LaunchConfigurationScope configurationScopes = LaunchConfigurationScope.from(configuration);
-        return resolveRuntimeClasspathEntry(entry, entry.getJavaProject(), configurationScopes);
+        // IJavaLaunchConfigurationConstants.ATTR_EXCLUDE_TEST_CODE not available in Eclipse 4.3
+        boolean excludeTestCode = configuration.getAttribute("org.eclipse.jdt.launching.ATTR_EXCLUDE_TEST_CODE", false);
+        return resolveRuntimeClasspathEntry(entry, entry.getJavaProject(), configurationScopes, excludeTestCode);
     }
 
     @Override
     public IRuntimeClasspathEntry[] resolveRuntimeClasspathEntry(IRuntimeClasspathEntry entry, IJavaProject project) throws CoreException {
-        return resolveRuntimeClasspathEntry(entry, project, LaunchConfigurationScope.INCLUDE_ALL);
+        return resolveRuntimeClasspathEntry(entry, project, LaunchConfigurationScope.INCLUDE_ALL, false);
     }
 
-    private IRuntimeClasspathEntry[] resolveRuntimeClasspathEntry(IRuntimeClasspathEntry entry, IJavaProject project, LaunchConfigurationScope configurationScopes) throws CoreException {
+    // @Override commented out as this method doesn't exist older Eclipse versions
+    public IRuntimeClasspathEntry[] resolveRuntimeClasspathEntry(IRuntimeClasspathEntry entry, IJavaProject project, boolean excludeTestCode) throws CoreException {
+        return resolveRuntimeClasspathEntry(entry, project, LaunchConfigurationScope.INCLUDE_ALL, excludeTestCode);
+    }
+
+    private IRuntimeClasspathEntry[] resolveRuntimeClasspathEntry(IRuntimeClasspathEntry entry, IJavaProject project, LaunchConfigurationScope configurationScopes,
+            boolean excludeTestCode) throws CoreException {
         if (entry.getType() != IRuntimeClasspathEntry.CONTAINER || !entry.getPath().equals(GradleClasspathContainer.CONTAINER_PATH)) {
             return new IRuntimeClasspathEntry[0];
         }
-        return collectContainerRuntimeClasspathIfPresent(project, configurationScopes);
-    }
 
-    private IRuntimeClasspathEntry[] collectContainerRuntimeClasspathIfPresent(IJavaProject project, LaunchConfigurationScope configurationScopes) throws CoreException {
-        List<IRuntimeClasspathEntry> result = Lists.newArrayList();
-        collectContainerRuntimeClasspathIfPresent(project, result, false, configurationScopes);
-        return result.toArray(new IRuntimeClasspathEntry[result.size()]);
-    }
+        PersistentModel model = CorePlugin.modelPersistence().loadModel(project.getProject());
+        if (!model.isPresent()) {
+            throw new GradlePluginsRuntimeException("Model not available for " + project.getProject().getName());
+        }
 
-    private void collectContainerRuntimeClasspathIfPresent(IJavaProject project, List<IRuntimeClasspathEntry> result, boolean includeExportedEntriesOnly,
-            LaunchConfigurationScope configurationScopes) throws CoreException {
-        IClasspathContainer container = JavaCore.getClasspathContainer(GradleClasspathContainer.CONTAINER_PATH, project);
-        if (container != null) {
-            collectContainerRuntimeClasspath(container, result, includeExportedEntriesOnly, configurationScopes);
+        // Eclipse 4.3 (Kepler) doesn't support test attributes, so for that case we fall back to custom scope attributes
+        if (model.getGradleVersion().supportsTestAttributes() && PlatformUtils.supportsTestAttributes()) {
+            return runtimeClasspathWithTestSources(project, excludeTestCode);
+        } else {
+            return runtimeClasspathWithGradleScopes(project, configurationScopes, excludeTestCode);
         }
     }
 
-    private void collectContainerRuntimeClasspath(IClasspathContainer container, List<IRuntimeClasspathEntry> result, boolean includeExportedEntriesOnly,
+    private IRuntimeClasspathEntry[] runtimeClasspathWithGradleScopes(IJavaProject project, LaunchConfigurationScope configurationScopes, boolean excludeTestCode)
+            throws CoreException {
+        List<IRuntimeClasspathEntry> result = Lists.newArrayList();
+        collectContainerRuntimeClasspathWithGradleScopes(project, result, false, configurationScopes);
+        return result.toArray(new IRuntimeClasspathEntry[result.size()]);
+    }
+
+    private void collectContainerRuntimeClasspathWithGradleScopes(IJavaProject project, List<IRuntimeClasspathEntry> result, boolean includeExportedEntriesOnly,
+            LaunchConfigurationScope configurationScopes) throws CoreException {
+        IClasspathContainer container = JavaCore.getClasspathContainer(GradleClasspathContainer.CONTAINER_PATH, project);
+        if (container != null) {
+            collectContainerRuntimeClasspathWithGradleScopes(container, result, includeExportedEntriesOnly, configurationScopes);
+        }
+    }
+
+    private void collectContainerRuntimeClasspathWithGradleScopes(IClasspathContainer container, List<IRuntimeClasspathEntry> result, boolean includeExportedEntriesOnly,
             LaunchConfigurationScope configurationScopes) throws CoreException {
         for (final IClasspathEntry cpe : container.getClasspathEntries()) {
             if (!includeExportedEntriesOnly || cpe.isExported()) {
@@ -84,15 +110,60 @@ public final class GradleClasspathContainerRuntimeClasspathEntryResolver impleme
                     if (candidate.isPresent()) {
                         IJavaProject dependencyProject = JavaCore.create(candidate.get());
                         IRuntimeClasspathEntry projectRuntimeEntry = JavaRuntime.newProjectRuntimeClasspathEntry(dependencyProject);
-                        // add the project entry itself so that the source lookup can find the classes
-                        // see https://github.com/eclipse/buildship/issues/383
+                        // add the project entry itself so that the source lookup can find the
+                        // classes. See https://github.com/eclipse/buildship/issues/383
                         result.add(projectRuntimeEntry);
                         Collections.addAll(result, GradleClasspathProvider.resolveOutputLocations(projectRuntimeEntry, dependencyProject, configurationScopes));
-                        collectContainerRuntimeClasspathIfPresent(dependencyProject, result, true, configurationScopes);
+                        collectContainerRuntimeClasspathWithGradleScopes(dependencyProject, result, true, configurationScopes);
                     }
                 }
             }
         }
+    }
+
+    private IRuntimeClasspathEntry[] runtimeClasspathWithTestSources(IJavaProject project, boolean excludeTestCode) throws CoreException {
+        List<IRuntimeClasspathEntry> result = Lists.newArrayList();
+
+        IClasspathContainer container = JavaCore.getClasspathContainer(GradleClasspathContainer.CONTAINER_PATH, project);
+        if (container == null) {
+            return new IRuntimeClasspathEntry[0];
+        }
+
+        for (final IClasspathEntry cpe : container.getClasspathEntries()) {
+            if (cpe.getEntryKind() == IClasspathEntry.CPE_LIBRARY && !(excludeTestCode && hasTestAttribute(cpe))) {
+                result.add(JavaRuntime.newArchiveRuntimeClasspathEntry(cpe.getPath()));
+            } else if (cpe.getEntryKind() == IClasspathEntry.CPE_PROJECT) {
+                Optional<IProject> candidate = findAccessibleJavaProject(cpe.getPath().segment(0));
+                if (candidate.isPresent()) {
+                    IJavaProject dependencyProject = JavaCore.create(candidate.get());
+                    IRuntimeClasspathEntry projectRuntimeEntry = JavaRuntime.newProjectRuntimeClasspathEntry(dependencyProject);
+                    // add the project entry itself so that the source lookup can find the classes
+                    // see https://github.com/eclipse/buildship/issues/383
+                    result.add(projectRuntimeEntry);
+                    Collections.addAll(result, invokeJavaRuntimeResolveRuntimeClasspathEntry(projectRuntimeEntry, dependencyProject, excludeTestCode));
+                }
+            }
+        }
+        return result.toArray(new IRuntimeClasspathEntry[result.size()]);
+    }
+
+    private static IRuntimeClasspathEntry[] invokeJavaRuntimeResolveRuntimeClasspathEntry(IRuntimeClasspathEntry projectRuntimeEntry, IJavaProject dependencyProject, boolean excludeTestCode) throws CoreException{
+        // JavaRuntime.resolveRuntimeClasspathEntry is available since Eclipse 4.8
+        try {
+            Method method = JavaRuntime.class.getMethod("resolveRuntimeClasspathEntry", IRuntimeClasspathEntry.class, IJavaProject.class, boolean.class);
+            return (IRuntimeClasspathEntry[]) method.invoke(null, projectRuntimeEntry, dependencyProject, excludeTestCode);
+        } catch (Exception e) {
+            throw new GradlePluginsRuntimeException("JavaRuntime.resolveRuntimeClasspathEntry() should not be called when Buildship is installed for Eclipse 4.8", e);
+        }
+    }
+
+    private boolean hasTestAttribute(IClasspathEntry entry) {
+        for (IClasspathAttribute a : entry.getExtraAttributes()) {
+            if ("test".equals(a.getName()) && "true".equals(a.getValue())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static Optional<IProject> findAccessibleJavaProject(String name) {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/PersistentModelBuilder.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/PersistentModelBuilder.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.core.IClasspathEntry;
 
 import org.eclipse.buildship.core.internal.preferences.DefaultPersistentModel;
 import org.eclipse.buildship.core.internal.preferences.PersistentModel;
+import org.eclipse.buildship.core.internal.util.gradle.GradleVersion;
 
 /**
  * Builder for {@link PersistentModel}.
@@ -38,6 +39,7 @@ public final class PersistentModelBuilder {
     private Collection<String> managedNatures;
     private Collection<ICommand> managedBuilders;
     private boolean hasAutoBuildTasks;
+    private GradleVersion gradleVersion;
 
     public PersistentModelBuilder(PersistentModel previous) {
         this.previous = Preconditions.checkNotNull(previous);
@@ -50,6 +52,7 @@ public final class PersistentModelBuilder {
             this.linkedResources = previous.getLinkedResources();
             this.managedNatures = previous.getManagedNatures();
             this.managedBuilders = previous.getManagedBuilders();
+            this.gradleVersion = previous.getGradleVersion();
         }
     }
 
@@ -98,11 +101,16 @@ public final class PersistentModelBuilder {
         return this;
     }
 
+    public PersistentModelBuilder gradleVersion(GradleVersion gradleVersion) {
+        this.gradleVersion = gradleVersion;
+        return this;
+    }
+
     public PersistentModel getPrevious() {
         return this.previous;
     }
 
     public PersistentModel build() {
-        return new DefaultPersistentModel(this.previous.getProject(), this.buildDir, this.buildScriptPath, this.subprojectPaths, this.classpath, this.derivedResources, this.linkedResources, this.managedNatures, this.managedBuilders, this.hasAutoBuildTasks);
+        return new DefaultPersistentModel(this.previous.getProject(), this.buildDir, this.buildScriptPath, this.subprojectPaths, this.classpath, this.derivedResources, this.linkedResources, this.managedNatures, this.managedBuilders, this.hasAutoBuildTasks, this.gradleVersion);
     }
 }

--- a/org.eclipse.buildship.core/src/main/resources/org/eclipse/buildship/core/internal/gradle/buildship-runtime.properties
+++ b/org.eclipse.buildship.core/src/main/resources/org/eclipse/buildship/core/internal/gradle/buildship-runtime.properties
@@ -1,1 +1,1 @@
-ToolingApiVersion=5.6-20190530145458+0000
+ToolingApiVersion=5.6-rc-1


### PR DESCRIPTION
This PR makes use of Eclipse's new test sources feature. Since Gradle 5.6, the `EclipseProject` model [contains](https://github.com/gradle/gradle/pull/9484) the `test` classpath attribute on all source folders and dependencies that belong to a test configuration. 

Gradle 5.6 still [provides](https://github.com/gradle/gradle/pull/9789) the custom scope information, which is used by previous Buildship releases. Buildship falls back to that information if an older Gradle version is being used or if the Host Eclipse version doesn't support test sources (< [4.8](https://www.eclipse.org/eclipse/news/4.8/jdt.php#jdt-test-sources)).

### Testing the feature

1. Install the Eclipse installer: go to https://www.eclipse.org/downloads/ and click the `Download 64` button and proceed with the installer installation.
2. Provision the Buildship IDE
  - Open the Eclipse installer
  - Select `Advanced mode...` in the menu in the top-right corner

<img width="858" alt="Screenshot 2019-07-31 at 14 27 50" src="https://user-images.githubusercontent.com/419883/62214328-20a26480-b3a5-11e9-9777-6839450e9108.png">

  - On the product page select Eclipse IDE for Eclipse Committers and change the product version to the latest release

<img width="820" alt="Screenshot 2019-07-31 at 14 30 09" src="https://user-images.githubusercontent.com/419883/62214378-3dd73300-b3a5-11e9-9883-ae918b2bd17a.png">

  - On the Projects page select `Eclipse Projects` > `Buildship`

<img width="821" alt="Screenshot 2019-07-31 at 14 30 49" src="https://user-images.githubusercontent.com/419883/62214391-462f6e00-b3a5-11e9-89ef-5092bbc82258.png">

  - On the variables page set the git branch to `donat/test-sources`. Also, set the installation / workspace / git clone location to your liking. 

<img width="822" alt="Screenshot 2019-07-31 at 14 46 58" src="https://user-images.githubusercontent.com/419883/62214404-4cbde580-b3a5-11e9-84b1-3c0f9c4c7b66.png">

  - Click finish and wait for the provisioning to finish. Once done, you should see a fully configured IDE with no compilation errors.

3. Launch development version of Buildship to verify changes
 -  In Eclipse, Open the Run Configuration dialog and run the `Launch Buildship` configuration

<img width="1025" alt="Screenshot 2019-07-31 at 15 01 08" src="https://user-images.githubusercontent.com/419883/62214426-58a9a780-b3a5-11e9-98ae-cc38240ab8c0.png">

 - Create a new Gradle project, try to use a test class in the main sources.
 - You can verify the classpath content by enabling tracing in the `Launch Buildship` configuration.

<img width="1069" alt="Screenshot 2019-07-31 at 15 04 18" src="https://user-images.githubusercontent.com/419883/62214455-63643c80-b3a5-11e9-9db2-969aefdd59b0.png">

In the development IDE if you right-click on a Gradle project and select `Gradle > Refresh Gradle project` then you should see the classpath attributes in the host IDE.
