### PR TITLE
Fix editor bindings for gradle.properties and Kotlin DSL files

### DIFF
--- a/org.eclipse.buildship.gradleprop.provider/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.gradleprop.provider/META-INF/MANIFEST.MF
@@ -11,4 +11,5 @@ Require-Bundle: org.eclipse.core.contenttype,
  org.eclipse.lsp4j.jsonrpc,
  org.eclipse.core.runtime,
  org.eclipse.tm4e.registry,
- org.eclipse.jdt.launching
+ org.eclipse.jdt.launching,
+ org.eclipse.ui.genericeditor

--- a/org.eclipse.buildship.gradleprop.provider/plugin.xml
+++ b/org.eclipse.buildship.gradleprop.provider/plugin.xml
@@ -5,8 +5,7 @@
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type
             base-type="org.eclipse.core.runtime.text"
-            file-extensions="properties"
-            file-names="gradle"
+            file-names="gradle.properties"
             id="org.eclipse.buildship.gradleprop.provider.content"
             name="content for gradle.properties files"
             priority="normal">

--- a/org.eclipse.buildship.kotlindsl.provider/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.kotlindsl.provider/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle: org.eclipse.core.contenttype,
  org.eclipse.core.runtime,
  org.eclipse.tm4e.registry,
  org.eclipse.jdt.launching,
- org.eclipse.swt
+ org.eclipse.swt,
+ org.eclipse.ui.genericeditor
 Export-Package: org.eclipse.buildship.kotlindsl.provider
 


### PR DESCRIPTION
In order for the editor content type bindings configured in the `plugin.xml` to work correctly, the missing dependencies for the _Generic Text Editor_ have to be added.

For Gradle Properties the content type configuration should use the full file name `gradle.properties` without a separate entry for the file extension, so that these files are opened with the _Generic Text Editor_ and other property files are still handled by the _Properties File Editor_.