### PR TITLE
Format test output messages in the Executios view

### DIFF
--- a/.teamcity/Buildship/Promotion30/Promotion30Template.kt
+++ b/.teamcity/Buildship/Promotion30/Promotion30Template.kt
@@ -12,8 +12,6 @@ object Promotion30Template : Template({
 
     artifactRules = "org.eclipse.buildship.site/build/repository/** => .teamcity/update-site"
 
-    addCredentialsLeakFailureCondition()
-
     // The artifact upload requires uses ssh which requires manual confirmation. to work around that, we use the same
     // machine for the upload.
     // TODO We should separate the update site generation and the artifact upload into two separate steps.

--- a/.teamcity/Buildship/Promotion30/Promotion30Template.kt
+++ b/.teamcity/Buildship/Promotion30/Promotion30Template.kt
@@ -12,6 +12,8 @@ object Promotion30Template : Template({
 
     artifactRules = "org.eclipse.buildship.site/build/repository/** => .teamcity/update-site"
 
+    addCredentialsLeakFailureCondition()
+
     // The artifact upload requires uses ssh which requires manual confirmation. to work around that, we use the same
     // machine for the upload.
     // TODO We should separate the update site generation and the artifact upload into two separate steps.

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/color/ColorUtils.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/color/ColorUtils.java
@@ -44,7 +44,6 @@ public final class ColorUtils {
      */
     public static ColorDescriptor getDecorationsColorDescriptorFromCurrentTheme() {
         ITheme theme = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme();
-        System.out.println(theme.getColorRegistry().getKeySet());
         return Preconditions.checkNotNull(theme.getColorRegistry().getColorDescriptor(DECORATIONS_COLOR));
     }
 
@@ -55,7 +54,6 @@ public final class ColorUtils {
      */
     public static ColorDescriptor getErrorColorDescriptorFromCurrentTheme() {
         ITheme theme = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme();
-        System.out.println(theme.getColorRegistry().getKeySet());
         return Preconditions.checkNotNull(theme.getColorRegistry().getColorDescriptor(ERROR_COLOR));
     }
 }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/color/ColorUtils.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/util/color/ColorUtils.java
@@ -22,6 +22,7 @@ import org.eclipse.ui.themes.ITheme;
 public final class ColorUtils {
 
     private static final String DECORATIONS_COLOR = "DECORATIONS_COLOR";
+    private static final String ERROR_COLOR = "ERROR_COLOR";
 
     private ColorUtils() {
     }
@@ -43,7 +44,18 @@ public final class ColorUtils {
      */
     public static ColorDescriptor getDecorationsColorDescriptorFromCurrentTheme() {
         ITheme theme = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme();
+        System.out.println(theme.getColorRegistry().getKeySet());
         return Preconditions.checkNotNull(theme.getColorRegistry().getColorDescriptor(DECORATIONS_COLOR));
     }
 
+    /**
+     * Returns the color descriptor for {@code ERROR_COLOR} from the current workbench theme.
+     *
+     * @return the theme color descriptor to decorate text
+     */
+    public static ColorDescriptor getErrorColorDescriptorFromCurrentTheme() {
+        ITheme theme = PlatformUI.getWorkbench().getThemeManager().getCurrentTheme();
+        System.out.println(theme.getColorRegistry().getKeySet());
+        return Preconditions.checkNotNull(theme.getColorRegistry().getColorDescriptor(ERROR_COLOR));
+    }
 }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/execution/ExecutionPage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/execution/ExecutionPage.java
@@ -111,6 +111,7 @@ public final class ExecutionPage extends BasePage<FilteredTree> implements NodeS
         this.filteredTree.getViewer().getTree().setHeaderVisible(true);
         this.filteredTree.getViewer().setContentProvider(new ExecutionPageContentProvider());
         this.filteredTree.getViewer().setUseHashlookup(true);
+        this.filteredTree.getViewer().setComparator(new ExecutionPageSorter());
 
         this.nameColumn = new TreeViewerColumn(this.filteredTree.getViewer(), SWT.NONE);
         this.nameColumn.getColumn().setText(ExecutionViewMessages.Tree_Column_Operation_Name_Text);

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/execution/ExecutionPageSorter.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/execution/ExecutionPageSorter.java
@@ -17,7 +17,9 @@ import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerComparator;
 
 /**
- * Sorts the test output so that the messages printed to the standard output always come first.
+ * Sorts the test output mesages in the Executions view.
+ * <p>
+ * The messages printed on standard error will come after the ones on standard out.  
  */
 public class ExecutionPageSorter extends ViewerComparator {
 

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/execution/ExecutionPageSorter.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/view/execution/ExecutionPageSorter.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Gradle Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+
+package org.eclipse.buildship.ui.internal.view.execution;
+
+import org.gradle.tooling.events.test.Destination;
+import org.gradle.tooling.events.test.TestOutputDescriptor;
+
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
+
+/**
+ * Sorts the test output so that the messages printed to the standard output always come first.
+ */
+public class ExecutionPageSorter extends ViewerComparator {
+
+    @Override
+    public int compare(Viewer viewer, Object e1, Object e2) {
+        //
+        if (e1 instanceof OperationItem && e2 instanceof OperationItem) {
+            OperationItem i1 = (OperationItem) e1;
+            OperationItem i2 = (OperationItem) e2;
+            if (i1.getDescriptor() instanceof TestOutputDescriptor && i2.getDescriptor() instanceof TestOutputDescriptor) {
+                Destination d1 = ((TestOutputDescriptor) i1.getDescriptor()).getDestination();
+                Destination d2 = ((TestOutputDescriptor) i2.getDescriptor()).getDestination();
+                if (d1 == Destination.StdOut && d2 == Destination.StdErr) {
+                    return -1;
+                } else if (d1 == Destination.StdErr && d2 == Destination.StdOut) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+
+            }
+        }
+        return super.compare(viewer, e1, e2);
+    }
+}


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

Before this PR, the Executions view showed the test output events in the order they appeared and with a distracting `StdOut`/`StdErr` prefixes.

<img width="829" alt="Screenshot 2020-08-03 at 10 20 37" src="https://user-images.githubusercontent.com/419883/89161565-0af4eb80-d573-11ea-9359-c227ea9b26ae.png">


This PR uses a red foreground color to distinguish messages that were printed on stderr. Also, the output events are now sorted: stdout messages always come before the ones on stderr.

<img width="830" alt="Screenshot 2020-08-03 at 10 20 02" src="https://user-images.githubusercontent.com/419883/89161573-11836300-d573-11ea-9bbf-2508aa03c988.png">

A follow-up PR will be to add new icons for the test output events.

