### PR TITLE
Prevent execution of the Java Resource Import Configurator #1288

### DIFF
--- a/org.eclipse.buildship.ui.test/Launch Buildship UI tests.launch
+++ b/org.eclipse.buildship.ui.test/Launch Buildship UI tests.launch
@@ -26,7 +26,7 @@
     <stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=org.eclipse.buildship.ui.test/src\/main\/groovy"/>
     <booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
     <stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
-    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+    <stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit5"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/project/GradleProjectConfigurator.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/project/GradleProjectConfigurator.java
@@ -78,7 +78,8 @@ public class GradleProjectConfigurator implements ProjectConfigurator {
 
   @Override
   public boolean shouldBeAnEclipseProject(IContainer container, IProgressMonitor monitor) {
-    return false;
+    IPath location = container.getLocation();
+    return location != null && isGradleRoot(location.toFile());
   }
 
   @Override
@@ -88,11 +89,7 @@ public class GradleProjectConfigurator implements ProjectConfigurator {
 
   @Override
   public boolean canConfigure(IProject project, Set<IPath> ignoredPaths, IProgressMonitor monitor) {
-    IPath location = project.getLocation();
-    if(location != null) {
-      return isGradleRoot(location.toFile());
-    }
-    return false;
+    return shouldBeAnEclipseProject(project, monitor);
   }
 
   @Override


### PR DESCRIPTION
Fixes #1288

When importing Gradle projects from a folder with the generic project configurator, other configurators like the `ProjectWithJavaResourcesImportConfigurator` must not run. Otherwise resources in subprojects could be imported twice.

To prevent the execution of secondary configurators the method `shouldBeAnEclipseProject(...)` has to return `true` for the root of Gradle projects.

Note: In the implementation of the integration test I have to wait for the `SmartImportJob` to finish. Unfortunately the job family of this job is the non-API job class. This is why I used `Class.forName(...)`.