### PR TITLE
Adds external dependencies to also honor .rar and other archives

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
@@ -9,9 +9,6 @@
  ******************************************************************************/
 package org.eclipse.buildship.core.internal.workspace
 
-import java.io.FileInputStream
-import java.util.zip.ZipOutputStream
-
 import org.gradle.tooling.model.eclipse.EclipseExternalDependency
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.eclipse.EclipseProjectDependency
@@ -26,9 +23,6 @@ import org.eclipse.jdt.core.JavaCore
 import org.eclipse.buildship.core.internal.test.fixtures.WorkspaceSpecification
 import org.eclipse.buildship.core.internal.util.gradle.HierarchicalElementUtils
 import org.eclipse.buildship.core.internal.util.gradle.ModelUtils
-import org.eclipse.buildship.core.internal.workspace.GradleClasspathContainer
-import org.eclipse.buildship.core.internal.workspace.GradleClasspathContainerUpdater
-import org.eclipse.buildship.core.internal.workspace.PersistentModelBuilder
 
 class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
 
@@ -144,7 +138,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         modifiedContainer.is(gradleClasspathContainer)
     }
 
-    def "Non lower case extensions should taken into account"(String path) {
+    def "Non-lowercase extensions should be taken into account"(String path) {
         given:
         def file = new File(path)
 
@@ -165,7 +159,7 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         path << ['test.Zip', 'test.ZIP', 'test.rar', 'test.RAR']
     }
 
-    def "Non ZIP files should be ignored"() {
+    def "Non-zip files should be ignored"() {
         given:
         def file = new File("test.dll")
 

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdaterTest.groovy
@@ -165,30 +165,9 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
         path << ['test.Zip', 'test.ZIP', 'test.rar', 'test.RAR']
     }
 
-    def "Existing ZIP archives with unkown extensions should taken into account"(String path) {
-        given:
-        def file = zipFile(path)
-
-        def gradleProject = gradleProjectWithClasspath(
-            externalDependency(file)
-        )
-        PersistentModelBuilder persistentModel = persistentModelBuilder(project.project)
-
-        when:
-        Set allProjects = HierarchicalElementUtils.getAll(gradleProject).toSet()
-        GradleClasspathContainerUpdater.updateFromModel(project, gradleProject, allProjects, persistentModel, null)
-
-        then:
-        resolvedClasspath[0].entryKind == IClasspathEntry.CPE_LIBRARY
-        resolvedClasspath[0].path.toFile() == file.absoluteFile
-
-        where:
-        path << ['test.zipx', 'test.special']
-    }
-
     def "Non ZIP files should be ignored"() {
         given:
-        def file = binaryFile("test.dll")
+        def file = new File("test.dll")
 
         def gradleProject = gradleProjectWithClasspath(
             externalDependency(file)
@@ -201,27 +180,6 @@ class GradleClasspathContainerUpdaterTest extends WorkspaceSpecification {
 
         then:
         resolvedClasspath.length == 0
-    }
-
-    private File zipFile(String path) {
-        def file = new File(path)
-        def zout = new ZipOutputStream(new FileOutputStream(file))
-        try {
-            zout.finish()
-        } catch (IOException e) {
-            // ignored
-        } finally {
-            zout.close()
-        }
-        file
-    }
-
-    private File binaryFile(String path) {
-        def file = new File(path)
-        file.withWriter('utf-8') {
-            writer -> writer.writeLine 'some file content'
-        }
-        file
     }
 
     EclipseProject gradleProjectWithClasspath(Object... dependencies) {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdater.java
@@ -104,7 +104,7 @@ final class GradleClasspathContainerUpdater {
                 String dependencyName = dependencyFile.getName();
                 // Eclipse only accepts folders and archives as external dependencies (but not, for
                 // example, a DLL)
-                if (dependencyFile.isDirectory() || isZipArchiveSuffix(dependencyName)) {
+                if (dependencyFile.isDirectory() || hasAcceptedSuffix(dependencyName)) {
                     IPath path = org.eclipse.core.runtime.Path.fromOSString(dependencyFile.getAbsolutePath());
                     File dependencySource = dependency.getSource();
                     IPath sourcePath = dependencySource != null ? org.eclipse.core.runtime.Path.fromOSString(dependencySource.getAbsolutePath()) : null;
@@ -117,9 +117,9 @@ final class GradleClasspathContainerUpdater {
         return result.build();
     }
 
-    private boolean isZipArchiveSuffix(String dependencyName) {
-       String dependencyNameLwc = dependencyName.toLowerCase();
-       return dependencyNameLwc.endsWith(".jar") || dependencyNameLwc.endsWith(".rar") || dependencyNameLwc.endsWith(".zip");
+    private boolean hasAcceptedSuffix(String dependencyName) {
+       String name = dependencyName.toLowerCase();
+       return name.endsWith(".jar") || name.endsWith(".rar") || name.endsWith(".zip");
     }
 
     private boolean tryCreatingLinkedResource(File dependencyFile, Builder<IClasspathEntry> result) {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdater.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerUpdater.java
@@ -10,11 +10,9 @@
 package org.eclipse.buildship.core.internal.workspace;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.zip.ZipFile;
 
 import org.gradle.tooling.model.eclipse.EclipseExternalDependency;
 import org.gradle.tooling.model.eclipse.EclipseProject;
@@ -106,7 +104,7 @@ final class GradleClasspathContainerUpdater {
                 String dependencyName = dependencyFile.getName();
                 // Eclipse only accepts folders and archives as external dependencies (but not, for
                 // example, a DLL)
-                if (dependencyFile.isDirectory() || isZipArchiveSuffix(dependencyName)|| isZipArchive(dependencyFile)) {
+                if (dependencyFile.isDirectory() || isZipArchiveSuffix(dependencyName)) {
                     IPath path = org.eclipse.core.runtime.Path.fromOSString(dependencyFile.getAbsolutePath());
                     File dependencySource = dependency.getSource();
                     IPath sourcePath = dependencySource != null ? org.eclipse.core.runtime.Path.fromOSString(dependencySource.getAbsolutePath()) : null;
@@ -121,17 +119,7 @@ final class GradleClasspathContainerUpdater {
 
     private boolean isZipArchiveSuffix(String dependencyName) {
        String dependencyNameLwc = dependencyName.toLowerCase();
-        return dependencyNameLwc.endsWith(".jar") || dependencyNameLwc.endsWith(".rar") || dependencyNameLwc.endsWith(".zip");
-    }
-
-    private boolean isZipArchive(File dependencyFile) {
-        try (ZipFile zipFile = new ZipFile(dependencyFile)) {
-            zipFile.size();
-            return true;
-        } catch (IOException e) {
-            // if not able to read we suppose it is not a ZIP file
-        }
-        return false;
+       return dependencyNameLwc.endsWith(".jar") || dependencyNameLwc.endsWith(".rar") || dependencyNameLwc.endsWith(".zip");
     }
 
     private boolean tryCreatingLinkedResource(File dependencyFile, Builder<IClasspathEntry> result) {


### PR DESCRIPTION
Fixes #996

### Context
Relaxes filter of taken external dependencies into account. Here also `.rar` and case sensitive versions of extensions will be accepted. Also lastly a existing file must be at least an ZIP archive.