### PR TITLE
Exclude test code from runtime classpath if without_test_code is set

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/RuntimeClasspathTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/RuntimeClasspathTest.groovy
@@ -194,6 +194,41 @@ class RuntimeClasspathTest extends ProjectSynchronizationSpecification {
         resolvedClasspath.find { it.path.lastSegment().contains 'guava' }
     }
 
+    @Issue("https://github.com/eclipse/buildship/issues/1004")
+    def "Project dependency test code is not on the classpath if without_test_code attribute is set"() {
+        setup:
+        // Another non-custom source directory is required for the default-directory to be set
+        new File(location, 'a/src/main/java').mkdirs()
+        new File(location, 'a/src/test/java').mkdirs()
+        buildFile << '''
+            project(':a') {
+                apply plugin: 'java-library'
+            }
+
+            project(':b') {
+                apply plugin: 'eclipse'
+
+                dependencies {
+                    implementation project(':a')
+                }
+
+                eclipse.classpath.file.whenMerged {
+                    entries.findAll { it instanceof org.gradle.plugins.ide.eclipse.model.ProjectDependency }
+                        .each { it.entryAttributes['without_test_code'] = 'true' }
+                }
+            }
+        '''
+        importAndWait(location)
+
+        when:
+        IJavaProject javaProject = JavaCore.create(findProject('b'))
+        IRuntimeClasspathEntry[] classpath = projectRuntimeClasspath(javaProject)
+
+        then:
+        classpath.find { it.type == IRuntimeClasspathEntry.ARCHIVE && it.path.toPortableString() == '/a/bin/main' }
+        !classpath.find { it.type == IRuntimeClasspathEntry.ARCHIVE && it.path.toPortableString() == '/a/bin/test' }
+    }
+
     private IRuntimeClasspathEntry[] projectRuntimeClasspath(IJavaProject project) {
         IRuntimeClasspathEntry projectEntry = JavaRuntime.computeUnresolvedRuntimeClasspath(project).find { it.path == project.project.fullPath }
         JavaRuntime.resolveRuntimeClasspathEntry(projectEntry, project)

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/RuntimeClasspathTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/RuntimeClasspathTest.groovy
@@ -21,6 +21,7 @@ import org.eclipse.jdt.launching.IRuntimeClasspathEntry
 import org.eclipse.jdt.launching.JavaRuntime
 
 import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationSpecification
+import org.eclipse.buildship.core.internal.util.eclipse.PlatformUtils
 import org.eclipse.buildship.core.GradleDistribution
 
 class RuntimeClasspathTest extends ProjectSynchronizationSpecification {
@@ -195,6 +196,7 @@ class RuntimeClasspathTest extends ProjectSynchronizationSpecification {
     }
 
     @Issue("https://github.com/eclipse/buildship/issues/1004")
+    @IgnoreIf({ !PlatformUtils.supportsTestAttributes() })
     def "Project dependency test code is not on the classpath if without_test_code attribute is set"() {
         setup:
         // Another non-custom source directory is required for the default-directory to be set

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
@@ -145,7 +145,7 @@ public final class GradleClasspathContainerRuntimeClasspathEntryResolver impleme
                     // add the project entry itself so that the source lookup can find the classes
                     // see https://github.com/eclipse/buildship/issues/383
                     result.add(projectRuntimeEntry);
-                    Collections.addAll(result, invokeJavaRuntimeResolveRuntimeClasspathEntry(projectRuntimeEntry, dependencyProject, isTestCodeExcluded(cpe)));
+                    Collections.addAll(result, invokeJavaRuntimeResolveRuntimeClasspathEntry(projectRuntimeEntry, dependencyProject,  excludeTestCode || isTestCodeExcluded(cpe)));
                 }
             }
         }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
@@ -145,7 +145,7 @@ public final class GradleClasspathContainerRuntimeClasspathEntryResolver impleme
                     // add the project entry itself so that the source lookup can find the classes
                     // see https://github.com/eclipse/buildship/issues/383
                     result.add(projectRuntimeEntry);
-                    Collections.addAll(result, invokeJavaRuntimeResolveRuntimeClasspathEntry(projectRuntimeEntry, dependencyProject,  excludeTestCode || isTestCodeExcluded(cpe)));
+                    Collections.addAll(result, invokeJavaRuntimeResolveRuntimeClasspathEntry(projectRuntimeEntry, dependencyProject, excludeTestCode || isTestCodeExcluded(cpe)));
                 }
             }
         }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
