### PR TITLE
Add Oomph setup compatibility with more than one Eclipse version

### DIFF
--- a/buildship.setup
+++ b/buildship.setup
@@ -30,6 +30,12 @@
   <!-- See https://github.com/groovy/groovy-eclipse/wiki#releases -->
   <setupTask
       xsi:type="setup.p2:P2Task"
+      filter="(scope.product.version.name=2022-09)">
+    <repository
+        url="https://dist.springsource.org/snapshot/GRECLIPSE/e4.25"/>
+  </setupTask>
+  <setupTask
+      xsi:type="setup.p2:P2Task"
       filter="(scope.product.version.name=2022-06)">
     <repository
         url="http://dist.springsource.org/snapshot/GRECLIPSE/e4.24"/>


### PR DESCRIPTION
Currently the groovy-eclipse repository targets one specific Eclipse version. If a different Eclipse version is selected in the Eclipse installer, the dependency resolution fails with a cryptic error (something about not being able to resolve artifical root). This has come up in a number of issues. For example #1184.

I don't think it is a good idea to limit the Oomph setup to one specific Eclipse Platform Version.