### PR TITLE
Sort Project Configurators according to their runsBefore/runsAfter attributes (#1032)

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/extension/InternalProjectConfiguratorTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/extension/InternalProjectConfiguratorTest.groovy
@@ -57,29 +57,21 @@ class InternalProjectConfiguratorTest extends WorkspaceSpecification {
         setup:
         ProjectConfiguratorContribution c1 = configurator('c1')
         ProjectConfiguratorContribution c2 = configurator('c2')
-        List<InternalProjectConfigurator> configurators = InternalProjectConfigurator.from([c1, c2])
 
         when:
-        configurators = configurators.toSorted()
+        List<InternalProjectConfigurator> configurators = InternalProjectConfigurator.from([c1, c2])
 
         then:
         assertOrder(configurators, 'c1', 'c2')
-
-        when:
-        configurators = configurators.reverse().toSorted()
-
-        then:
-        assertOrder(configurators, 'c2', 'c1')
     }
 
     def "Ordering respects 'runsBefore' dependency"() {
         setup:
         ProjectConfiguratorContribution c1 = configurator('c1')
         ProjectConfiguratorContribution c2 = configurator('c2', ['c1'])
-        List<InternalProjectConfigurator> configurators = InternalProjectConfigurator.from([c1, c2])
 
         when:
-        configurators = configurators.toSorted()
+        List<InternalProjectConfigurator> configurators = InternalProjectConfigurator.from([c1, c2])
 
         then:
         assertOrder(configurators, 'c2', 'c1')
@@ -89,10 +81,9 @@ class InternalProjectConfiguratorTest extends WorkspaceSpecification {
         setup:
         ProjectConfiguratorContribution c1 = configurator('c1', [], ['c2'])
         ProjectConfiguratorContribution c2 = configurator('c2')
-        List<InternalProjectConfigurator> configurators = InternalProjectConfigurator.from([c1, c2])
 
         when:
-        configurators = configurators.toSorted()
+        List<InternalProjectConfigurator> configurators = InternalProjectConfigurator.from([c1, c2])
 
         then:
         assertOrder(configurators, 'c2', 'c1')
@@ -103,10 +94,9 @@ class InternalProjectConfiguratorTest extends WorkspaceSpecification {
         ProjectConfiguratorContribution c1 = configurator('c1', ['c2'])
         ProjectConfiguratorContribution c2 = configurator('c2', ['c3'])
         ProjectConfiguratorContribution c3 = configurator('c3', ['c1'])
-        List<InternalProjectConfigurator> configurators = InternalProjectConfigurator.from([c3, c2, c1])
 
         when:
-        configurators = configurators.toSorted()
+        List<InternalProjectConfigurator> configurators = InternalProjectConfigurator.from([c3, c2, c1])
 
         then:
         assertOrder(configurators, 'c2', 'c3', 'c1')

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/extension/InternalProjectConfigurator.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/extension/InternalProjectConfigurator.java
@@ -10,6 +10,7 @@
 package org.eclipse.buildship.core.internal.extension;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +90,11 @@ public final class InternalProjectConfigurator implements ProjectConfigurator, C
         filterDuplicateIds(configurators);
         filterInvalidDependencies(configurators);
         filterCylicDependencies(configurators);
-        return configurators.stream().map(c -> new InternalProjectConfigurator(c)).collect(Collectors.toList());
+
+        List<InternalProjectConfigurator> internalConfigurators = configurators.stream().map(c -> new InternalProjectConfigurator(c)).collect(Collectors.toList());
+        Collections.sort(internalConfigurators);
+
+        return internalConfigurators;
     }
 
     private static void filterInvalidConfigurators(List<ProjectConfiguratorContribution> configurators) {


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #1032

### Context
<!--- Why do you believe many users will benefit from this change? -->
When adding a ProjectConfigurator with the extension "org.eclipse.buildship.core.projectconfigurators", the "runsBefore" and "runsAfter" attributes are not considered. No matter the values set on these attributes, the new ProjectConfigurator is always executed the default ones.

This change makes sure that the ProjectConfigurator objects returned by the method org.eclipse.buildship.core.internal.extension.InternalProjectConfigurator.from(List<ProjectConfiguratorContribution>) are always sorted according the these attributes.

The related tests have been adapted to test the behavior of the org.eclipse.buildship.core.internal.extension.InternalProjectConfigurator.from(List<ProjectConfiguratorContribution>) method.

<!--- Link to relevant issues or forum discussions here -->
https://github.com/eclipse/buildship/issues/1032