### PR TITLE
Add failure condition to detect potential credentials leaks

### DIFF
--- a/.teamcity/Buildship/EclipseBuildTemplate.kt
+++ b/.teamcity/Buildship/EclipseBuildTemplate.kt
@@ -3,7 +3,10 @@ package Buildship
 import jetbrains.buildServer.configs.kotlin.v2019_2.CheckoutMode
 import jetbrains.buildServer.configs.kotlin.v2019_2.Template
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.retryBuild
+import jetbrains.buildServer.configs.kotlin.v2019_2.ui.add
 
 object EclipseBuildTemplate : Template({
     name = "Tooling-Eclipse-Build"
@@ -51,6 +54,15 @@ object EclipseBuildTemplate : Template({
 
     failureConditions {
         errorMessage = true
+        add {
+            failOnText {
+                conditionType = BuildFailureOnText.ConditionType.CONTAINS
+                pattern = "%unmaskedFakeCredentials%"
+                failureMessage = "This build might be leaking credentials"
+                reverse = false
+                stopBuildOnFailure = true
+            }
+        }
     }
 
     cleanup {


### PR DESCRIPTION
Uses a fake unmasked credentials value to fail the build. This fake value is added in TeamCity build parameters and environment variables. It won't detect every credentials leak, but will at least fail the build if all the environment variables or build properties (that might include sensitive values) are dumped during the build.
