### PR TITLE
Fixes RepositoryNotFoundException

### DIFF
--- a/docs/development/OomphImport.md
+++ b/docs/development/OomphImport.md
@@ -1,0 +1,19 @@
+# Testing buildship.setup
+By default, Oomph will use the master version at: https://raw.githubusercontent.com/eclipse/buildship/master/buildship.setup.
+
+The installer can be instructed to use a different version (e.g. via eclipse-inst.ini):
+
+```ini
+-Doomph.redirection.buildship=https://raw.githubusercontent.com/eclipse/buildship/master/buildship.setup->file:/<path to buildship checkout>/buildship.setup 
+```
+
+Windows has no eclipse-inst.ini, do this instead:
+
+```
+.\eclipse-inst-jre-win64.exe -vmargs '-Doomph.redirection.buildship=https://raw.githubusercontent.com/eclipse/buildship/master/buildship.setup->file:/<path to buildship checkout>/buildship.setup'
+```
+
+Replace `<path to buildship checkout>` with the location of your Buildship checkout.
+On the variables page, enter the URL of your fork, `https://github.com/<user>/buildship`, and the branch you want to checkout. This step can be skipped, if you only want to test changes to your `buildship.setup` (the local version will be used). 
+To redirect Eclipse to use the local `buildship.setup`, use `-Dbuildship.oomphtest.enabled=true`. It will add another variable `buildship.oomphtest.setupLocation`. Set it to `<path to buildship checkout>/buildship.setup`. 
+Without this configuration, the new Eclipse installation, will perform the setup tasks using the `buildship.setup` from the update site.

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -4,3 +4,4 @@ The following developer documentation of Buildship is currently available:
 
 1. [Development setup](Setup.md)
 2. [Public API examples](ApiExamples.md)
+3. [Oomph Import](OomphImport.md)

--- a/samples/oomph-setup/README.md
+++ b/samples/oomph-setup/README.md
@@ -8,19 +8,12 @@ Oomph will import an example gradle project using Buildship.
 
 # Testing against the local checkout
 By default the setup tasks uses the latest released Buildship version from the update site. The eclipse
-installer can be instructed to use the local site and model by the eclipse installer with the following parameters (e.g. via eclipse-inst.ini):
+installer can be instructed to use the local site and model by building it using `gradlew :org.eclipse.buildship.site:build` and
+supplying the eclipse installer with the following parameters (e.g. via eclipse-inst.ini):
 
 ```ini
--Doomph.redirection.buildship=https://raw.githubusercontent.com/eclipse/buildship/master/buildship.setup->file:/<path to buildship checkout>/buildship.setup 
+-Doomph.redirection.bs=https://raw.githubusercontent.com/eclipse/buildship/master/org.eclipse.buildship.oomph/model/GradleImport-1.0.ecore->file:/<path to builship checkout>/org.eclipse.buildship.oomph/model/GradleImport-1.0.ecore
+-Doomph.redirection.p2.buildship=https://download.eclipse.org/buildship/updates/latest->file:/<path to builship checkout>/org.eclipse.buildship.site/build/repository
 ```
 
-Windows has no eclipse-inst.ini, do this instead:
-
-```
-.\eclipse-inst-jre-win64.exe -vmargs '-Doomph.redirection.buildship=https://raw.githubusercontent.com/eclipse/buildship/master/buildship.setup->file:/<path to buildship checkout>/buildship.setup'
-```
-
-Replace `<path to buildship checkout>` with the location of your buildship checkout.
-On the variables page, enter the URL of your fork, `https://github.com/<user>/buildship`, and the branch you want to checkout. This step can be skipped, if you only want to test changes to your `buildship.setup` (the local version will be used). 
-To redirect Eclipse to use the local `buildship.setup`, use `-Dbuildship.oomphtest.enabled=true`. It will add another variable `buildship.oomphtest.setupLocation`. Set it to `<path to buildship checkout>/buildship.setup`. 
-Without this configuration, the new Eclipse installation, will perform the setup tasks using the `buildship.setup` from the update site.
+Replace `<path to builship checkout>` with the location of your buildship checkout.


### PR DESCRIPTION
Fixes #1149

JGit expects an empty directory, but `buildship.setup` generates the `tooling-local.target`, which leads to the `RepositoryNotFoundException`. For reference, I tried to find out how other projects use `pde:TargetPlatformTask`. I looked at
- https://github.com/eclipse/dartboard/blob/master/target-platform-latest/target-platform-latest.target
- https://github.com/eclipse/dartboard/blob/master/org.eclipse.dartboard.releng/Dartboard.setup

Both define a "latest" setup file that is used. I copied this approach. The generated `tooling-local.target` seems broken anyway, because it is identical to the 2021-12 target. Not sure how this was supposed to work.

The remaining changes are not great, but I could not find another way to test my local `buildship.setup` with the Eclipse installer. I documented how this is supposed to be used in the oomph-setup readme.