### PR TITLE
eclipseBuild plugin: Ensure compatibility with Java 17

### DIFF
--- a/buildSrc/src/main/groovy/eclipsebuild/mavenize/Bundle2Pom.groovy
+++ b/buildSrc/src/main/groovy/eclipsebuild/mavenize/Bundle2Pom.groovy
@@ -52,7 +52,7 @@ final class Bundle2Pom {
         } else
             manifest = new JarFile(bundleFileOrDirectory).manifest
 
-        pom.artifact = manifest.attr.getValue(Constants.BUNDLE_SYMBOLICNAME)
+        pom.artifact = manifest.mainAttributes.getValue(Constants.BUNDLE_SYMBOLICNAME)
         if (pom.artifact.contains(';'))
             pom.artifact = pom.artifact.split(';')[0]
         pom.artifact = pom.artifact.trim()
@@ -62,10 +62,10 @@ final class Bundle2Pom {
 
         // cut the qualifier and use only the major.minor.service segments as version number
         // this is in sync with version constraints declared in the bundle manifest
-        def version = new Version(manifest.attr.getValue(Constants.BUNDLE_VERSION))
+        def version = new Version(manifest.mainAttributes.getValue(Constants.BUNDLE_VERSION))
         pom.version = "${version.major}.${version.minor}.${version.release}"
 
-        parseDependencyBundles(pom.dependencyBundles, manifest.attr.getValue(Constants.REQUIRE_BUNDLE))
+        parseDependencyBundles(pom.dependencyBundles, manifest.mainAttributes.getValue(Constants.REQUIRE_BUNDLE))
 
         return pom
     }


### PR DESCRIPTION
With Java 17 the private field `attr` is no longer accessible and must be replaced with a call to the corresponding public getter method.

Without the change the build shows this stacktrace on standard output and fails later:

```
groovy.lang.MissingPropertyException: No such property: attr for class: java.util.jar.Manifest
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:65)
        at org.codehaus.groovy.runtime.callsite.GetEffectivePojoPropertySite.getProperty(GetEffectivePojoPropertySite.java:65)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGetProperty(AbstractCallSite.java:329)
        at eclipsebuild.mavenize.Bundle2Pom.convert(Bundle2Pom.groovy:55)
        at eclipsebuild.mavenize.Bundle2Pom$convert.call(Unknown Source)
        at eclipsebuild.mavenize.BundleMavenDeployer$_collectArtifacts_closure1.doCall(BundleMavenDeployer.groovy:64)
[...]
```