### PR TITLE
Save versions cache file in plugin's state location by default

### DIFF
--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersions.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/util/gradle/PublishedGradleVersions.java
@@ -37,6 +37,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
+import org.eclipse.buildship.core.internal.CorePlugin;
+
 /**
  * Provides information about the Gradle versions available from services.gradle.org. The version information can optionally be cached on the local file system.
  *
@@ -220,10 +222,10 @@ public final class PublishedGradleVersions {
     private static File getCacheFile() {
         // ensures compliance with XDG base spec: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
         String xdgCache = System.getenv("XDG_CACHE_HOME");
-        if (xdgCache == null) {
-            xdgCache = System.getProperty("user.home") + "/.cache/";
+        if (xdgCache != null) {
+            return new File(xdgCache, "tooling/gradle/versions.json");
         }
-        return new File(xdgCache, "tooling/gradle/versions.json");
+        return CorePlugin.getInstance().getStateLocation().append("gradle").append("versions.json").toFile();
     }
 
     /**


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/eclipse/buildship/issues/1178.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
