### PR TITLE
GradleVersions: comply with XDG base spec

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersions.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersions.java
@@ -218,7 +218,12 @@ public final class PublishedGradleVersions {
     }
 
     private static File getCacheFile() {
-        return new File(System.getProperty("user.home"), ".tooling/gradle/versions.json");
+        // ensures compliance with XDG base spec: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+        String xdgCache = System.getenv("XDG_CACHE_HOME");
+        if (xdgCache == null) {
+            xdgCache = System.getProperty("user.home") + "/.cache/";
+        }
+        return new File(xdgCache, "tooling/gradle/versions.json");
     }
 
     /**


### PR DESCRIPTION
### Context

This PR ensures compatible systems are compliant with the XDG base specification ( https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html ). If no XDG related environment variables are set then the folder used defaults to $HOME/.cache/tooling for the gradle versions cache, as per the standard.