### PR TITLE
Fixed build failures because of jcenter

### DIFF
--- a/org.eclipse.buildship.site/build.gradle
+++ b/org.eclipse.buildship.site/build.gradle
@@ -2,7 +2,9 @@ apply plugin: eclipsebuild.UpdateSitePlugin
 apply plugin: 'org.hidetake.ssh'
 
 buildscript {
-    repositories { jcenter() }
+    repositories {
+        gradlePluginPortal()
+    }
     dependencies {
         classpath 'org.hidetake:gradle-ssh-plugin:2.10.1'
     }


### PR DESCRIPTION
Replaced deprecated jcenter with gradlePluginPortal repository
