### PR TITLE
Fix Unsatisfied version constraint: 'org.gradle.toolingapi: [7.4.2,7.5.0)'

### DIFF
--- a/org.gradle.toolingapi/META-INF/MANIFEST.MF
+++ b/org.gradle.toolingapi/META-INF/MANIFEST.MF
@@ -28,4 +28,4 @@ Export-Package: org.gradle.api;version="7.4.2",
  org.gradle.tooling.model.idea;version="7.4.2",
  org.gradle.tooling.model.java;version="7.4.2",
  org.gradle.tooling.model.kotlin.dsl;version="7.4.2"
-Bundle-Version: 3.1.7.qualifier
+Bundle-Version: 7.4.2.qualifier


### PR DESCRIPTION
@donat , in a3df26ac3e1ce6b3b87f1dae9b9655f13997ffd3 you seem to have updated the `org.gradle.toolingapi` bundle version by accident. This leads to lots of errors in Eclipse.
