### PR TITLE
Github Actions build with multiple OSes

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,8 +1,16 @@
 name: CI
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,17 +8,19 @@ on:
 jobs:
   build:
     strategy:
+        fail-fast: false
         matrix:
             os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 8
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
+          distribution: 'zulu'
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: 'temurin'
@@ -27,6 +29,6 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Build with Gradle
-        run: ./gradlew build  -x eclipseTest -Pbuild.invoker=ci
+        run: ./gradlew build -x eclipseTest -Pbuild.invoker=ci
 
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,12 +13,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: 8
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Build with Gradle
         run: ./gradlew build  -x eclipseTest -Pbuild.invoker=ci
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,6 +29,6 @@ jobs:
         with:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Build with Gradle
-        run: ./gradlew build -x eclipseTest -Pbuild.invoker=ci
+        run: ./gradlew build -x eclipseTest '-Pbuild.invoker=ci'
 
 


### PR DESCRIPTION
This set up Github Actions build with multiple OSes. An example of how this would look like can be seen [here](https://github.com/ribafish/buildship/actions/runs/10699868215).

This also updates to latest versions of actions used and added the `setup-gradle` action. To get buildScan publishing a secret (`DEVELOCITY_ACCESS_KEY`) will need to be added to this repository.
