### PR TITLE
Fix construction of paths for compatibility on Windows #1279

### DIFF
--- a/org.eclipse.buildship.gradleprop.ls/src/main/java/org/eclipse/buildship/gradleprop/ls/fileSync/FileSync.java
+++ b/org.eclipse.buildship.gradleprop.ls/src/main/java/org/eclipse/buildship/gradleprop/ls/fileSync/FileSync.java
@@ -13,6 +13,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -44,7 +46,13 @@ public class FileSync {
   }
 
   public boolean openFile(String uri) {
-    Path path = getPathFromUri(uri);
+    Path path;
+    try {
+      path = getPathFromUri(uri);
+    } catch (URISyntaxException e) {
+      LOGGER.error("Malformed uri:" + uri, e);
+      return false;
+    }
     try {
       String content = Files.readString(path);
       contentByUri.put(uri, new ContentInFile(content, 0));
@@ -92,9 +100,8 @@ public class FileSync {
   }
 
 
-  private Path getPathFromUri(String uri) {
-    String trimmedUri = uri.substring("file://".length());
-    return Paths.get(trimmedUri);
+  private Path getPathFromUri(String uri) throws URISyntaxException {
+    return Paths.get(new URI(uri));
   }
 
   private String applyChange(String content, TextDocumentContentChangeEvent change)

--- a/org.eclipse.buildship.gradleprop.provider/src/main/java/org/eclipse/buildship/gradleprop/provider/GradlePropertiesConnectionProvider.java
+++ b/org.eclipse.buildship.gradleprop.provider/src/main/java/org/eclipse/buildship/gradleprop/provider/GradlePropertiesConnectionProvider.java
@@ -10,7 +10,6 @@
 package org.eclipse.buildship.gradleprop.provider;
 
 import java.io.IOException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -43,12 +42,10 @@ public class GradlePropertiesConnectionProvider extends ProcessStreamConnectionP
     implements StreamConnectionProvider {
 
   public GradlePropertiesConnectionProvider() {
-    URL localFileURL;
     Bundle bundle = FrameworkUtil.getBundle(GradlePropertiesConnectionProvider.class);
     try {
-      localFileURL = FileLocator.toFileURL(bundle.getEntry("/"));
-      URI localFileURI = new URI(localFileURL.toExternalForm());
-      Path pathToPlugin = Paths.get(localFileURI.getPath());
+      URL localFileURL = FileLocator.toFileURL(bundle.getEntry("/"));
+      Path pathToPlugin = Paths.get(localFileURL.toURI());
 
       String pathToServer = pathToPlugin.resolve("libs/language-server.jar").toString();
 

--- a/org.eclipse.buildship.kotlindsl.provider/src/main/java/org/eclipse/buildship/kotlindsl/provider/KotlinDSLConnectionProvider.java
+++ b/org.eclipse.buildship.kotlindsl.provider/src/main/java/org/eclipse/buildship/kotlindsl/provider/KotlinDSLConnectionProvider.java
@@ -23,7 +23,6 @@ import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.Bundle;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -42,12 +41,10 @@ public class KotlinDSLConnectionProvider extends ProcessStreamConnectionProvider
     implements StreamConnectionProvider {
 
   public KotlinDSLConnectionProvider() {
-    URL localFileURL;
     Bundle bundle = FrameworkUtil.getBundle(KotlinDSLConnectionProvider.class);
     try {
-      localFileURL = FileLocator.toFileURL(bundle.getEntry("/"));
-      URI localFileURI = new URI(localFileURL.toExternalForm());
-      Path pathToPlugin = Paths.get(localFileURI.getPath());
+      URL localFileURL = FileLocator.toFileURL(bundle.getEntry("/"));
+      Path pathToPlugin = Paths.get(localFileURL.toURI());
 
       String pathToServer = pathToPlugin.resolve("libs/server-1.0.0-all.jar").toString();
 


### PR DESCRIPTION
The direct construction of paths from URIs ensures the correct handling of drive letters on Windows.

Fixes #1279