### PR TITLE
Add missing problemApiSupportEnabled argument in unit tests

### DIFF
--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/configuration/BuildConfigurationTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/configuration/BuildConfigurationTest.groovy
@@ -56,7 +56,7 @@ class BuildConfigurationTest extends ProjectSynchronizationSpecification {
         WorkspaceConfiguration orignalConfiguration = configurationManager.loadWorkspaceConfiguration()
 
         when:
-        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(distribution, workspaceGradleUserHome, workspaceJavaHome, offlineMode, buildScansEnabled, autoSync, workspaceArguments, workspaceJvmArguments, showConsole, showExecutions, false))
+        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(distribution, workspaceGradleUserHome, workspaceJavaHome, offlineMode, buildScansEnabled, autoSync, workspaceArguments, workspaceJvmArguments, showConsole, showExecutions, false, false))
         BuildConfiguration configuration = createInheritingBuildConfiguration(projectDir)
 
         then:
@@ -203,7 +203,7 @@ connection.gradle.distribution=MODIFIED_DISTRO"""
 
         when:
         configurationManager.saveBuildConfiguration(buildConfig)
-        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(distribution, workspaceGradleUserHome, workspaceJavaHome, offlineMode, buildScansEnabled, autoSync, workspaceArguments, workspaceJvmArguments, showConsole, showExecutions, false))
+        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(distribution, workspaceGradleUserHome, workspaceJavaHome, offlineMode, buildScansEnabled, autoSync, workspaceArguments, workspaceJvmArguments, showConsole, showExecutions, false, false))
         buildConfig = configurationManager.loadBuildConfiguration(projectDir)
 
         then:
@@ -242,7 +242,7 @@ connection.gradle.distribution=MODIFIED_DISTRO"""
 
         when:
         configurationManager.saveBuildConfiguration(buildConfig)
-        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(GradleDistribution.fromBuild(), null, null, !buildScansEnabled, !offlineMode, !autoSync, [], [], false, false, false))
+        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(GradleDistribution.fromBuild(), null, null, !buildScansEnabled, !offlineMode, !autoSync, [], [], false, false, false, false))
         buildConfig = configurationManager.loadBuildConfiguration(projectDir)
 
         then:

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/configuration/ProjectConfigurationTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/configuration/ProjectConfigurationTest.groovy
@@ -190,7 +190,7 @@ class ProjectConfigurationTest extends ProjectSynchronizationSpecification {
 
         when:
         configurationManager.saveProjectConfiguration(projectConfig)
-        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(distribution, gradleUserHome, javaHome, offlineMode, buildScansEnabled, autoSync, arguments, jvmArguments, showConsole, showExecutions, false))
+        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(distribution, gradleUserHome, javaHome, offlineMode, buildScansEnabled, autoSync, arguments, jvmArguments, showConsole, showExecutions, false, false))
         projectConfig = configurationManager.loadProjectConfiguration(project)
 
         then:
@@ -224,7 +224,7 @@ class ProjectConfigurationTest extends ProjectSynchronizationSpecification {
 
         when:
         configurationManager.saveProjectConfiguration(projectConfig)
-        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(GradleDistribution.fromBuild(), null, null, !buildScansEnabled, !offlineMode, !autoSync, [], [], false, false, false))
+        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(GradleDistribution.fromBuild(), null, null, !buildScansEnabled, !offlineMode, !autoSync, [], [], false, false, false, false))
         projectConfig = configurationManager.loadProjectConfiguration(project)
 
         then:

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/configuration/WorkspaceConfigurationTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/configuration/WorkspaceConfigurationTest.groovy
@@ -40,7 +40,7 @@ class WorkspaceConfigurationTest extends WorkspaceSpecification {
         when:
         File gradleUserHomeDir = dir(gradleUserHome)
         File javaHomeDir = dir(javaHome)
-        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(distribution, gradleUserHomeDir, javaHomeDir, offlineMode, buildScansEnabled, autoSync, args, jvmArgs, showConsole, showExecutions, moduleSupportEnabled))
+        configurationManager.saveWorkspaceConfiguration(new WorkspaceConfiguration(distribution, gradleUserHomeDir, javaHomeDir, offlineMode, buildScansEnabled, autoSync, args, jvmArgs, showConsole, showExecutions, moduleSupportEnabled, false))
         WorkspaceConfiguration updatedConfiguration = configurationManager.loadWorkspaceConfiguration()
 
         then:

--- a/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/SynchronizingBuildScriptUpdateListenerTest.groovy
+++ b/org.eclipse.buildship.core.test/src/main/groovy/org/eclipse/buildship/core/internal/workspace/SynchronizingBuildScriptUpdateListenerTest.groovy
@@ -212,6 +212,7 @@ class SynchronizingBuildScriptUpdateListenerTest extends ProjectSynchronizationS
             workspaceConfig.jvmArguments,
             workspaceConfig.showConsoleView,
             workspaceConfig.showExecutionsView,
+            false,
             false)
         configurationManager.saveWorkspaceConfiguration(workspaceConfig)
     }

--- a/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/internal/workspace/AddBuildshipNatureHandlerTest.groovy
+++ b/org.eclipse.buildship.ui.test/src/main/groovy/org/eclipse/buildship/ui/internal/workspace/AddBuildshipNatureHandlerTest.groovy
@@ -41,7 +41,7 @@ class AddBuildshipNatureHandlerTest extends WorkspaceSpecification {
     def "Uses configuration from workspace settings"() {
         setup:
         WorkspaceConfiguration originalWorkspaceConfig = configurationManager.loadWorkspaceConfiguration()
-        WorkspaceConfiguration config = new WorkspaceConfiguration(GradleDistribution.forVersion("3.0"), dir('custom-gradle-home'), null, false, false, false, [], [], false, false, false)
+        WorkspaceConfiguration config = new WorkspaceConfiguration(GradleDistribution.forVersion("3.0"), dir('custom-gradle-home'), null, false, false, false, [], [], false, false, false, false)
         configurationManager.saveWorkspaceConfiguration(config)
 
         IProject project = EclipseProjects.newProject('add-buildship-nature')


### PR DESCRIPTION
In order for the tests to run again successfully, an argument for the new constructor parameter `problemApiSupportEnabled` must be added.

The constructor has been changed as part of #1296 ([diff](https://github.com/eclipse/buildship/pull/1296/files#diff-d596417761b9a9c9b4fee84c8528e395326a739b76d312bf377d4a6c4cb3d4eeR44)).