### PR TITLE
Add modular libraries to modulepath instead of classpath

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/configuration/WorkspaceConfigurationTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/configuration/WorkspaceConfigurationTest.groovy
@@ -26,16 +26,17 @@ class WorkspaceConfigurationTest extends WorkspaceSpecification {
         configuration.jvmArguments == []
         configuration.showConsoleView == true
         configuration.showExecutionsView == true
-
+        configuration.experimentalModuleSupportEnabled == false
     }
-    def "Can save workpsace configuration"(GradleDistribution distribution, String gradleUserHome, String javaHome, boolean offlineMode, boolean buildScansEnabled, boolean autoSync, List args, List jvmArgs, boolean showConsole, boolean showExecutions) {
+
+    def "Can save workpsace configuration"(GradleDistribution distribution, String gradleUserHome, String javaHome, boolean offlineMode, boolean buildScansEnabled, boolean autoSync, List args, List jvmArgs, boolean showConsole, boolean showExecutions, moduleSupportEnabled) {
         setup:
         WorkspaceConfiguration orignalConfiguration = configurationManager.loadWorkspaceConfiguration()
 
         when:
         File gradleUserHomeDir = dir(gradleUserHome)
         File javaHomeDir = dir(javaHome)
-        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(distribution, gradleUserHomeDir, javaHomeDir, offlineMode, buildScansEnabled, autoSync, args, jvmArgs, showConsole, showExecutions))
+        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(distribution, gradleUserHomeDir, javaHomeDir, offlineMode, buildScansEnabled, autoSync, args, jvmArgs, showConsole, showExecutions, moduleSupportEnabled))
         WorkspaceConfiguration updatedConfiguration = configurationManager.loadWorkspaceConfiguration()
 
         then:
