### PR TITLE
Add failure condition to detect potential credentials leaks to both build and promotion templates

### DIFF
--- a/.teamcity/Buildship/EclipseBuildTemplate.kt
+++ b/.teamcity/Buildship/EclipseBuildTemplate.kt
@@ -3,10 +3,7 @@ package Buildship
 import jetbrains.buildServer.configs.kotlin.v2019_2.CheckoutMode
 import jetbrains.buildServer.configs.kotlin.v2019_2.Template
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.gradle
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
-import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.retryBuild
-import jetbrains.buildServer.configs.kotlin.v2019_2.ui.add
 
 object EclipseBuildTemplate : Template({
     name = "Tooling-Eclipse-Build"
@@ -52,18 +49,7 @@ object EclipseBuildTemplate : Template({
         }
     }
 
-    failureConditions {
-        errorMessage = true
-        add {
-            failOnText {
-                conditionType = BuildFailureOnText.ConditionType.CONTAINS
-                pattern = "%unmaskedFakeCredentials%"
-                failureMessage = "This build might be leaking credentials"
-                reverse = false
-                stopBuildOnFailure = true
-            }
-        }
-    }
+    addCredentialsLeakFailureCondition()
 
     cleanup {
         all(days = 5)

--- a/.teamcity/Buildship/Promotion30/Promotion30Template.kt
+++ b/.teamcity/Buildship/Promotion30/Promotion30Template.kt
@@ -2,6 +2,7 @@ package Buildship.Promotion30
 
 import Buildship.Check30.Checkpoints.buildTypes.Final
 import Buildship.GitHubVcsRoot
+import Buildship.addCredentialsLeakFailureCondition
 import jetbrains.buildServer.configs.kotlin.v2019_2.CheckoutMode
 import jetbrains.buildServer.configs.kotlin.v2019_2.FailureAction
 import jetbrains.buildServer.configs.kotlin.v2019_2.Template
@@ -10,6 +11,8 @@ object Promotion30Template : Template({
     name = "Promotion30 Template"
 
     artifactRules = "org.eclipse.buildship.site/build/repository/** => update-site"
+
+    addCredentialsLeakFailureCondition()
 
     // The artifact upload requires uses ssh which requires manual confirmation. to work around that, we use the same
     // machine for the upload.

--- a/.teamcity/Buildship/extensions.kt
+++ b/.teamcity/Buildship/extensions.kt
@@ -1,0 +1,20 @@
+package Buildship
+
+import jetbrains.buildServer.configs.kotlin.v2019_2.Template
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailureOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
+import jetbrains.buildServer.configs.kotlin.v2019_2.ui.add
+
+fun Template.addCredentialsLeakFailureCondition() {
+    failureConditions {
+        add {
+            failOnText {
+                conditionType = BuildFailureOnText.ConditionType.CONTAINS
+                pattern = "%unmaskedFakeCredentials%"
+                failureMessage = "This build might be leaking credentials"
+                reverse = false
+                stopBuildOnFailure = true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Uses a fake unmasked credentials value to fail the build. This fake value is added in TC build parameters and environment variables. It won't detect every credentials leak, but will at least fail the build if all the environment variables or build properties (that might include sensitive values) are dumped during the build.