### PR TITLE
Let users import multi-composite builds

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
@@ -47,7 +47,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         PersistentModelBuilder persistentModel = persistentModelBuilder(project.project)
 
         when:
-        Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
+        Collection allProjects = collectAllProjects(gradleProject)
         GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
@@ -63,7 +63,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         PersistentModelBuilder persistentModel = persistentModelBuilder(project.project)
 
         when:
-        Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
+        Collection allProjects = collectAllProjects(gradleProject)
         GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
@@ -79,7 +79,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         PersistentModelBuilder persistentModel = persistentModelBuilder(project.project)
 
         when:
-        Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
+        Collection allProjects = collectAllProjects(gradleProject)
         GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
@@ -98,7 +98,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         PersistentModelBuilder persistentModel = persistentModelBuilder(project.project)
 
         when:
-        Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
+        Collection allProjects = collectAllProjects(gradleProject)
         GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
@@ -122,7 +122,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         initialContainer
 
         when:
-        Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
+        Collection allProjects = collectAllProjects(gradleProject)
         GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
@@ -131,7 +131,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
 
         when:
         persistentModel = persistentModelBuilder(persistentModel.build())
-        allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
+        allProjects = collectAllProjects(gradleProject)
         GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
@@ -202,5 +202,9 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
 
     GradleClasspathContainer getGradleClasspathContainer() {
         JavaCore.getClasspathContainer(GradleClasspathContainer.CONTAINER_PATH, project)
+    }
+
+    List collectAllProjects(EclipseProject project) {
+        HierarchicalElementUtils.getAll([project])
     }
 }

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
@@ -148,7 +148,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         PersistentModelBuilder persistentModel = persistentModelBuilder(project.project)
 
         when:
-        Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
+        Collection allProjects = collectAllProjects(gradleProject)
         GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
@@ -169,7 +169,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         PersistentModelBuilder persistentModel = persistentModelBuilder(project.project)
 
         when:
-        Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
+        Collection allProjects = collectAllProjects(gradleProject)
         GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingMultiComposite.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingMultiComposite.groovy
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Gradle Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.buildship.core.internal.workspace
+
+import spock.lang.Issue
+
+import org.eclipse.core.runtime.IStatus
+
+import org.eclipse.buildship.core.SynchronizationResult
+import org.eclipse.buildship.core.internal.UnsupportedConfigurationException
+import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
+import org.eclipse.buildship.core.internal.test.fixtures.TestEnvironment.*
+
+class ImportingMultiComposite extends ProjectSynchronizationSpecification {
+
+    @Issue('https://github.com/eclipse/buildship/issues/908')
+    def "Can import composite build that includes the same build multiple times"() {
+        setup:
+        File projectDir
+        fileTree(dir('multi-composite')) {
+                projectDir = dir('A') {
+                file 'settings.gradle', """
+                    includeBuild('../B')
+                    includeBuild('../C')
+                """
+            }
+            dir('B') {
+                file 'settings.gradle', """
+                    includeBuild('../C')
+                """
+            }
+            dir('C')
+        }
+
+        when:
+        SynchronizationResult result = tryImportAndWait(projectDir)
+
+        then:
+        result.status.isOK()
+    }
+}

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingProjectInOverlappingProjectDirectory.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingProjectInOverlappingProjectDirectory.groovy
@@ -12,15 +12,12 @@ package org.eclipse.buildship.core.internal.workspace
 import org.eclipse.core.resources.IMarker
 
 import org.eclipse.buildship.core.SynchronizationResult
