### PR TITLE
Fix for undo/redo and editor toolbar actions

### DIFF
--- a/org.eclipse.buildship.ui/plugin.xml
+++ b/org.eclipse.buildship.ui/plugin.xml
@@ -656,4 +656,13 @@
        </activeWhen>
        </projectConfigurator>
     </extension>
+    <extension
+          point="org.eclipse.ui.actionSetPartAssociations">
+       <actionSetPartAssociation
+             targetID="org.eclipse.ui.edit.text.actionSet.presentation">
+          <part
+                id="org.eclipse.buildship.ui.gradlebuildscripteditor">
+          </part>
+       </actionSetPartAssociation>
+    </extension>
 </plugin>

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/editor/GradleEditorContributor.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/editor/GradleEditorContributor.java
@@ -10,7 +10,7 @@
 package org.eclipse.buildship.ui.internal.editor;
 
 import org.eclipse.jface.action.IToolBarManager;
-import org.eclipse.ui.part.EditorActionBarContributor;
+import org.eclipse.ui.texteditor.BasicTextEditorActionContributor;
 
 import org.eclipse.buildship.ui.internal.workspace.RefreshProjectAction;
 
@@ -19,7 +19,7 @@ import org.eclipse.buildship.ui.internal.workspace.RefreshProjectAction;
  *
  * @author Christophe Moine
  */
-public class GradleEditorContributor extends EditorActionBarContributor {
+public class GradleEditorContributor extends BasicTextEditorActionContributor {
 
     @Override
     public void contributeToToolBar(IToolBarManager toolBarManager) {


### PR DESCRIPTION
Fixes #1188 and #1211

The first commit insures that on editor part activation the toolbar buttons (e.g. Show Whitespace Characters) and global action handlers (e.g. Undo Typing) are correctly restored.

The second commit enables the buttons from the _Editor Presentation_ toolbar (e.g. Show Whitespace Characters) for the Gradle Build Script Editor (like the _Default Text Editor_ or _Generic Editor_).