### PR TITLE
Don't use deprecated TreeTraverser API

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/execution/ExecutionPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/execution/ExecutionPage.java
@@ -27,12 +27,10 @@ import org.gradle.tooling.events.task.TaskOperationDescriptor;
 import org.gradle.tooling.events.test.JvmTestKind;
 import org.gradle.tooling.events.test.JvmTestOperationDescriptor;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.collect.TreeTraverser;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.jobs.Job;
@@ -358,21 +356,6 @@ public final class ExecutionPage extends BasePage<FilteredTree> implements NodeS
                 }
             }
         });
-    }
-
-    public FluentIterable<OperationItem> filterTreeNodes(Predicate<OperationItem> predicate) {
-        OperationItem root = (OperationItem) getPageControl().getViewer().getInput();
-        if (root == null) {
-            return FluentIterable.from(ImmutableList.<OperationItem>of());
-        }
-
-        return new TreeTraverser<OperationItem>() {
-
-            @Override
-            public Iterable<OperationItem> children(OperationItem operationItem) {
-                return operationItem.getChildren();
-            }
-        }.breadthFirstTraversal(root).filter(predicate);
     }
 
     @Override


### PR DESCRIPTION
Guava deprecated its `TreeTraverser` class. This PR takes care of updating the usage to the recommended `Traverser` API. 