### PR TITLE
Try to find the project first when load configuration

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationInvalidLocationTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/SynchronizationInvalidLocationTest.groovy
@@ -16,7 +16,7 @@ import org.eclipse.buildship.core.internal.test.fixtures.ProjectSynchronizationS
 
 class SynchronizationInvalidLocationTest extends ProjectSynchronizationSpecification {
 
-   def "Can import a nonexistent location"() {
+   def "Cannot import a nonexistent location"() {
        setup:
        File location = new File('nonexistent')
 
@@ -24,7 +24,8 @@ class SynchronizationInvalidLocationTest extends ProjectSynchronizationSpecifica
        SynchronizationResult result = tryImportAndWait(location)
 
        then:
-       result.status.isOK()
+       result.status.severity == IStatus.WARNING
+       ToolingApiStatusType.IMPORT_ROOT_DIR_FAILED.matches(result.status)
    }
 
    def "Cannot import a plain file"() {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/DefaultConfigurationManager.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/DefaultConfigurationManager.java
@@ -115,7 +115,7 @@ public class DefaultConfigurationManager implements ConfigurationManager {
         if (project.isAccessible()) {
             try {
                 pathToRoot = this.buildConfigurationPersistence.readPathToRoot(project);
-            } catch (RuntimeException e) {
+            } catch (Exception e) {
                 // fallback to the file IO based preferences store.
             }   
         }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/ImportRootProjectOperation.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/ImportRootProjectOperation.java
@@ -65,8 +65,8 @@ public final class ImportRootProjectOperation {
 
                 File rootDir = ImportRootProjectOperation.this.buildConfiguration.getRootProjectDirectory();
                 verifyNoWorkspaceRootIsImported(rootDir, progress.newChild(1));
-                saveProjectConfiguration(ImportRootProjectOperation.this.buildConfiguration, rootDir, progress.newChild(1));
                 importRootProject(rootDir, progress.newChild(1));
+                saveProjectConfiguration(ImportRootProjectOperation.this.buildConfiguration, rootDir, progress.newChild(1));
             }
         }, monitor);
     }

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/internal/view/task/TaskViewContentTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/internal/view/task/TaskViewContentTest.groovy
@@ -10,7 +10,9 @@
 package org.eclipse.buildship.ui.internal.view.task
 
 import org.eclipse.core.resources.IResource
+import org.eclipse.core.resources.ProjectScope
 import org.eclipse.core.runtime.NullProgressMonitor
+import org.eclipse.core.runtime.preferences.IEclipsePreferences
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem
 
 import org.eclipse.buildship.core.internal.CorePlugin
@@ -116,17 +118,16 @@ class TaskViewContentTest extends BaseTaskViewTest {
         waitFor { taskTree.b }
     }
 
-    def "If one project has invalid configuration then tasks from other projects are still visible"(String config) {
+    def "If one project has invalid configuration then tasks from other projects are still visible"() {
         given:
         def first = dir("a") { file 'build.gradle' }
         def second = dir("b") { file 'build.gradle' }
         importAndWait(first)
         importAndWait(second)
-        fileTree(first) {
-            dir('.settings') {
-                file("${CorePlugin.PLUGIN_ID}.prefs").text = config
-            }
-        }
+        IEclipsePreferences preferences = new ProjectScope(findProject('a')).getNode(CorePlugin.PLUGIN_ID)
+        preferences.put('connection.project.dir', 'invalid')
+        preferences.flush()
+
         findProject('a').refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor())
 
         when:
@@ -135,9 +136,6 @@ class TaskViewContentTest extends BaseTaskViewTest {
         then:
         waitFor { !taskTree.a }
         waitFor { taskTree.b }
-
-        where:
-        config << ['', 'connection.project.dir=invalid']
     }
 
     def "The task view is refreshed when projects are added/deleted"() {


### PR DESCRIPTION
Signed-off-by: Sheng Chen <sheche@microsoft.com>

<!--- The issue this PR addresses -->
Fixes #1111

### Changed things
1. As other methods in `DefaultConfigurationManager`, It will first try to find the project by the given dir path, if it's found. use the platform API to deal with the preferences file. Otherwise fallback to IO based approach.
2. In import stage, I changed to task order to first import the project then persist the configurations.
   > Same procedures can be found in m2e, `org.eclipse.m2e.core.internal.project.ProjectConfigurationManager#importProjects() -> create() -> enableBasicMavenNature() -> saveResolverConfiguration()`
3. In test cases, because we will persist the preferences after project import, so the non-existence folder won't exist when starts import, so the result status is changed to warning. (Previously, the folder is created when persisting the preferences file via [Java IO API](https://github.com/eclipse/buildship/blob/0c31d23e4af982c3f8e61f31b70dda495203c888/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/PreferenceStore.java#L241-L244))

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

More context can be found in the context section of #1111 

_// cc @rgrunber @fbricon for awareness._