### PR TITLE
Save versions cache file in plugin's state location by default

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersions.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersions.java
@@ -37,6 +37,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
+import org.eclipse.buildship.core.internal.CorePlugin;
+
 /**
  * Provides information about the Gradle versions available from services.gradle.org. The version information can optionally be cached on the local file system.
  *
@@ -220,10 +222,10 @@ public final class PublishedGradleVersions {
     private static File getCacheFile() {
         // ensures compliance with XDG base spec: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
         String xdgCache = System.getenv("XDG_CACHE_HOME");
-        if (xdgCache == null) {
-            xdgCache = System.getProperty("user.home") + "/.cache/";
+        if (xdgCache != null) {
+            return new File(xdgCache, "tooling/gradle/versions.json");
         }
-        return new File(xdgCache, "tooling/gradle/versions.json");
+        return CorePlugin.getInstance().getStateLocation().append("cache").append("versions.json").toFile();
     }
 
     /**


### PR DESCRIPTION
Fixes #1178.

This PR changes the folder where the versions cache is stored to be inside buildship's state location. It keeps the xdgcache thing though and will use it if it's set.

### Context
In my case, the `.cache` folder where it was being saved previously was only used for this one file, and I doubt I'm the only one. Not only that, I think it makes sense for buildship's files to be in buildship's folder, according to [this Eclipse wiki page](https://wiki.eclipse.org/FAQ_Where_do_plug-ins_store_their_state%3F) it's the folder that should be used for "cached information".

Only testing I ran was from the set up Github Actions. Weirdly the default build failed because Gradle was unable to find dependencies for the `buildSrc` project. I changed the repos (in another branch) just for the purposes of running the build, and it then passed.