@@ -145,7 +145,7 @@ public final class GradleClasspathContainerRuntimeClasspathEntryResolver impleme
                     // add the project entry itself so that the source lookup can find the classes
                     // see https://github.com/eclipse/buildship/issues/383
                     result.add(projectRuntimeEntry);
-                    Collections.addAll(result, invokeJavaRuntimeResolveRuntimeClasspathEntry(projectRuntimeEntry, dependencyProject, excludeTestCode));
+                    Collections.addAll(result, invokeJavaRuntimeResolveRuntimeClasspathEntry(projectRuntimeEntry, dependencyProject, isTestCodeExcluded(cpe)));
                 }
             }
         }
@@ -163,8 +163,16 @@ public final class GradleClasspathContainerRuntimeClasspathEntryResolver impleme
     }
 
     private boolean hasTestAttribute(IClasspathEntry entry) {
-        for (IClasspathAttribute a : entry.getExtraAttributes()) {
-            if ("test".equals(a.getName()) && Boolean.valueOf(a.getValue())) {
+        return hasEnabledBooleanAttribute("test", entry);
+    }
+
+    private static boolean isTestCodeExcluded(IClasspathEntry entry) {
+        return hasEnabledBooleanAttribute("without_test_code", entry);
+    }
+
+    private static boolean hasEnabledBooleanAttribute(String key, IClasspathEntry entry) {
+        for (IClasspathAttribute attribute : entry.getExtraAttributes()) {
+            if (key.equals(attribute.getName()) && Boolean.parseBoolean(attribute.getValue())) {
                 return true;
             }
         }


### PR DESCRIPTION
Fixes #1004

Eclipse 3.14 introduced the `without_test_code` attribute for project dependencies. If set then the runtime classpath should not contain the resources marked with `test`. This PR modifies the runtime classpath calculation to respect this attribute. 

In the context of Gradle, the `without_test_code` attribute should be always set for project dependencies. To fix that, there's a follow-up PR: https://github.com/gradle/gradle/pull/13798.

# Testing the changes

## Launching a test instance

### 1. Install the Eclipse installer

Go to https://www.eclipse.org/downloads/ and click the `Download 64` button and proceed with the installer installation.

### 2. Provision the Buildship IDE

- Open the Eclipse installer
- Select `Advanced mode...` in the menu in the top-right corner

<img width="400" alt="Screenshot 2019-07-31 at 14 27 50" src="https://user-images.githubusercontent.com/419883/62214328-20a26480-b3a5-11e9-9777-6839450e9108.png">

- On the product page select Eclipse IDE for Eclipse Committers and change the product version to `Latest Release (2019-09)`

<img width="400" alt="Screenshot 2019-07-31 at 14 30 09" src="https://user-images.githubusercontent.com/419883/62214378-3dd73300-b3a5-11e9-9883-ae918b2bd17a.png">

- On the Projects page select `Eclipse Projects` > `Buildship`

<img width="400" alt="Screenshot 2019-07-31 at 14 30 49" src="https://user-images.githubusercontent.com/419883/62214391-462f6e00-b3a5-11e9-89ef-5092bbc82258.png">

- On the variables page set the git branch to `donat/exclude-test-code`. Also, set the installation / workspace / git clone location to your liking.

<img width="400" alt="Screenshot 2019-07-31 at 14 46 58" src="https://user-images.githubusercontent.com/419883/62214404-4cbde580-b3a5-11e9-84b1-3c0f9c4c7b66.png">

- Click finish and wait for the provisioning to finish. Once done, you should see a fully configured IDE with no compilation errors

## Launch development version of Buildship to verify changes

-  In Eclipse, Open the Run Configuration dialog and run the `Launch Buildship` configuration

<img width="400" alt="Screenshot 2019-07-31 at 15 01 08" src="https://user-images.githubusercontent.com/419883/62214426-58a9a780-b3a5-11e9-98ae-cc38240ab8c0.png">

- Import [this](https://github.com/eclipse/buildship/files/4919496/buildship-classpath-problem.zip)  sample project with the `Import Gradle Project` wizard.
- Run the contained test project (with JDT) and observe it fail. 
- Add the following snippet to the project's build script:
```
  eclipse.classpath.file.whenMerged {
    entries.findAll { it instanceof org.gradle.plugins.ide.eclipse.model.ProjectDependency }
            .each { it.entryAttributes['without_test_code'] = 'true' }
  }
```
- Right-click on the project and select `Gradle > Synchronize Project`
- Re-run the test and verify that it succeeds.
