### PR TITLE
Show menu entry "Refresh Gradle Project" for Kotlin DSL scripts

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/GradleResourceTester.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/GradleResourceTester.java
@@ -19,6 +19,7 @@ import org.eclipse.core.resources.IResource;
  * <ul>
  *  <li>a Gradle project</li>
  *  <li>a .gradle file</li>
+ *  <li>a .gradle.kts file</li>
  *  <li>a gradle.properties file</li>
  * </ul>
  * @author Stefan Oehme
@@ -32,7 +33,7 @@ public class GradleResourceTester extends PropertyTester {
             IResource resource = (IResource) receiver;
             IProject project = resource.getProject();
             if (GradleProjectNature.isPresentOn(project)) {
-                return resource instanceof IProject || "gradle".equals(resource.getFileExtension()) || "gradle.properties".equals(resource.getName());
+                return resource instanceof IProject || "gradle".equals(resource.getFileExtension()) || resource.getName().endsWith(".gradle.kts") || "gradle.properties".equals(resource.getName());
             }
         }
         return false;

--- a/org.eclipse.buildship.ui/plugin.xml
+++ b/org.eclipse.buildship.ui/plugin.xml
@@ -201,21 +201,16 @@
                 <iterate
                         operator="or"
                         ifEmpty="false">
-                    <adapt
-                            type="org.eclipse.core.resources.IResource">
-                        <and>
-                            <test
-                                    forcePluginActivation="true"
-                                    property="org.eclipse.core.resources.projectNature"
-                                    value="org.eclipse.buildship.core.gradleprojectnature">
-                            </test>
-                            <test
-                                    forcePluginActivation="true"
-                                    property="org.eclipse.buildship.core.isGradleResource">
-                            </test>
-                         </and>
-                    </adapt>
+                   <reference
+                         definitionId="org.eclipse.buildship.ui.GradleResourceInGradleProject">
+                   </reference>
                 </iterate>
+                <with
+                      variable="activeEditorInput">
+                   <reference
+                         definitionId="org.eclipse.buildship.ui.GradleResourceInGradleProject">
+                   </reference>
+                </with>
             </or>
          </activeWhen>
       </handler>
@@ -455,21 +450,16 @@
                             <iterate
                                     operator="or"
                                     ifEmpty="false">
-                                 <adapt
-                                            type="org.eclipse.core.resources.IResource">
-                                         <and>
-                                            <test
-                                                    forcePluginActivation="true"
-                                                    property="org.eclipse.core.resources.projectNature"
-                                                    value="org.eclipse.buildship.core.gradleprojectnature">
-                                            </test>
-                                            <test
-                                                    forcePluginActivation="true"
-                                                    property="org.eclipse.buildship.core.isGradleResource">
-                                            </test>
-                                         </and>
-                                </adapt>
+                               <reference
+                                     definitionId="org.eclipse.buildship.ui.GradleResourceInGradleProject">
+                               </reference>
                             </iterate>
+                        </with>
+                        <with
+                              variable="activeEditorInput">
+                           <reference
+                                 definitionId="org.eclipse.buildship.ui.GradleResourceInGradleProject">
+                           </reference>
                         </with>
                     </or>
                 </visibleWhen>
@@ -664,5 +654,25 @@
                 id="org.eclipse.buildship.ui.gradlebuildscripteditor">
           </part>
        </actionSetPartAssociation>
+    </extension>
+    <extension
+          point="org.eclipse.core.expressions.definitions">
+       <definition
+             id="org.eclipse.buildship.ui.GradleResourceInGradleProject">
+          <adapt
+                type="org.eclipse.core.resources.IResource">
+             <and>
+                <test
+                      forcePluginActivation="true"
+                      property="org.eclipse.core.resources.projectNature"
+                      value="org.eclipse.buildship.core.gradleprojectnature">
+                </test>
+                <test
+                      forcePluginActivation="true"
+                      property="org.eclipse.buildship.core.isGradleResource">
+                </test>
+             </and>
+          </adapt>
+       </definition>
     </extension>
 </plugin>


### PR DESCRIPTION
As for Groovy DSL scripts show the _Refresh Gradle Project_ action when a `.gradle.kts` file is selected in the _Package/Project Explorer_ or opened in an editor.

The common property tests have been refactored out into a separate expression definition.