-import org.eclipse.buildship.core.internal.Logger
 import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
 
 class ImportingProjectInOverlappingProjectDirectory extends ProjectSynchronizationSpecification {
 
     def "Importing projects with overlapping project directory gives warning"() {
         setup:
-        Logger logger = Mock(Logger)
-        registerService(Logger, logger)
         File rootProject = fileTree(dir('overlapping-project-dir')) {
             file 'settings.gradle', """
                 include('sub1')

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingProjectInOverlappingProjectDirectory.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/ImportingProjectInOverlappingProjectDirectory.groovy
@@ -34,7 +34,6 @@ class ImportingProjectInOverlappingProjectDirectory extends ProjectSynchronizati
 
         then:
         result.status.isOK()
-        getGradleErrorMarkers(findProject('sub1')).size() == 1
-        getGradleErrorMarkers(findProject('sub1'))[0].getAttribute(IMarker.MESSAGE) == "The Gradle build declares more than one sub-projects at this location"
+        getGradleErrorMarkers(findProject('sub1')).empty
     }
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/DefaultGradleBuild.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/DefaultGradleBuild.java
@@ -11,6 +11,7 @@ package org.eclipse.buildship.core.internal;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -28,7 +29,6 @@ import org.gradle.tooling.model.eclipse.EclipseProject;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.collect.ImmutableSet;
 
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -260,11 +260,7 @@ public final class DefaultGradleBuild implements InternalGradleBuild {
     }
 
     private static Set<EclipseProject> collectAll(Collection<EclipseProject> models) {
-        ImmutableSet.Builder<EclipseProject> result = ImmutableSet.builder();
-        for (EclipseProject model : models) {
-            result.addAll(HierarchicalElementUtils.getAll(model));
-        }
-        return result.build();
+        return new LinkedHashSet<>(HierarchicalElementUtils.getAll(models));
     }
 
     private static class DefaultSynchronizationResult implements SynchronizationResult {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/BaseConfigurator.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/BaseConfigurator.java
@@ -37,7 +37,7 @@ import org.eclipse.buildship.core.InitializationContext;
 import org.eclipse.buildship.core.ProjectConfigurator;
 import org.eclipse.buildship.core.ProjectContext;
 import org.eclipse.buildship.core.internal.CorePlugin;
-import org.eclipse.buildship.core.internal.marker.GradleErrorMarker;
+import org.eclipse.buildship.core.internal.CoreTraceScopes;
 import org.eclipse.buildship.core.internal.util.gradle.GradleVersion;
 import org.eclipse.buildship.core.internal.util.gradle.HierarchicalElementUtils;
 public class BaseConfigurator implements ProjectConfigurator {
@@ -45,7 +45,6 @@ public class BaseConfigurator implements ProjectConfigurator {
     Set<File> duplicateLocations;
     private Map<File, EclipseProject> locationToProject;
     private GradleVersion gradleVersion;
-    private GradleBuild gradleBuild;
 
     @Override
     public void init(InitializationContext context, IProgressMonitor monitor) {
@@ -59,7 +58,6 @@ public class BaseConfigurator implements ProjectConfigurator {
             this.duplicateLocations = calculateDuplicateLocations(rootModels);
             this.locationToProject = HierarchicalElementUtils.getAll(rootModels).stream()
                 .collect(Collectors.toMap(p -> p.getProjectDirectory(), p -> p));
-            this.gradleBuild = context.getGradleBuild();
         } catch (Exception e) {
             context.error("Cannot Query Eclipse model", e);
         }
@@ -122,8 +120,8 @@ public class BaseConfigurator implements ProjectConfigurator {
             return;
         }
         if (this.duplicateLocations.contains(location.toFile())) {
-            String message = "The Gradle build declares more than one sub-projects at this location";
-            GradleErrorMarker.createWarning(project, (InternalGradleBuild) this.gradleBuild, message, null, -1);
+            String message = "The Gradle build declares more than one sub-projects at location" + location.toPortableString();
+            CorePlugin.logger().trace(CoreTraceScopes.PROJECT_CONFIGURATORS, message);
         }
     }
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleFolderUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleFolderUpdater.java
@@ -20,6 +20,7 @@ import org.gradle.tooling.model.eclipse.EclipseLinkedResource;
 import org.gradle.tooling.model.eclipse.EclipseProject;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -81,7 +82,7 @@ final class GradleFolderUpdater {
         List<IPath> nestedBuildDirPaths = Lists.newArrayList();
 
 
-        for (EclipseProject project : HierarchicalElementUtils.getAll(this.modelProject)) {
+        for (EclipseProject project : HierarchicalElementUtils.getAll(ImmutableList.of(this.modelProject))) {
             GradleProject gradleProject = project.getGradleProject();
             IPath projectPath = Path.fromOSString(project.getProjectDirectory().getPath());
             if (currentProjectPath.isPrefixOf(projectPath)) {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/WtpConfigurator.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/WtpConfigurator.java
@@ -64,9 +64,8 @@ public class WtpConfigurator implements ProjectConfigurator {
         GradleBuild gradleBuild = context.getGradleBuild();
         try {
             Collection<EclipseProject> rootModels = gradleBuild.withConnection(connection -> EclipseModelUtils.queryModels(connection), monitor);
-            this.locationToProject = rootModels.stream()
-                .flatMap(p -> HierarchicalElementUtils.getAll(p).stream())
-                .collect(Collectors.toMap(p -> p.getProjectDirectory(), p -> p));
+            this.locationToProject = HierarchicalElementUtils.getAll(rootModels).stream()
+                    .collect(Collectors.toMap(p -> p.getProjectDirectory(), p -> p));
         } catch (Exception e) {
             context.error("Cannot Query Eclipse model", e);
         }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/task/ReloadTaskViewJob.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/task/ReloadTaskViewJob.java
@@ -21,7 +21,6 @@ import org.gradle.tooling.model.eclipse.EclipseProject;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -91,11 +90,7 @@ final class ReloadTaskViewJob extends ToolingApiJob<TaskViewContent> {
 
     private Set<EclipseProject> fetchEclipseGradleProjects(ModelProvider modelProvider, CancellationTokenSource tokenSource, IProgressMonitor monitor) {
         Collection<EclipseProject> models = modelProvider.fetchModels(EclipseProject.class, this.modelFetchStrategy, tokenSource, monitor);
-        LinkedHashSet<EclipseProject> projects = Sets.newLinkedHashSet();
-        for (EclipseProject model : models) {
-            projects.addAll(HierarchicalElementUtils.getAll(model));
-        }
-        return projects;
+        return new LinkedHashSet<>(HierarchicalElementUtils.getAll(models));
     }
 
     private void refreshTaskView(final TaskViewContent content) {


### PR DESCRIPTION
It is a valid use-case in Gradle to have a composite build that includes the same build multiple times. Unfortunately, Buildship doesn't handle this scenario well. Previous versions showed duplications in the Tasks view, and recent versions simple disallowed the import of those projects. For more context see https://github.com/eclipse/buildship/issues/908 and https://github.com/eclipse/buildship/issues/877.

The root cause of all those problems that the Tooling API depends on the same classes as the `eclipse` Gradle plugin and creates a new `EclipseProject` model for each sub-project. For included builds it ends up having duplicate models with the same project directory. For the `eclipse` plugin it's not a problem, because at the end it just writes the same `.project` and `.classpath` files multiple times. 

This PR solves the situation by eliminating the duplicate models when collecting the `EclipseProject` instances based on the project directory. It might not be an optimal solution, but it unblocks users and works in a backward-compatible way (works with all Gradle versions).

Overall, it's another example of why Buildship should have its own separate TAPI model builder that doesn't depend on the `eclipse` plugin.

