### PR TITLE
Fire up a warning marker when there's an unresolved dependency

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
@@ -51,7 +51,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
 
         when:
         Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
-        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null)
+        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
         resolvedClasspath[0].entryKind == IClasspathEntry.CPE_LIBRARY
@@ -67,7 +67,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
 
         when:
         Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
-        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null)
+        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
         resolvedClasspath[0].entryKind == IClasspathEntry.CPE_LIBRARY
@@ -83,7 +83,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
 
         when:
         Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
-        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null)
+        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
         resolvedClasspath[0].entryKind == IClasspathEntry.CPE_LIBRARY
@@ -102,7 +102,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
 
         when:
         Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
-        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null)
+        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
         resolvedClasspath[0].entryKind == IClasspathEntry.CPE_LIBRARY
@@ -126,7 +126,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
 
         when:
         Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
-        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null)
+        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
         def modifiedContainer = gradleClasspathContainer
@@ -135,7 +135,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         when:
         persistentModel = persistentModelBuilder(persistentModel.build())
         allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
-        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null)
+        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null, null)
 
         then:
         modifiedContainer.is(gradleClasspathContainer)

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/RefreshingTheGradleClasspathContainer.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/RefreshingTheGradleClasspathContainer.groovy
@@ -14,7 +14,6 @@ import org.eclipse.jdt.core.IJavaProject
 import org.eclipse.jdt.core.JavaCore
 
 import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
-import org.eclipse.buildship.core.internal.workspace.GradleClasspathContainer
 
 class RefreshingTheGradleClasspathContainer extends ProjectSynchronizationSpecification {
 
@@ -30,6 +29,19 @@ class RefreshingTheGradleClasspathContainer extends ProjectSynchronizationSpecif
         then:
         hasLocalGroovyDependencyDefinedInClasspathContainer(project)
     }
+	
+	def "Update with unresolved dependencies creates error markers"(){
+		setup:
+		File location = importNewSimpleProject('simpleproject')
+		IJavaProject project = findJavaProject('simpleproject')
+		defineMixedUnresolvedDependencies(new File(location, 'build.gradle'))
+		
+		when:
+		synchronizeAndWait(project.project)
+		
+		then:
+		gradleErrorMarkers.size()==2
+	}
 
     def "Update changes the classpath of all related projects"() {
         setup:
@@ -115,10 +127,15 @@ class RefreshingTheGradleClasspathContainer extends ProjectSynchronizationSpecif
             }
         }
     }
-
+	
     private static def defineLocalGroovyDependency(File buildScript) {
         buildScript << '\ndependencies { compile localGroovy() }'
     }
+	
+	private static def defineMixedUnresolvedDependencies(File buildScript) {
+		buildScript << "\ndependencies { compile localGroovy() \ncompile 'this:isalso:unresolved' \ncompile 'this:again:unresolved'}"
+	}
+
 
     private static def hasLocalGroovyDependencyDefinedInClasspathContainer(IJavaProject javaProject) {
         IClasspathContainer rootContainer = JavaCore.getClasspathContainer(GradleClasspathContainer.CONTAINER_PATH, javaProject)

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/RefreshingTheGradleClasspathContainer.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/RefreshingTheGradleClasspathContainer.groovy
@@ -29,19 +29,19 @@ class RefreshingTheGradleClasspathContainer extends ProjectSynchronizationSpecif
         then:
         hasLocalGroovyDependencyDefinedInClasspathContainer(project)
     }
-	
-	def "Update with unresolved dependencies creates error markers"(){
-		setup:
-		File location = importNewSimpleProject('simpleproject')
-		IJavaProject project = findJavaProject('simpleproject')
-		defineMixedUnresolvedDependencies(new File(location, 'build.gradle'))
-		
-		when:
-		synchronizeAndWait(project.project)
-		
-		then:
-		gradleErrorMarkers.size()==2
-	}
+
+    def "Update with unresolved dependencies creates error markers"(){
+        setup:
+        File location = importNewSimpleProject('simpleproject')
+        IJavaProject project = findJavaProject('simpleproject')
+        defineLocalGroovyAndSomeUnresolvedDependencies(new File(location, 'build.gradle'))
+
+        when:
+        synchronizeAndWait(project.project)
+
+        then:
+        gradleErrorMarkers.size() == 2
+    }
 
     def "Update changes the classpath of all related projects"() {
         setup:
@@ -127,15 +127,24 @@ class RefreshingTheGradleClasspathContainer extends ProjectSynchronizationSpecif
             }
         }
     }
-	
-    private static def defineLocalGroovyDependency(File buildScript) {
-        buildScript << '\ndependencies { compile localGroovy() }'
-    }
-	
-	private static def defineMixedUnresolvedDependencies(File buildScript) {
-		buildScript << "\ndependencies { compile localGroovy() \ncompile 'this:isalso:unresolved' \ncompile 'this:again:unresolved'}"
-	}
 
