### PR TITLE
Provides GH action for Buildship PR validation

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,17 @@
+name: CI
+on: [pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: 'gradle'
+      - name: Build with Gradle
+        run: ./gradlew build  -x eclipseTest -Pbuild.invoker=ci
+
+


### PR DESCRIPTION
Currently BuildShip seems to have no visible build confirmation, adding
this GH action to ensure BuildShip PR are validated and also to validate
that the BuildShip build works as documented.

<!--- The issue this PR addresses -->
Fixes #?

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
