### PR TITLE
Support of Kotlin DSL files [google summer of code]

### DIFF
--- a/org.eclipse.buildship.kotlindsl.provider/.classpath
+++ b/org.eclipse.buildship.kotlindsl.provider/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.buildship.kotlindsl.provider/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.kotlindsl.provider/META-INF/MANIFEST.MF
@@ -12,4 +12,5 @@ Require-Bundle: org.eclipse.core.contenttype,
  org.eclipse.tm4e.registry,
  org.eclipse.jdt.launching,
  org.eclipse.swt
-Automatic-Module-Name: org.eclipse.buildship.kotlindsl.provider
+Export-Package: org.eclipse.buildship.kotlindsl.provider
+

--- a/org.eclipse.buildship.kotlindsl.provider/build.gradle
+++ b/org.eclipse.buildship.kotlindsl.provider/build.gradle
@@ -1,1 +1,16 @@
+plugins{
+	id 'de.undercouch.download' version '5.4.0'
+}
+
 apply plugin: eclipsebuild.BundlePlugin
+dependencies {
+	api withEclipseBundle("org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}")
+}
+
+def copyLibs = tasks.register('downloadLibs', Download) {
+	src 'https://maven.pkg.github.com/D0zee/language-server-for-KTS-scripts/kts-language-server/server/1.0.0/server-1.0.0-all.jar'
+	dest file('libs')
+	// type here own an username and key (classic token from github which allows read packages)
+	username project.findProperty('gpr.user')
+	password project.findProperty('gpr.key')
+}

--- a/org.eclipse.buildship.kotlindsl.provider/build.properties
+++ b/org.eclipse.buildship.kotlindsl.provider/build.properties
@@ -1,6 +1,8 @@
-source.. = src/
+source.. = src/main/java,
 output.. = bin/
 bin.includes = .,\
+               libs/,\
                plugin.xml,\
                kotlin.tmLanguage.json,\
                META-INF/
+

--- a/org.eclipse.buildship.kotlindsl.provider/build.properties
+++ b/org.eclipse.buildship.kotlindsl.provider/build.properties
@@ -2,5 +2,5 @@ source.. = src/
 output.. = bin/
 bin.includes = .,\
                plugin.xml,\
-               src/main/resources/Kotlin.tmLanguage.json,\
+               kotlin.tmLanguage.json,\
                META-INF/

