### PR TITLE
Check JDT.LS bundle when org.eclipse.platform is unavailable

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/eclipse/PlatformUtils.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/eclipse/PlatformUtils.java
@@ -21,10 +21,20 @@ public class PlatformUtils {
     public static boolean supportsTestAttributes() {
         Bundle platformBundle = Platform.getBundle("org.eclipse.platform");
         if (platformBundle == null) {
-            return false;
+        	// the bundle "org.eclipse.platform" will be null when it's JDT.LS
+        	// in that case we check the JDT.LS bundle
+            return supportsTestAttrubutesInJdtLs();
         }
         Version platform = platformBundle.getVersion();
         Version eclipseLuna = new Version(4, 8, 0);
         return platform.compareTo(eclipseLuna) >= 0;
+    }
+    
+    private static boolean supportsTestAttrubutesInJdtLs() {
+    	Bundle lsBundle = Platform.getBundle("org.eclipse.jdt.ls.core");
+        if (lsBundle == null) {
+            return false;
+        }
+        return lsBundle.getVersion().compareTo(new Version(1, 0, 0)) >= 0;
     }
 }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/eclipse/PlatformUtils.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/eclipse/PlatformUtils.java
@@ -30,7 +30,7 @@ public class PlatformUtils {
         return platform.compareTo(eclipseLuna) >= 0;
     }
     
-    private static boolean supportsTestAttrubutesInJdtLs() {
+    private static boolean supportsTestAttributesInJdtLs() {
     	Bundle lsBundle = Platform.getBundle("org.eclipse.jdt.ls.core");
         if (lsBundle == null) {
             return false;


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #1094 

### Context
related with https://github.com/microsoft/vscode-java-debug/issues/1008

More details can be found in #1094.

Basically, we also check `org.eclipse.jdt.ls.core` when `org.eclipse.platform` is unavailable in the JDT.LS context.
Then the buildship can call `GradleClasspathContainerRuntimeClasspathEntryResolver.runtimeClasspathWithTestSources()` to get more accurate classpath in VS Code Java
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