@@ -49,15 +50,16 @@ class WorkspaceConfigurationTest extends WorkspaceSpecification {
         updatedConfiguration.jvmArguments == jvmArgs
         updatedConfiguration.showConsoleView == showConsole
         updatedConfiguration.showExecutionsView == showExecutions
+        updatedConfiguration.experimentalModuleSupportEnabled == moduleSupportEnabled
 
         cleanup:
         configurationManager.saveWorkspaceConfiguration(orignalConfiguration)
 
         where:
-        distribution                                                                 | gradleUserHome    | javaHome    | offlineMode  | buildScansEnabled | autoSync | args   | jvmArgs | showConsole | showExecutions
-        GradleDistribution.fromBuild()                                               | 'customUserHome1' | 'javaHome1' |  false       | false             | true     | ['a1'] | ['j1']  | false       | true
-        GradleDistribution.forVersion("3.2.1")                                       | 'customUserHome2' | 'javaHome2' |  false       | true              | false    | ['a2'] | ['j2']  | true        | false
-        GradleDistribution.forLocalInstallation(new File('/').canonicalFile)         | 'customUserHome3' | 'javaHome3' |  true        | true              | true     | ['a3'] | ['j3']  | false       | true
-        GradleDistribution.forRemoteDistribution(new URI('http://example.com/gd'))   | 'customUserHome4' | 'javaHome4' |  true        | false             | false    | ['a4'] | ['j4']  | true        | false
+        distribution                                                                 | gradleUserHome    | javaHome    | offlineMode  | buildScansEnabled | autoSync | args   | jvmArgs | showConsole | showExecutions | moduleSupportEnabled
+        GradleDistribution.fromBuild()                                               | 'customUserHome1' | 'javaHome1' |  false       | false             | true     | ['a1'] | ['j1']  | false       | true           | false
+        GradleDistribution.forVersion("3.2.1")                                       | 'customUserHome2' | 'javaHome2' |  false       | true              | false    | ['a2'] | ['j2']  | true        | false          | false
+        GradleDistribution.forLocalInstallation(new File('/').canonicalFile)         | 'customUserHome3' | 'javaHome3' |  true        | true              | true     | ['a3'] | ['j3']  | false       | true           | true
+        GradleDistribution.forRemoteDistribution(new URI('http://example.com/gd'))   | 'customUserHome4' | 'javaHome4' |  true        | false             | false    | ['a4'] | ['j4']  | true        | false          | true
     }
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/WorkspaceConfiguration.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/WorkspaceConfiguration.java
@@ -34,12 +34,13 @@ public final class WorkspaceConfiguration {
     private final List<String> jvmArguments;
     private final boolean showConsoleView;
     private final boolean showExecutionsView;
+    private final boolean experimentalModuleSupportEnabled;
 
     public WorkspaceConfiguration(GradleDistribution gradleDistribution, File gradleUserHome,
                                   File javaHome, boolean gradleIsOffline, boolean buildScansEnabled,
                                   boolean autoSync, List<String> arguments,
                                   List<String> jvmArguments, boolean showConsoleView,
-                                  boolean showExecutionsView) {
+                                  boolean showExecutionsView, boolean experimentalModuleSupportEnabled) {
         this.gradleDistribution = gradleDistribution;
         this.gradleUserHome = gradleUserHome;
         this.javaHome = javaHome;
@@ -50,6 +51,7 @@ public final class WorkspaceConfiguration {
         this.jvmArguments = jvmArguments;
         this.showConsoleView = showConsoleView;
         this.showExecutionsView = showExecutionsView;
+        this.experimentalModuleSupportEnabled = experimentalModuleSupportEnabled;
     }
 
     public GradleDistribution getGradleDistribution() {
@@ -93,6 +95,11 @@ public final class WorkspaceConfiguration {
         return this.showExecutionsView;
     }
 
+
+    public boolean isExperimentalModuleSupportEnabled() {
+        return this.experimentalModuleSupportEnabled;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof WorkspaceConfiguration) {
@@ -106,13 +113,14 @@ public final class WorkspaceConfiguration {
                     && Objects.equal(this.arguments, other.arguments)
                     && Objects.equal(this.jvmArguments, other.jvmArguments)
                     && Objects.equal(this.showConsoleView, other.showConsoleView)
-                    && Objects.equal(this.showExecutionsView, other.showExecutionsView);
+                    && Objects.equal(this.showExecutionsView, other.showExecutionsView)
+                    && Objects.equal(this.experimentalModuleSupportEnabled, other.experimentalModuleSupportEnabled);
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this.gradleDistribution, this.gradleUserHome, this.javaHome, this.gradleIsOffline, this.buildScansEnabled, this.autoSync, this.arguments, this.jvmArguments, this.showConsoleView, this.showExecutionsView);
+        return Objects.hashCode(this.gradleDistribution, this.gradleUserHome, this.javaHome, this.gradleIsOffline, this.buildScansEnabled, this.autoSync, this.arguments, this.jvmArguments, this.showConsoleView, this.showExecutionsView, this.experimentalModuleSupportEnabled);
     }
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/WorkspaceConfigurationPersistence.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/WorkspaceConfigurationPersistence.java
@@ -43,6 +43,7 @@ final class WorkspaceConfigurationPersistence {
     private static final String JVM_ARGUMENTS = "jvm.arguments";
     private static final String SHOW_CONSOLE_VIEW = "show.console.view";
     private static final String SHOW_EXECUTIONS_VIEW = "show.executions.view";
+    private static final String EXPERIMENTAL_ENABLE_MODULE_SUPPORT = "experimental.module.support";
 
     public WorkspaceConfiguration readWorkspaceConfig() {
         IEclipsePreferences preferences = getPreferences();
@@ -70,8 +71,9 @@ final class WorkspaceConfigurationPersistence {
         List<String> jvmArguments = Splitter.on(File.pathSeparator).omitEmptyStrings().splitToList(jvmArgumentsString);
         boolean showConsoleView = preferences.getBoolean(SHOW_CONSOLE_VIEW, true);
         boolean showExecutionsView = preferences.getBoolean(SHOW_EXECUTIONS_VIEW, true);
+        boolean moduleSupport = preferences.getBoolean(EXPERIMENTAL_ENABLE_MODULE_SUPPORT, false);
 
-        return new WorkspaceConfiguration(distribution, gradleUserHome, javaHome, offlineMode, buildScansEnabled, autoSyncEnabled, arguments, jvmArguments, showConsoleView, showExecutionsView);
+        return new WorkspaceConfiguration(distribution, gradleUserHome, javaHome, offlineMode, buildScansEnabled, autoSyncEnabled, arguments, jvmArguments, showConsoleView, showExecutionsView, moduleSupport);
     }
 
     public void saveWorkspaceConfiguration(WorkspaceConfiguration config) {
@@ -95,6 +97,7 @@ final class WorkspaceConfigurationPersistence {
         preferences.put(JVM_ARGUMENTS, Joiner.on(File.pathSeparator).join(config.getJvmArguments()));
         preferences.putBoolean(SHOW_CONSOLE_VIEW, config.isShowConsoleView());
         preferences.putBoolean(SHOW_EXECUTIONS_VIEW, config.isShowExecutionsView());
+        preferences.putBoolean(EXPERIMENTAL_ENABLE_MODULE_SUPPORT, config.isExperimentalModuleSupportEnabled());
         try {
             preferences.flush();
         } catch (BackingStoreException e) {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/GradleClasspathContainerRuntimeClasspathEntryResolver.java
@@ -109,7 +109,8 @@ public final class GradleClasspathContainerRuntimeClasspathEntryResolver impleme
         for (final IClasspathEntry cpe : container.getClasspathEntries()) {
             if (!includeExportedEntriesOnly || cpe.isExported()) {
                 if (cpe.getEntryKind() == IClasspathEntry.CPE_LIBRARY && configurationScopes.isEntryIncluded(cpe)) {
-                    result.add(JavaRuntime.newArchiveRuntimeClasspathEntry(cpe.getPath()));
+                    result.add(JavaRuntime.newArchiveRuntimeClasspathEntry(cpe.getPath(),
+                            hasModuleAttribute(cpe) ? IRuntimeClasspathEntry.MODULE_PATH : IRuntimeClasspathEntry.CLASS_PATH));
                 } else if (cpe.getEntryKind() == IClasspathEntry.CPE_PROJECT) {
                     Optional<IProject> candidate = findAccessibleJavaProject(cpe.getPath().segment(0));
                     if (candidate.isPresent()) {
@@ -136,7 +137,8 @@ public final class GradleClasspathContainerRuntimeClasspathEntryResolver impleme
 
         for (final IClasspathEntry cpe : container.getClasspathEntries()) {
             if (cpe.getEntryKind() == IClasspathEntry.CPE_LIBRARY && !(excludeTestCode && hasTestAttribute(cpe))) {
-                result.add(JavaRuntime.newArchiveRuntimeClasspathEntry(cpe.getPath()));
+                result.add(JavaRuntime.newArchiveRuntimeClasspathEntry(cpe.getPath(),
+                        hasModuleAttribute(cpe) ? IRuntimeClasspathEntry.MODULE_PATH : IRuntimeClasspathEntry.CLASS_PATH));
             } else if (cpe.getEntryKind() == IClasspathEntry.CPE_PROJECT) {
                 Optional<IProject> candidate = findAccessibleJavaProject(cpe.getPath().segment(0));
                 if (candidate.isPresent()) {
@@ -160,6 +162,9 @@ public final class GradleClasspathContainerRuntimeClasspathEntryResolver impleme
         } catch (Exception e) {
             throw new GradlePluginsRuntimeException("JavaRuntime.resolveRuntimeClasspathEntry() should not be called when Buildship is installed for Eclipse 4.8", e);
         }
+    }
+    private boolean hasModuleAttribute(IClasspathEntry entry) {
+        return hasEnabledBooleanAttribute(IClasspathAttribute.MODULE, entry);
     }
 
     private boolean hasTestAttribute(IClasspathEntry entry) {

--- a/org.eclipse.buildship.ui/plugin.xml
+++ b/org.eclipse.buildship.ui/plugin.xml
@@ -580,6 +580,12 @@
              id="org.eclipse.buildship.ui.preferences"
              name="Gradle">
        </page>
+       <page
+             category="org.eclipse.buildship.ui.preferences"
+             class="org.eclipse.buildship.ui.internal.preferences.GradleExperimentalFeaturesPreferencePage"
+             id="org.eclipse.buildship.ui.preferences.experimental"
+             name="Experimental features">
+       </page>
     </extension>
 
     <!-- Add the "Gradle" menu to the project preferences -->

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/preferences/GradleExperimentalFeaturesPreferencePage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/preferences/GradleExperimentalFeaturesPreferencePage.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Gradle Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.buildship.ui.internal.preferences;
+
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
+import org.eclipse.jface.preference.PreferencePage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+import org.eclipse.buildship.core.internal.CorePlugin;
+import org.eclipse.buildship.core.internal.configuration.ConfigurationManager;
+import org.eclipse.buildship.core.internal.configuration.WorkspaceConfiguration;
+import org.eclipse.buildship.ui.internal.util.widget.HoverText;
+
+/**
+ * The main workspace preference page for Buildship. Currently only used to configure the Gradle
+ * User Home.
+ */
+public final class GradleExperimentalFeaturesPreferencePage extends PreferencePage implements IWorkbenchPreferencePage {
+
+    public static final String PAGE_ID = "org.eclipse.buildship.ui.preferences.experimental";
+    private Button enableModuleSuppotCheckbox;
+
+    @Override
+    public void init(IWorkbench workbench) {
+    }
+
+    @Override
+    protected Control createContents(Composite parent) {
+        Composite composite = new Composite(parent, SWT.NONE);
+        GridLayoutFactory.swtDefaults().numColumns(1).margins(0, 0).applyTo(composite);
+
+        this.enableModuleSuppotCheckbox = new Button(parent, SWT.CHECK);
+        this.enableModuleSuppotCheckbox.setText("Enable module support");
+        this.enableModuleSuppotCheckbox.setSelection(CorePlugin.configurationManager().loadWorkspaceConfiguration().isExperimentalModuleSupportEnabled());
+        GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(this.enableModuleSuppotCheckbox);
+        HoverText.createAndAttach(this.enableModuleSuppotCheckbox, "Add module dependencies to the modulepath");
+
+        return composite;
+    }
+
+    @Override
+    public boolean performOk() {
+        ConfigurationManager manager = CorePlugin.configurationManager();
+        WorkspaceConfiguration c = manager.loadWorkspaceConfiguration();
+        manager.saveWorkspaceConfiguration(new WorkspaceConfiguration(c.getGradleDistribution(), c.getGradleUserHome(), c.getJavaHome(), c.isOffline(), c.isBuildScansEnabled(),
+                c.isAutoSync(), c.getArguments(), c.getJvmArguments(), c.isShowConsoleView(), c.isShowExecutionsView(), this.enableModuleSuppotCheckbox.getSelection()));
+        return true;
+    }
+}

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/preferences/GradleWorkbenchPreferencePage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/preferences/GradleWorkbenchPreferencePage.java
@@ -44,6 +44,7 @@ public final class GradleWorkbenchPreferencePage extends PreferencePage implemen
     private final Validator<GradleDistributionViewModel> distributionValidator;
 
     private GradleProjectSettingsComposite gradleProjectSettingsComposite;
+    private boolean experimentalModuleSupportEnabled;
 
 
     public GradleWorkbenchPreferencePage() {
@@ -78,6 +79,7 @@ public final class GradleWorkbenchPreferencePage extends PreferencePage implemen
         this.gradleProjectSettingsComposite.getAutoSyncCheckbox().setSelection(config.isAutoSync());
         this.gradleProjectSettingsComposite.getShowConsoleViewCheckbox().setSelection(config.isShowConsoleView());
         this.gradleProjectSettingsComposite.getShowExecutionsViewCheckbox().setSelection(config.isShowExecutionsView());
+        this.experimentalModuleSupportEnabled = config.isExperimentalModuleSupportEnabled();
     }
 
     private void addListeners() {
@@ -101,7 +103,7 @@ public final class GradleWorkbenchPreferencePage extends PreferencePage implemen
         List<String> jvmArguments = this.gradleProjectSettingsComposite.getAdvancedOptionsGroup().getJvmArguments();
         boolean showConsoleView = this.gradleProjectSettingsComposite.getShowConsoleViewCheckbox().getSelection();
         boolean showExecutionsView = this.gradleProjectSettingsComposite.getShowExecutionsViewCheckbox().getSelection();
-        WorkspaceConfiguration workspaceConfig = new WorkspaceConfiguration(distribution, gradleUserHome, javaHome, offlineMode, buildScansEnabled, autoSync, arguments, jvmArguments, showConsoleView, showExecutionsView);
+        WorkspaceConfiguration workspaceConfig = new WorkspaceConfiguration(distribution, gradleUserHome, javaHome, offlineMode, buildScansEnabled, autoSync, arguments, jvmArguments, showConsoleView, showExecutionsView, this.experimentalModuleSupportEnabled);
         CorePlugin.configurationManager().saveWorkspaceConfiguration(workspaceConfig);
         return super.performOk();
     }


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #1045 ?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Running junit tests from eclipse will give a 'module not found' exception if a modular library is required by the project. This commit fixes that.