+    private static def defineLocalGroovyDependency(File buildScript) {
+        buildScript << '''
+            dependencies {
+                implementation localGroovy()
+            }
+        '''
+    }
+
+    private static def defineLocalGroovyAndSomeUnresolvedDependencies(File buildScript) {
+        buildScript << '''
+            dependencies {
+                implementation localGroovy()
+                implementation 'this:isalso:unresolved'
+                implementation 'this:again:unresolved'
+            }
+        '''
+    }
 
     private static def hasLocalGroovyDependencyDefinedInClasspathContainer(IJavaProject javaProject) {
         IClasspathContainer rootContainer = JavaCore.getClasspathContainer(GradleClasspathContainer.CONTAINER_PATH, javaProject)

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/SynchronizingClosedProjectsTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/SynchronizingClosedProjectsTest.groovy
@@ -9,6 +9,7 @@
  ******************************************************************************/
 package org.eclipse.buildship.core.internal.workspace
 
+import org.eclipse.core.resources.IMarker
 import org.eclipse.jdt.core.IClasspathEntry
 import org.eclipse.jdt.core.IJavaProject
 import org.eclipse.jdt.core.JavaCore
@@ -146,19 +147,20 @@ class SynchronizingClosedProjectsTest extends ProjectSynchronizationSpecificatio
 
     def "Substitutions include dependencies from other configurations"() {
         when:
-        importAndWait(buildB)
+        tryImportAndWait(buildB)
 
         then:
         allProjects().size() == 3
 
         when:
         findProject("b2").close()
-        synchronizeAndWait(buildB)
+        trySynchronizeAndWait(buildB)
         IJavaProject javaProject = JavaCore.create(findProject('b1'))
         IRuntimeClasspathEntry[] classpath = projectRuntimeClasspath(javaProject)
 
         then:
-        numOfGradleErrorMarkers == 0
+        numOfGradleErrorMarkers == 1
+        gradleErrorMarkers[0].getAttribute(IMarker.MESSAGE) == 'Unresolved dependency: org.test:buildC:1.0'
         !classpath.find { it.type ==IRuntimeClasspathEntry.PROJECT && it.path.lastSegment() == 'b2' }
         classpath.find { it.type ==IRuntimeClasspathEntry.ARCHIVE && it.path.lastSegment() == 'b2-1.0.jar' }
         classpath.find { it.type ==IRuntimeClasspathEntry.ARCHIVE && it.path.lastSegment() == 'b2-1.0-tests.jar' }
@@ -170,14 +172,14 @@ class SynchronizingClosedProjectsTest extends ProjectSynchronizationSpecificatio
 
     def "Substitutes can have source attachments"() {
         when:
-        importAndWait(buildB)
+        tryImportAndWait(buildB)
 
         then:
         allProjects().size() == 3
 
         when:
         findProject("b2").close()
-        synchronizeAndWait(buildB)
+        trySynchronizeAndWait(buildB)
         IJavaProject javaProject = findJavaProject('b1')
 
         then:

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/BaseConfigurator.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/BaseConfigurator.java
@@ -117,7 +117,7 @@ public class BaseConfigurator implements ProjectConfigurator {
         LibraryFilter.update(javaProject, model, progress.newChild(1));
         ClasspathContainerUpdater.update(javaProject, model, progress.newChild(1));
         JavaSourceSettingsUpdater.update(javaProject, model, progress.newChild(1));
-        GradleClasspathContainerUpdater.updateFromModel(javaProject, model, this.locationToProject.values(), persistentModel, progress.newChild(1));
+        GradleClasspathContainerUpdater.updateFromModel(javaProject, model, this.locationToProject.values(), persistentModel, progress.newChild(1), context);
         persistentModel.hasAutoBuildTasks(model.hasAutoBuildTasks());
     }
 

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdater.java
@@ -118,9 +118,9 @@ final class GradleClasspathContainerUpdater {
                         String groupId = m.group(1);
                         String artifactId = m.group(2);
                         String version = m.group(3);
-                        this.projectContext.warning("Unresolved dependency: " + groupId + ":" + artifactId + ":" + version, null);
+                        this.projectContext.error("Unresolved dependency: " + groupId + ":" + artifactId + ":" + version, null);
                     } else {
-                        this.projectContext.warning("Unresolved dependency: " + coordinates, null);
+                        this.projectContext.error("Unresolved dependency: " + coordinates, null);
                     }
                     continue;
                 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdater.java
@@ -45,8 +45,9 @@ import org.eclipse.buildship.core.internal.util.classpath.ClasspathUtils;
  * Updates the classpath container of the target project.
  * <p/>
  * The update is triggered via
- * {@link #updateFromModel(IJavaProject, EclipseProject, Set, IProgressMonitor, ProjectContext)}. The method
- * executes synchronously and unprotected, without thread synchronization or job scheduling.
+ * {@link #updateFromModel(IJavaProject, EclipseProject, Set, IProgressMonitor, ProjectContext)}.
+ * The method executes synchronously and unprotected, without thread synchronization or job
+ * scheduling.
  * <p/>
  * The update logic composes a new classpath container containing all project and external
  * dependencies defined in the Gradle model. At the end of the execution the old classpath container
@@ -65,7 +66,7 @@ final class GradleClasspathContainerUpdater {
 
     private GradleClasspathContainerUpdater(IJavaProject eclipseProject, EclipseProject gradleProject, Iterable<EclipseProject> allGradleProjects, ProjectContext projectContext) {
         this.projectContext = projectContext;
-		this.eclipseProject = Preconditions.checkNotNull(eclipseProject);
+        this.eclipseProject = Preconditions.checkNotNull(eclipseProject);
         this.gradleProject = Preconditions.checkNotNull(gradleProject);
         this.projectDirToProject = Maps.newHashMap();
 
@@ -103,11 +104,11 @@ final class GradleClasspathContainerUpdater {
             File dependencyFile = dependency.getFile();
             boolean linkedResourceCreated = tryCreatingLinkedResource(dependencyFile, result);
             if (!linkedResourceCreated) {
-                //Taken from UnresolvedIdeDependencyHandler.java on the gradle resolver subproject
+                // Taken from UnresolvedIdeDependencyHandler.java on the gradle resolver subproject
                 String[] unresolvedDependency = dependencyFile.getPath().split("unresolved dependency - ");
-                if(unresolvedDependency.length>1) {
-                	projectContext.warning("The dependency "+unresolvedDependency[1].replaceFirst(" ", ":").replaceFirst(" ", ":")+" could not be resolved.", null);
-                	continue;
+                if (unresolvedDependency.length > 1) {
+                    this.projectContext.warning("The dependency " + unresolvedDependency[1].replaceFirst(" ", ":").replaceFirst(" ", ":") + " could not be resolved.", null);
+                    continue;
                 }
                 String dependencyName = dependencyFile.getName();
                 // Eclipse only accepts folders and archives as external dependencies (but not, for
@@ -154,8 +155,8 @@ final class GradleClasspathContainerUpdater {
      * container will be persisted so it does not have to be reloaded after the workbench is
      * restarted.
      */
-    public static void updateFromModel(IJavaProject eclipseProject, EclipseProject gradleProject, Iterable<EclipseProject> allGradleProjects, PersistentModelBuilder persistentModel,
-            IProgressMonitor monitor, ProjectContext context) throws JavaModelException {
+    public static void updateFromModel(IJavaProject eclipseProject, EclipseProject gradleProject, Iterable<EclipseProject> allGradleProjects,
+            PersistentModelBuilder persistentModel, IProgressMonitor monitor, ProjectContext context) throws JavaModelException {
         GradleClasspathContainerUpdater updater = new GradleClasspathContainerUpdater(eclipseProject, gradleProject, allGradleProjects, context);
         updater.updateClasspathContainer(persistentModel, monitor);
     }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdater.java
@@ -106,7 +106,7 @@ final class GradleClasspathContainerUpdater {
             if (!linkedResourceCreated) {
                 // Taken from UnresolvedIdeDependencyHandler.java on the gradle resolver subproject
                 String[] unresolvedDependency = dependencyFile.getPath().split("unresolved dependency - ");
-                if (unresolvedDependency.length > 1) {
+                if (unresolvedDependency.length > 1 && this.projectContext != null) {
                     this.projectContext.warning("The dependency " + unresolvedDependency[1].replaceFirst(" ", ":").replaceFirst(" ", ":") + " could not be resolved.", null);
                     continue;
                 }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #263. A warning is issued when there's an unresolved dependency. Since there's no API in the Tooling API, I've used the tip in [UnresolvedIdeDependencyHandler.java](https://github.com/gradle/gradle/blob/4159d1fb2e1102902168aa58566d7715485dd59f/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/UnresolvedIdeDependencyHandler.java) to show the warning.

This fix probably covers all versions since Gradle REL_1.11-rc-1, because while UnresolvedIdeDependencyHandler.java was created only on Gradle 4.5, DefaultIdeDependencyResolver.java triggered the same message before.

### Context
<!--- Why do you believe many users will benefit from this change? -->

Ever since i've started working with vscode-java, gradle support felt kinda subpar compared to maven. While everything works, i believe that some QoL changes is need for better experience. 

What triggered me to to try to fix this particular issue was a somewhat frustrating experience when trying to figure out why i couldn't import some library in vscode-java while gradle showed no errors/warnings. Turns out that my build.gradle had a typo and gradle couldn't find a library and i only discovered it when using the :compileJava task.

<!--- Link to relevant issues or forum discussions here -->
https://github.com/gradle/gradle/issues/7733
