### PR TITLE
Fixes oomph test configuration variables

### DIFF
--- a/buildship.setup
+++ b/buildship.setup
@@ -52,6 +52,14 @@
         <description>Redirect setup model to check for changes in the local file instead in the url</description>
       </setupTask>
       <setupTask
+        xsi:type="setup:EclipseIniTask"
+        option="-Dbuildship.jre.location-1.8"
+        value="=${jre.location-1.8}"/>
+      <setupTask
+        xsi:type="setup:EclipseIniTask"
+        option="-Dbuildship.jre.location-11"
+        value="=${jre.location-11}"/>
+      <setupTask
           xsi:type="jdt:JRETask"
           id="buildship.preferences.compiler.jre8"
           version="JavaSE-1.8"
@@ -564,16 +572,7 @@
         id="installation.id"
         name="installation.id"
         defaultValue="buildship"/>
-    <setupTask
-        xsi:type="setup:VariableTask"
-        id="jre.location-1.8"
-        name="jre.location-1.8"
-        defaultValue="${jre.location-1.8}"/>
-    <setupTask
-        xsi:type="setup:VariableTask"
-        id="jre.location-11"
-        name="jre.location-11"
-        defaultValue="${jre.location-11}"/>
+
   </setupTask>
   <setupTask
       xsi:type="git:GitCloneTask"

--- a/org.eclipse.buildship.core.test/Launch Buildship core tests.launch
+++ b/org.eclipse.buildship.core.test/Launch Buildship core tests.launch
@@ -34,7 +34,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.buildship.core.test"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Djdk8.location=${jre.location-1.8} -Djdk11.location=${jre.location-11}"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Djdk8.location=&quot;${system_property:buildship.jre.location-1.8}&quot; -Djdk11.location=&quot;${system_property:buildship.jre.location-11}&quot;"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
     <booleanAttribute key="run_in_ui_thread" value="false"/>

--- a/org.eclipse.buildship.ui.test/Launch Buildship UI tests.launch
+++ b/org.eclipse.buildship.ui.test/Launch Buildship UI tests.launch
@@ -34,7 +34,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.eclipse.buildship.ui.test"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Djdk8.location=${jre.location-1.8} -Djdk11.location=${jre.location-11}"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-ea -Djdk8.location=&quot;${system_property:buildship.jre.location-1.8}&quot; -Djdk11.location=&quot;${system_property:buildship.jre.location-11}&quot;"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.sdk.ide"/>
     <booleanAttribute key="run_in_ui_thread" value="false"/>


### PR DESCRIPTION
@donat `setup:VariableTask` was not doing what I expected. I changed it to add a system property to the `eclipse.ini`. After running Help > Perform setup task, Eclipse adds the system properties:

![oomph-improvement-1](https://user-images.githubusercontent.com/2384738/167151670-338bfa30-60b7-4a63-9203-d62b6d3f8b30.png)

I also quoted the path to the JDK as you requested in #1154.