--- a/org.eclipse.buildship.kotlindsl.provider/kotlin.tmLanguage.json
+++ b/org.eclipse.buildship.kotlindsl.provider/kotlin.tmLanguage.json
@@ -14,7 +14,6 @@
         }
     ],
     "fileTypes": [
-        "kt",
         "kts"
     ],
     "repository": {

--- a/org.eclipse.buildship.kotlindsl.provider/plugin.xml
+++ b/org.eclipse.buildship.kotlindsl.provider/plugin.xml
@@ -14,7 +14,7 @@
    <extension
          point="org.eclipse.tm4e.registry.grammars">
       <grammar
-            path="src/main/resources/Kotlin.tmLanguage.json"
+            path="kotlin.tmLanguage.json"
             scopeName="source.kotlin">
       </grammar>
       <scopeNameContentTypeBinding

--- a/org.eclipse.buildship.kotlindsl.provider/plugin.xml
+++ b/org.eclipse.buildship.kotlindsl.provider/plugin.xml
@@ -5,7 +5,7 @@
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type
             base-type="org.eclipse.core.runtime.text"
-            file-extensions="kts"
+            file-patterns="*.gradle.kts"
             id="org.eclipse.buildship.kotlindsl.content"
             name="kotlin DSL content type"
             priority="normal">
@@ -28,6 +28,19 @@
             contentTypeId="org.eclipse.buildship.kotlindsl.content"
             editorId="org.eclipse.ui.genericeditor.GenericEditor">
       </editorContentTypeBinding>
+   </extension>
+
+   <extension
+         point="org.eclipse.lsp4e.languageServer">
+      <contentTypeMapping
+            contentType="org.eclipse.buildship.kotlindsl.content"
+            id="org.eclipse.buildship.kotlindsl.provider.server">
+      </contentTypeMapping>
+      <server
+            class="org.eclipse.buildship.kotlindsl.provider.KotlinDSLConnectionProvider"
+            id="org.eclipse.buildship.kotlindsl.provider.server"
+            label="Kotlin DSL language server">
+      </server>
    </extension>
 
 </plugin>

--- a/org.eclipse.buildship.kotlindsl.provider/src/main/java/org/eclipse/buildship/kotlindsl/provider/KotlinDSLConnectionProvider.java
+++ b/org.eclipse.buildship.kotlindsl.provider/src/main/java/org/eclipse/buildship/kotlindsl/provider/KotlinDSLConnectionProvider.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Gradle Inc. and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.buildship.kotlindsl.provider;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Arrays;
+
+import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
+import org.eclipse.lsp4e.server.StreamConnectionProvider;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.Bundle;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
+
+/**
+ * Is a entry point to launching of a kotlin language server.
+ *
+ * @author Nikolai Vladimirov
+ */
+
+public class KotlinDSLConnectionProvider extends ProcessStreamConnectionProvider
+    implements StreamConnectionProvider {
+
+  public KotlinDSLConnectionProvider() {
+    URL localFileURL;
+    Bundle bundle = FrameworkUtil.getBundle(KotlinDSLConnectionProvider.class);
+    try {
+      localFileURL = FileLocator.toFileURL(bundle.getEntry("/"));
+      URI localFileURI = new URI(localFileURL.toExternalForm());
+      Path pathToPlugin = Paths.get(localFileURI.getPath());
+
+      String pathToServer = pathToPlugin.resolve("libs/server-1.0.0-all.jar").toString();
+
+      IExecutionEnvironment[] executionEnvironments = JavaRuntime.getExecutionEnvironmentsManager()
+          .getExecutionEnvironments();
+
+      IExecutionEnvironment java11Environment = null;
+
+      for (IExecutionEnvironment environment : executionEnvironments) {
+        if (environment.getId().equals("JavaSE-11")) {
+          java11Environment = environment;
+          break;
+        }
+      }
+
+      ArrayList<IVMInstall> compatibleJVMs = new ArrayList<>(
+          Arrays.asList(java11Environment.getCompatibleVMs()));
+      IVMInstall defaultVMInstall = JavaRuntime.getDefaultVMInstall();
+      IVMInstall javaExecutable = null;
+
+      if (!compatibleJVMs.isEmpty()) {
+        if (compatibleJVMs.contains(defaultVMInstall)) {
+          javaExecutable = defaultVMInstall;
+        } else {
+          javaExecutable = compatibleJVMs.get(0);
+        }
+
+        String pathToJavaExecutable = javaExecutable.getInstallLocation().toPath().resolve("bin")
+            .resolve("java")
+            .toString();
+
+        List<String> commands = new ArrayList<>(
+            Arrays.asList(pathToJavaExecutable, "-jar", pathToServer));
+
+        // add in commands path to bin application of language server
+        setCommands(commands);
+        setWorkingDirectory(pathToPlugin.toString());
+        
+      } else {
+        PlatformUI.getWorkbench().getDisplay().syncExec(new Runnable() {
+          public void run() {
+            Shell shell = new Shell();
+            MessageBox messageBox = new MessageBox(shell, SWT.ICON_WARNING | SWT.OK);
+            messageBox.setText("Error");
+            messageBox.setMessage(
+                "Compatible version of Java isn't found! Install and rerun application.");
+            messageBox.open();
+            shell.dispose();
+          }
+        });
+      }
+
+
+    } catch (IOException | URISyntaxException e) {
+      System.err.println("[GradlePropertiesConnectionProvider]:" + e.toString());
+      e.printStackTrace();
+    }
+  }
+
+}

--- a/org.eclipse.buildship.site/build.gradle
+++ b/org.eclipse.buildship.site/build.gradle
@@ -45,7 +45,7 @@ dependencies {
         localPlugin project(':org.eclipse.buildship.gradleprop.provider')
         localFeature project(':org.eclipse.buildship.gradleprop.feature')
 
-        localPlugin project('org.eclipse.buildship.kotlindsl.provider')
+        localPlugin project(':org.eclipse.buildship.kotlindsl.provider')
         localFeature project(':org.eclipse.buildship.kotlindsl.feature')
     }
     if (findProperty('include.experimental.features') == 'true') {

--- a/org.eclipse.buildship.site/category.xml
+++ b/org.eclipse.buildship.site/category.xml
@@ -12,6 +12,9 @@
    <feature url="features/org.eclipse.buildship.oomph_0.0.0.jar" id="org.eclipse.buildship.oomph" version="0.0.0">
       <category name="BuildshipExtras"/>
    </feature>
+   <feature id="org.eclipse.buildship.kotlindsl">
+      <category name="BuildshipExtrasIncubating"/>
+   </feature>
    <category-def name="Buildship" label="Buildship: Eclipse Plug-ins for Gradle"/>
    <category-def name="BuildshipExtras" label="Buildship Extras"/>
    <category-def name="BuildshipExtrasIncubating" label="Buildship Extras - Incubating"/>


### PR DESCRIPTION
This PR adds support for `.build.kts` files inside the Eclipse IDE. This plugin is a wrapper that checks whether the user has the required Java version and launches the KTS language server.

**About implementation of language server.**
 [Kotlin-language-server](https://github.com/fwcd/kotlin-language-server) was used as a basis. My fixes and modifications are located [here](https://github.com/D0zee/Eclipse-Gradle-KTS-editing/tree/language-server). The following work has been done:
 - Dependencies and implicit imports of the project are calculated by invoking the Gradle Tooling API instead of custom build scripts.
- If the build configuration is broken, the user receives a detailed error in all opened Kotlin build files, and subsequent compilation is impossible.
- The compilation system has been completely changed.
- Indexing and searching all types of files except `.gradle.kts` have been removed to increase the performance of the language server.
- Included builds are supported via a modified version of [CompositeModelQuery](https://github.com/eclipse/buildship/blob/master/org.eclipse.buildship.compat/src/main/java/org/eclipse/buildship/core/internal/workspace/CompositeModelQuery.java). 

**How Language Server Works?**

Each Kotlin build file has its own compilation environment to provide accurate diagnostics to the user. I decided to create a `Map< File, Set<Path> >` where the set of paths represents the classpath. This is necessary because if a user adds plugins, the classpath changes, and therefore the language server must update the compilation environment.

An important point to note is that the `updating of the compilation environment happens when the user saves the file.` In this scenario, the server checks two invariants to avoid unnecessary Tooling API (TAPI) calls:
- If the build configuration contains an error (TAPI call failed during initialization or the last attempt to update the compilation environment), the server updates ALL compilation environments.
- If the plugin block has been modified (the user added or removed some plugins), the server updates the compilation environment only for the current build file.

The Tooling API is invoked on each project and includes compilation information about subprojects and included builds. The language server decides whether to make the call based on two criteria:
1) If a subproject has a parent or is the root, the language server makes a TAPI call on the root project.
2) if 1st statement is false, but the directory contains `settings.gradle.kts` then language server invokes TAPI on this subproject.

**How are Errors Processed?**
If an error occurs during the initialization stage of the language server, the user receives a detailed description of the issue on each opened build file. Compilation doesn't proceed until the user fixes the errors and saves the files with problems. To obtain the most up-to-date and accurate diagnostics, the user must re-lint the file by either saving or editing it.


