### PR TITLE
Update to Guava 30.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ def eclipseVersionAgnosticDependencies = [
     'org.gradle.toolingapi'                 : toolingApiBundleVersion,
     'org.slf4j.api'                         : '1.7.2',
     'org.slf4j.simple'                      : '1.7.2',
-    'com.google.guava'                      : '27.1.0',
+    'com.google.guava'                      : '30.1.0',
     'com.google.gson'                       : '2.7.0',
     'org.apache.log4j'                      : '1.2.15',
     'org.eclipse.swtbot.eclipse.finder'     : '2.2.1',

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     compile 'nu.studer:java-ordered-properties:1.0.1'
     compile 'org.apache.maven:maven-ant-tasks:2.1.3'
     compile 'bcel:bcel:5.1'
-    compile 'com.google.guava:guava:27.1-jre'
+    compile 'com.google.guava:guava:30.1-jre'
 }
 

--- a/buildship.setup
+++ b/buildship.setup
@@ -635,7 +635,7 @@
           versionRange="2.7.0"/>
       <requirement
           name="com.google.guava"
-          versionRange="27.1.0"/>
+          versionRange="30.1.0"/>
       <requirement
           name="org.slf4j.api"
           versionRange="1.7.2"/>

--- a/org.eclipse.buildship.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.core/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.core.expressions,
  org.eclipse.jdt.launching,
  org.eclipse.debug.core,
  org.gradle.toolingapi;bundle-version="[7.0.0,7.1.0)";visibility:=reexport,
- com.google.guava;bundle-version="[27.0.0,28.0.0)",
+ com.google.guava;bundle-version="[30.1.0,32.0.0)",
  com.google.gson;bundle-version="[2.7.0,3.0.0)"
 Bundle-ActivationPolicy: lazy
 Import-Package: org.slf4j;version="1.7.2"

--- a/org.eclipse.buildship.kotlin/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.kotlin/META-INF/MANIFEST.MF
@@ -15,6 +15,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.buildship.core,
  org.jetbrains.kotlin.bundled-compiler;bundle-version="[0.8.5,0.9.0)",
  org.jetbrains.kotlin.core;bundle-version="[0.8.5,0.9.0)",
- com.google.guava;bundle-version="[27.0.0,28.0.0)",
+ com.google.guava;bundle-version="[30.1.0,32.0.0)",
  org.gradle.toolingapi;bundle-version="[5.5.0,5.6.0)"
 Import-Package: org.slf4j;version="1.7.2"

--- a/org.eclipse.buildship.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.ui/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Require-Bundle: org.eclipse.buildship.core,
  org.eclipse.jface.databinding,
  org.eclipse.jface.text,
  com.ibm.icu,
- com.google.guava;bundle-version="[27.0.0,28.0.0)",
+ com.google.guava;bundle-version="[30.1.0,32.0.0)",
  org.gradle.toolingapi;bundle-version="[7.0.0,7.1.0)",
  org.eclipse.ui.workbench.texteditor
 Bundle-ActivationPolicy: lazy

--- a/tooling-e416.target
+++ b/tooling-e416.target
@@ -9,7 +9,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="com.google.gson" version="2.7.0.v20170129-0911"/>
-            <unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
+            <unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
             <unit id="org.junit" version="4.12.0.v201504281640"/>
             <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
             <repository location="https://builds.gradle.org:8001/eclipse/update-site/mirror/orbit-rolling/"/>


### PR DESCRIPTION
- Fixes #1075
- Bump minimum Guava version to 30.1.0 and eliminate 27.1.0 from target
  platform

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>

This change requires an update to the orbit-rolling gradle update site. It currently seems to include the 2020-12 (4.18) repo but not the 2021-03 (4.19) or 2021-06 (4.20) repo. I was able to confirm things would work with the following local change :

```
diff --git a/tooling-e416.target b/tooling-e416.target
index 1efcaf0d..52a573fe 100644
--- a/tooling-e416.target
+++ b/tooling-e416.target
@@ -12,7 +12,7 @@
             <unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
             <unit id="org.junit" version="4.12.0.v201504281640"/>
             <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
-            <repository location="https://builds.gradle.org:8001/eclipse/update-site/mirror/orbit-rolling/"/>
+            <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.2.1.201402241301"/>
```