### PR TITLE
Add experimental LSP in order to support Declarative Gradle's DCL files

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   build:
     strategy:
-        fail-fast: false
-        matrix:
-            os: [ubuntu-latest, windows-latest, macos-latest]
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -18,17 +18,15 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 8
-          distribution: 'zulu'
+          distribution: "zulu"
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
           java-version: 11
-          distribution: 'temurin'
+          distribution: "temurin"
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:
           develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: Build with Gradle
         run: ./gradlew build -x eclipseTest '-Pbuild.invoker=ci'
-
-

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # Eclipse Buildship: Gradle integration for the Eclipse IDE <a href="https://builds.gradle.org/viewType.html?buildTypeId=Tooling_Buildship_Checkpoint_Full_Test_Coverage_Phase_33"><img src="https://builds.gradle.org/guestAuth/app/rest/builds/buildType:(id:Tooling_Buildship_Checkpoint_Full_Test_Coverage_Phase_33)/statusIcon"/></a>
 
-Buildship is a set of Eclipse Plug-ins that provide a deep integration of Gradle into the Eclipse IDE. Buildship is hosted
-on [eclipse.org](https://projects.eclipse.org/projects/tools.buildship).
-
+> [!TIP]
+> We have preview of Declarative Gradle support. See [here](/docs/user/DeclarativeGradle.md) how to set it up.
 
 ## Requirements
 
 Buildship can be used with Eclipse IDE 4.2.x or newer. Older versions of Eclipse the IDE might work but have not been tested explicitly. Depending
 on the version of Gradle that Buildship interacts with, certain features of Buildship may not be available.
-
 
 ## Documentation
 
@@ -16,16 +14,14 @@ All documentation of Buildship for users and developers is hosted on [GitHub](ht
 
 More specifically, you can find
 
- * [User documentation](docs/user/README.md) (plugin installation, current functionality)
- * [Developer documentation](docs/development/README.md) (development environment setup)
- * [Build documentation](docs/pluginbuild/README.md) (building Eclipse projects with Gradle)
- * [Outline of upcoming stories](docs/stories/README.md)
-
+- [User documentation](docs/user/README.md) (plugin installation, current functionality)
+- [Developer documentation](docs/development/README.md) (development environment setup)
+- [Build documentation](docs/pluginbuild/README.md) (building Eclipse projects with Gradle)
+- [Outline of upcoming stories](docs/stories/README.md)
 
 ## Discussions &amp; News
 
 We are very interested in feedback from the Gradle and Eclipse communities. All things Buildship are discussed on the [Gradle Forums](http://discuss.gradle.org/c/help-discuss/buildship).
-
 
 ## Issue Tracking
 

--- a/docs/user/DeclarativeGradle.md
+++ b/docs/user/DeclarativeGradle.md
@@ -1,0 +1,26 @@
+# Declarative Gradle - EAP
+
+Our [Declarative Gradle](https://declarative.gradle.org/) attempts to create an elegant and extensible declarative build language that enables expressing any build in a clear and understandable way.
+Declarative uses a new `*.gradle.dcl` format, which resembles a simplified Kotlin language with some unique features.
+
+Buildship provides some EAP support for the Declarative Gradle language by using our [declarative-lsp](https://github.com/gradle/declarative-lsp) project.
+
+## Setup
+
+In order to install
+
+1. In the Help > Install New Software dialog, add the following update site: https://download.eclipse.org/buildship/updates/latest-snapshot/
+1. Install the "Buildship - Gradle Declarative editor support" under the "Buildship Extras - Incubating" category.
+1. Check out and build the [declarative-lsp](https://github.com/gradle/declarative-lsp) project by running `shadowJar`. The task should make a `lsp-all.jar` file under `build/libs`.
+1. Go to the "Settings > Gradle > Experimental features" menu, and select this `lsp-all.jar` file.
+1. Upon opening any `gradle.dcl` file, the LSP should turn on. Observe the console for any diagnostic messages.
+
+## Sample projects
+
+To try out the feature, take a look at our [sample projects](https://declarative.gradle.org/docs/getting-started/samples/).
+These projects should be importable by Buildship without any problem, but make sure that the importing uses the wrapper shipped by the samples.
+
+## Verifying if the LSP works
+
+Eclipse offers a "Language Servers" view.
+If everything is set up correctly, upon opening a DCL file, a "Declarative Gradle Language Server" entry should show up in the list persistently.

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -6,3 +6,4 @@ The following user documentation of Buildship is currently available:
 1. [Release Announcements](ReleaseAnnouncements.md)
 1. [Overview of current functionality](Overview.md)
 1. [Frequently Asked Questions](Faq.md)
+1. [Declarative Gradle - EAP](DeclarativeGradle.md)

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/WorkspaceConfiguration.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/WorkspaceConfiguration.java
@@ -36,12 +36,13 @@ public final class WorkspaceConfiguration {
     private final boolean showExecutionsView;
     private final boolean experimentalModuleSupportEnabled;
     private final boolean problemsApiSupportEnabled;
+    private final String lspJarPath;
 
     public WorkspaceConfiguration(GradleDistribution gradleDistribution, File gradleUserHome,
                                   File javaHome, boolean gradleIsOffline, boolean buildScansEnabled,
                                   boolean autoSync, List<String> arguments,
                                   List<String> jvmArguments, boolean showConsoleView,
-                                  boolean showExecutionsView, boolean experimentalModuleSupportEnabled, boolean problemApiSupportEnabled) {
+                                  boolean showExecutionsView, boolean experimentalModuleSupportEnabled, boolean problemApiSupportEnabled, String lspJarPath) {
         this.gradleDistribution = gradleDistribution;
         this.gradleUserHome = gradleUserHome;
         this.javaHome = javaHome;
@@ -54,6 +55,7 @@ public final class WorkspaceConfiguration {
         this.showExecutionsView = showExecutionsView;
         this.experimentalModuleSupportEnabled = experimentalModuleSupportEnabled;
         this.problemsApiSupportEnabled = problemApiSupportEnabled;
+        this.lspJarPath = lspJarPath;
     }
 
     public GradleDistribution getGradleDistribution() {
@@ -107,6 +109,10 @@ public final class WorkspaceConfiguration {
         return this.problemsApiSupportEnabled;
     }
 
+    public String getLspJarPath() {
+        return this.lspJarPath;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj instanceof WorkspaceConfiguration) {
@@ -122,7 +128,8 @@ public final class WorkspaceConfiguration {
                     && Objects.equal(this.showConsoleView, other.showConsoleView)
                     && Objects.equal(this.showExecutionsView, other.showExecutionsView)
                     && Objects.equal(this.experimentalModuleSupportEnabled, other.experimentalModuleSupportEnabled)
-                    && Objects.equal(this.problemsApiSupportEnabled, other.problemsApiSupportEnabled);
+                    && Objects.equal(this.problemsApiSupportEnabled, other.problemsApiSupportEnabled
+                    && Objects.equal(this.lspJarPath, other.lspJarPath));
         }
         return false;
     }

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/WorkspaceConfigurationPersistence.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/configuration/WorkspaceConfigurationPersistence.java
@@ -45,6 +45,7 @@ final class WorkspaceConfigurationPersistence {
     private static final String SHOW_EXECUTIONS_VIEW = "show.executions.view";
     private static final String EXPERIMENTAL_ENABLE_MODULE_SUPPORT = "experimental.module.support";
     private static final String PROBLEMS_API_SUPPORT = "problems.api.support";
+    private static final String LSP_JAR_PATH = "lsp.jar.path";
 
     public WorkspaceConfiguration readWorkspaceConfig() {
         IEclipsePreferences preferences = getPreferences();
@@ -74,7 +75,8 @@ final class WorkspaceConfigurationPersistence {
         boolean showExecutionsView = preferences.getBoolean(SHOW_EXECUTIONS_VIEW, true);
         boolean moduleSupport = preferences.getBoolean(EXPERIMENTAL_ENABLE_MODULE_SUPPORT, false);
         boolean problemsApiSupport = preferences.getBoolean(PROBLEMS_API_SUPPORT, false);
-        return new WorkspaceConfiguration(distribution, gradleUserHome, javaHome, offlineMode, buildScansEnabled, autoSyncEnabled, arguments, jvmArguments, showConsoleView, showExecutionsView, moduleSupport, problemsApiSupport);
+        String lspJarPath = preferences.get(LSP_JAR_PATH, "");
+        return new WorkspaceConfiguration(distribution, gradleUserHome, javaHome, offlineMode, buildScansEnabled, autoSyncEnabled, arguments, jvmArguments, showConsoleView, showExecutionsView, moduleSupport, problemsApiSupport, lspJarPath);
     }
 
     public void saveWorkspaceConfiguration(WorkspaceConfiguration config) {
@@ -100,6 +102,7 @@ final class WorkspaceConfigurationPersistence {
         preferences.putBoolean(SHOW_EXECUTIONS_VIEW, config.isShowExecutionsView());
         preferences.putBoolean(EXPERIMENTAL_ENABLE_MODULE_SUPPORT, config.isExperimentalModuleSupportEnabled());
         preferences.putBoolean(PROBLEMS_API_SUPPORT, config.isProblemsApiSupportEnabled());
+        preferences.put(LSP_JAR_PATH, config.getLspJarPath());
         try {
             preferences.flush();
         } catch (BackingStoreException e) {

--- a/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/i18n/CoreMessages.java
+++ b/org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/i18n/CoreMessages.java
@@ -81,6 +81,10 @@ public final class CoreMessages extends NLS {
     public static String Preference_Label_ProblemsApiSupport;
     public static String Preference_Label_ProblemsApiSupportHover;
 
+    public static String Preference_Label_LspJarPath;
+    public static String Preference_Label_LspJarBrowse;
+    public static String Preference_Label_LspJarPathFilterName;
+
     static {
         // initialize resource bundle
         NLS.initializeMessages(BUNDLE_NAME, CoreMessages.class);

--- a/org.eclipse.buildship.core/src/main/resources/org/eclipse/buildship/core/internal/i18n/CoreMessages.properties
+++ b/org.eclipse.buildship.core/src/main/resources/org/eclipse/buildship/core/internal/i18n/CoreMessages.properties
@@ -67,3 +67,6 @@ Preference_Label_ModulePath=Enable module support
 Preference_Label_ModulePathHover=Add module dependencies to the modulepath
 Preference_Label_ProblemsApiSupport=Enable Problems API support
 Preference_Label_ProblemsApiSupportHover=Problems reported via the Problems API will appear as error markers on the UI.
+Preference_Label_LspJarPath=Language Server Protocol JAR path
+Preference_Label_LspJarBrowse=Browse
+Preference_Label_LspJarPathFilterName=LSP JAR

--- a/org.eclipse.buildship.dcl.feature/.project
+++ b/org.eclipse.buildship.dcl.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.eclipse.buildship.dcl.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.buildship.dcl.feature/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.dcl.feature/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+

--- a/org.eclipse.buildship.dcl.feature/build.gradle
+++ b/org.eclipse.buildship.dcl.feature/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: eclipsebuild.FeaturePlugin

--- a/org.eclipse.buildship.dcl.feature/build.properties
+++ b/org.eclipse.buildship.dcl.feature/build.properties
@@ -1,0 +1,9 @@
+bin.includes = epl-v10.html,\
+               feature.xml,\
+               feature.properties,\
+               license.html
+src.includes = build.properties,\
+               epl-v10.html,\
+               feature.xml,\
+               feature.properties,\
+               license.html

--- a/org.eclipse.buildship.dcl.feature/category.xml
+++ b/org.eclipse.buildship.dcl.feature/category.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+   <bundle id="org.eclipse.buildship.dcl.provider">
+      <category name="Declarative DCL support"/>
+   </bundle>
+   <category-def name="Declarative Gradle" label="Features for Declarative Gradle support"/>
+</site>

--- a/org.eclipse.buildship.dcl.feature/epl-v10.html
+++ b/org.eclipse.buildship.dcl.feature/epl-v10.html
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>Eclipse Public License - Version 1.0</title>
+<style type="text/css">
+  body {
+    size: 8.5in 11.0in;
+    margin: 0.25in 0.5in 0.25in 0.5in;
+    tab-interval: 0.5in;
+    }
+  p {  	
+    margin-left: auto;
+    margin-top:  0.5em;
+    margin-bottom: 0.5em;
+    }
+  p.list {
+  	margin-left: 0.5in;
+    margin-top:  0.05em;
+    margin-bottom: 0.05em;
+    }
+  </style>
+
+</head>
+
+<body lang="EN-US">
+
+<h2>Eclipse Public License - v 1.0</h2>
+
+<p>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR
+DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS
+AGREEMENT.</p>
+
+<p><b>1. DEFINITIONS</b></p>
+
+<p>&quot;Contribution&quot; means:</p>
+
+<p class="list">a) in the case of the initial Contributor, the initial
+code and documentation distributed under this Agreement, and</p>
+<p class="list">b) in the case of each subsequent Contributor:</p>
+<p class="list">i) changes to the Program, and</p>
+<p class="list">ii) additions to the Program;</p>
+<p class="list">where such changes and/or additions to the Program
+originate from and are distributed by that particular Contributor. A
+Contribution 'originates' from a Contributor if it was added to the
+Program by such Contributor itself or anyone acting on such
+Contributor's behalf. Contributions do not include additions to the
+Program which: (i) are separate modules of software distributed in
+conjunction with the Program under their own license agreement, and (ii)
+are not derivative works of the Program.</p>
+
+<p>&quot;Contributor&quot; means any person or entity that distributes
+the Program.</p>
+
+<p>&quot;Licensed Patents&quot; mean patent claims licensable by a
+Contributor which are necessarily infringed by the use or sale of its
+Contribution alone or when combined with the Program.</p>
+
+<p>&quot;Program&quot; means the Contributions distributed in accordance
+with this Agreement.</p>
+
+<p>&quot;Recipient&quot; means anyone who receives the Program under
+this Agreement, including all Contributors.</p>
+
+<p><b>2. GRANT OF RIGHTS</b></p>
+
+<p class="list">a) Subject to the terms of this Agreement, each
+Contributor hereby grants Recipient a non-exclusive, worldwide,
+royalty-free copyright license to reproduce, prepare derivative works
+of, publicly display, publicly perform, distribute and sublicense the
+Contribution of such Contributor, if any, and such derivative works, in
+source code and object code form.</p>
+
+<p class="list">b) Subject to the terms of this Agreement, each
+Contributor hereby grants Recipient a non-exclusive, worldwide,
+royalty-free patent license under Licensed Patents to make, use, sell,
+offer to sell, import and otherwise transfer the Contribution of such
+Contributor, if any, in source code and object code form. This patent
+license shall apply to the combination of the Contribution and the
+Program if, at the time the Contribution is added by the Contributor,
+such addition of the Contribution causes such combination to be covered
+by the Licensed Patents. The patent license shall not apply to any other
+combinations which include the Contribution. No hardware per se is
+licensed hereunder.</p>
+
+<p class="list">c) Recipient understands that although each Contributor
+grants the licenses to its Contributions set forth herein, no assurances
+are provided by any Contributor that the Program does not infringe the
+patent or other intellectual property rights of any other entity. Each
+Contributor disclaims any liability to Recipient for claims brought by
+any other entity based on infringement of intellectual property rights
+or otherwise. As a condition to exercising the rights and licenses
+granted hereunder, each Recipient hereby assumes sole responsibility to
+secure any other intellectual property rights needed, if any. For
+example, if a third party patent license is required to allow Recipient
+to distribute the Program, it is Recipient's responsibility to acquire
+that license before distributing the Program.</p>
+
+<p class="list">d) Each Contributor represents that to its knowledge it
+has sufficient copyright rights in its Contribution, if any, to grant
+the copyright license set forth in this Agreement.</p>
+
+<p><b>3. REQUIREMENTS</b></p>
+
+<p>A Contributor may choose to distribute the Program in object code
+form under its own license agreement, provided that:</p>
+
+<p class="list">a) it complies with the terms and conditions of this
+Agreement; and</p>
+
+<p class="list">b) its license agreement:</p>
+
+<p class="list">i) effectively disclaims on behalf of all Contributors
+all warranties and conditions, express and implied, including warranties
+or conditions of title and non-infringement, and implied warranties or
+conditions of merchantability and fitness for a particular purpose;</p>
+
+<p class="list">ii) effectively excludes on behalf of all Contributors
+all liability for damages, including direct, indirect, special,
+incidental and consequential damages, such as lost profits;</p>
+
+<p class="list">iii) states that any provisions which differ from this
+Agreement are offered by that Contributor alone and not by any other
+party; and</p>
+
+<p class="list">iv) states that source code for the Program is available
+from such Contributor, and informs licensees how to obtain it in a
+reasonable manner on or through a medium customarily used for software
+exchange.</p>
+
+<p>When the Program is made available in source code form:</p>
+
+<p class="list">a) it must be made available under this Agreement; and</p>
+
+<p class="list">b) a copy of this Agreement must be included with each
+copy of the Program.</p>
+
+<p>Contributors may not remove or alter any copyright notices contained
+within the Program.</p>
+
+<p>Each Contributor must identify itself as the originator of its
+Contribution, if any, in a manner that reasonably allows subsequent
+Recipients to identify the originator of the Contribution.</p>
+
+<p><b>4. COMMERCIAL DISTRIBUTION</b></p>
+
+<p>Commercial distributors of software may accept certain
+responsibilities with respect to end users, business partners and the
+like. While this license is intended to facilitate the commercial use of
+the Program, the Contributor who includes the Program in a commercial
+product offering should do so in a manner which does not create
+potential liability for other Contributors. Therefore, if a Contributor
+includes the Program in a commercial product offering, such Contributor
+(&quot;Commercial Contributor&quot;) hereby agrees to defend and
+indemnify every other Contributor (&quot;Indemnified Contributor&quot;)
+against any losses, damages and costs (collectively &quot;Losses&quot;)
+arising from claims, lawsuits and other legal actions brought by a third
+party against the Indemnified Contributor to the extent caused by the
+acts or omissions of such Commercial Contributor in connection with its
+distribution of the Program in a commercial product offering. The
+obligations in this section do not apply to any claims or Losses
+relating to any actual or alleged intellectual property infringement. In
+order to qualify, an Indemnified Contributor must: a) promptly notify
+the Commercial Contributor in writing of such claim, and b) allow the
+Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own
+expense.</p>
+
+<p>For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those
+performance claims and warranties, and if a court requires any other
+Contributor to pay any damages as a result, the Commercial Contributor
+must pay those damages.</p>
+
+<p><b>5. NO WARRANTY</b></p>
+
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS
+PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS
+OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION,
+ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY
+OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely
+responsible for determining the appropriateness of using and
+distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to
+the risks and costs of program errors, compliance with applicable laws,
+damage to or loss of data, programs or equipment, and unavailability or
+interruption of operations.</p>
+
+<p><b>6. DISCLAIMER OF LIABILITY</b></p>
+
+<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT
+NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING
+WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR
+DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED
+HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
+
+<p><b>7. GENERAL</b></p>
+
+<p>If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further action
+by the parties hereto, such provision shall be reformed to the minimum
+extent necessary to make such provision valid and enforceable.</p>
+
+<p>If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other
+software or hardware) infringes such Recipient's patent(s), then such
+Recipient's rights granted under Section 2(b) shall terminate as of the
+date such litigation is filed.</p>
+
+<p>All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of time
+after becoming aware of such noncompliance. If all Recipient's rights
+under this Agreement terminate, Recipient agrees to cease use and
+distribution of the Program as soon as reasonably practicable. However,
+Recipient's obligations under this Agreement and any licenses granted by
+Recipient relating to the Program shall continue and survive.</p>
+
+<p>Everyone is permitted to copy and distribute copies of this
+Agreement, but in order to avoid inconsistency the Agreement is
+copyrighted and may only be modified in the following manner. The
+Agreement Steward reserves the right to publish new versions (including
+revisions) of this Agreement from time to time. No one other than the
+Agreement Steward has the right to modify this Agreement. The Eclipse
+Foundation is the initial Agreement Steward. The Eclipse Foundation may
+assign the responsibility to serve as the Agreement Steward to a
+suitable separate entity. Each new version of the Agreement will be
+given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version
+of the Agreement is published, Contributor may elect to distribute the
+Program (including its Contributions) under the new version. Except as
+expressly stated in Sections 2(a) and 2(b) above, Recipient receives no
+rights or licenses to the intellectual property of any Contributor under
+this Agreement, whether expressly, by implication, estoppel or
+otherwise. All rights in the Program not expressly granted under this
+Agreement are reserved.</p>
+
+<p>This Agreement is governed by the laws of the State of New York and
+the intellectual property laws of the United States of America. No party
+to this Agreement will bring a legal action under this Agreement more
+than one year after the cause of action arose. Each party waives its
+rights to a jury trial in any resulting litigation.</p>
+
+</body>
+
+</html>

--- a/org.eclipse.buildship.dcl.feature/feature.properties
+++ b/org.eclipse.buildship.dcl.feature/feature.properties
@@ -1,0 +1,146 @@
+# "featureName" property - the name of the feature
+featureName=\
+Buildship - Gradle Declarative editor support
+
+# "providerName" property - the name of the company providing the feature
+providerName=\
+Eclipse Buildship
+
+# "description" property - description of the feature
+description=\
+Buildship: Eclipse Plug-ins for Gradle, provided as part of the Gradle Platform.\n\n\
+Copyright (c) 2015 Gradle Inc.\n\
+For more information, visit our website https://projects.eclipse.org/projects/tools.buildship
+
+# "copyright" property - the copyright notice
+copyright=\
+Copyright (c) 2015 Gradle Inc.
+
+# "license" property - the Eclipse Foundation SUA
+license=\
+Eclipse Foundation Software User Agreement\n\
+April 9, 2014\n\
+\n\
+Usage Of Content\n\
+\n\
+THE ECLIPSE FOUNDATION MAKES AVAILABLE SOFTWARE, DOCUMENTATION, INFORMATION AND/OR\n\
+OTHER MATERIALS FOR OPEN SOURCE PROJECTS (COLLECTIVELY "CONTENT").\n\
+USE OF THE CONTENT IS GOVERNED BY THE TERMS AND CONDITIONS OF THIS\n\
+AGREEMENT AND/OR THE TERMS AND CONDITIONS OF LICENSE AGREEMENTS OR\n\
+NOTICES INDICATED OR REFERENCED BELOW.  BY USING THE CONTENT, YOU\n\
+AGREE THAT YOUR USE OF THE CONTENT IS GOVERNED BY THIS AGREEMENT\n\
+AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS\n\
+OR NOTICES INDICATED OR REFERENCED BELOW.  IF YOU DO NOT AGREE TO THE\n\
+TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND CONDITIONS\n\
+OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED\n\
+BELOW, THEN YOU MAY NOT USE THE CONTENT.\n\
+\n\
+Applicable Licenses\n\
+\n\
+Unless otherwise indicated, all Content made available by the\n\
+Eclipse Foundation is provided to you under the terms and conditions of\n\
+the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is\n\
+provided with this Content and is also available at http://www.eclipse.org/legal/epl-v10.html.\n\
+For purposes of the EPL, "Program" will mean the Content.\n\
+\n\
+Content includes, but is not limited to, source code, object code,\n\
+documentation and other files maintained in the Eclipse Foundation source code\n\
+repository ("Repository") in software modules ("Modules") and made available\n\
+as downloadable archives ("Downloads").\n\
+\n\
+\t- Content may be structured and packaged into modules to facilitate delivering,\n\
+\t  extending, and upgrading the Content. Typical modules may include plug-ins ("Plug-ins"),\n\
+\t  plug-in fragments ("Fragments"), and features ("Features").\n\
+\t- Each Plug-in or Fragment may be packaged as a sub-directory or JAR (Java(TM) ARchive)\n\
+\t  in a directory named "plugins".\n\
+\t- A Feature is a bundle of one or more Plug-ins and/or Fragments and associated material.\n\
+\t  Each Feature may be packaged as a sub-directory in a directory named "features".\n\
+\t  Within a Feature, files named "feature.xml" may contain a list of the names and version\n\
+\t  numbers of the Plug-ins and/or Fragments associated with that Feature.\n\
+\t- Features may also include other Features ("Included Features"). Within a Feature, files\n\
+\t  named "feature.xml" may contain a list of the names and version numbers of Included Features.\n\
+\n\
+The terms and conditions governing Plug-ins and Fragments should be\n\
+contained in files named "about.html" ("Abouts"). The terms and\n\
+conditions governing Features and Included Features should be contained\n\
+in files named "license.html" ("Feature Licenses"). Abouts and Feature\n\
+Licenses may be located in any directory of a Download or Module\n\
+including, but not limited to the following locations:\n\
+\n\
+\t- The top-level (root) directory\n\
+\t- Plug-in and Fragment directories\n\
+\t- Inside Plug-ins and Fragments packaged as JARs\n\
+\t- Sub-directories of the directory named "src" of certain Plug-ins\n\
+\t- Feature directories\n\
+\n\
+Note: if a Feature made available by the Eclipse Foundation is installed using the\n\
+Provisioning Technology (as defined below), you must agree to a license ("Feature \n\
+Update License") during the installation process. If the Feature contains\n\
+Included Features, the Feature Update License should either provide you\n\
+with the terms and conditions governing the Included Features or inform\n\
+you where you can locate them. Feature Update Licenses may be found in\n\
+the "license" property of files named "feature.properties" found within a Feature.\n\
+Such Abouts, Feature Licenses, and Feature Update Licenses contain the\n\
+terms and conditions (or references to such terms and conditions) that\n\
+govern your use of the associated Content in that directory.\n\
+\n\
+THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER\n\
+TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS.\n\
+SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
+\n\
+\t- Eclipse Distribution License Version 1.0 (available at http://www.eclipse.org/licenses/edl-v1.0.html)\n\
+\t- Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
+\t- Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
+\t- Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
+\t- Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\
+\n\
+IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR\n\
+TO USE OF THE CONTENT. If no About, Feature License, or Feature Update License\n\
+is provided, please contact the Eclipse Foundation to determine what terms and conditions\n\
+govern that particular Content.\n\
+\n\
+\nUse of Provisioning Technology\n\
+\n\
+The Eclipse Foundation makes available provisioning software, examples of which include,\n\
+but are not limited to, p2 and the Eclipse Update Manager ("Provisioning Technology") for\n\
+the purpose of allowing users to install software, documentation, information and/or\n\
+other materials (collectively "Installable Software"). This capability is provided with\n\
+the intent of allowing such users to install, extend and update Eclipse-based products.\n\
+Information about packaging Installable Software is available at\n\
+http://eclipse.org/equinox/p2/repository_packaging.html ("Specification").\n\
+\n\
+You may use Provisioning Technology to allow other parties to install Installable Software.\n\
+You shall be responsible for enabling the applicable license agreements relating to the\n\
+Installable Software to be presented to, and accepted by, the users of the Provisioning Technology\n\
+in accordance with the Specification. By using Provisioning Technology in such a manner and\n\
+making it available in accordance with the Specification, you further acknowledge your\n\
+agreement to, and the acquisition of all necessary rights to permit the following:\n\
+\n\
+\t1. A series of actions may occur ("Provisioning Process") in which a user may execute\n\
+\t   the Provisioning Technology on a machine ("Target Machine") with the intent of installing,\n\
+\t   extending or updating the functionality of an Eclipse-based product.\n\
+\t2. During the Provisioning Process, the Provisioning Technology may cause third party\n\
+\t   Installable Software or a portion thereof to be accessed and copied to the Target Machine.\n\
+\t3. Pursuant to the Specification, you will provide to the user the terms and conditions that\n\
+\t   govern the use of the Installable Software ("Installable Software Agreement") and such\n\
+\t   Installable Software Agreement shall be accessed from the Target Machine in accordance\n\
+\t   with the Specification. Such Installable Software Agreement must inform the user of the\n\
+\t   terms and conditions that govern the Installable Software and must solicit acceptance by\n\
+\t   the end user in the manner prescribed in such Installable Software Agreement. Upon such\n\
+\t   indication of agreement by the user, the provisioning Technology will complete installation\n\
+\t   of the Installable Software.\n\
+\n\
+Cryptography\n\
+\n\
+Content may contain encryption software. The country in which you are\n\
+currently may have restrictions on the import, possession, and use,\n\
+and/or re-export to another country, of encryption software. BEFORE\n\
+using any encryption software, please check the country's laws,\n\
+regulations and policies concerning the import, possession, or use, and\n\
+re-export of encryption software, to see if this is permitted.\n\
+\n\
+Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.\n
+
+# "licenseURL" property - the URL pointing to the local Eclipse Foundation SUA
+licenseUrl=\
+license.html

--- a/org.eclipse.buildship.dcl.feature/feature.xml
+++ b/org.eclipse.buildship.dcl.feature/feature.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Copyright (c) 2023 the original author or authors.
+ All rights reserved. This program and the accompanying materials
+ are made available under the terms of the Eclipse Public License v1.0
+ which accompanies this distribution, and is available at
+ http://www.eclipse.org/legal/epl-v10.html
+ 
+-->
+<feature
+      id="org.eclipse.buildship.dcl"
+      label="%featureName"
+      version="1.0.0.qualifier"
+      provider-name="%providerName"
+      plugin="org.eclipse.buildship.branding">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      %copyright
+   </copyright>
+
+   <license url="%licenseUrl">
+      %license
+   </license>
+
+   <plugin
+         id="org.eclipse.buildship.dcl.provider"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+</feature>

--- a/org.eclipse.buildship.dcl.feature/license.html
+++ b/org.eclipse.buildship.dcl.feature/license.html
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+<title>Eclipse Foundation Software User Agreement</title>
+</head>
+
+<body lang="EN-US">
+<h2>Eclipse Foundation Software User Agreement</h2>
+<p>April 9, 2014</p>
+
+<h3>Usage Of Content</h3>
+
+<p>THE ECLIPSE FOUNDATION MAKES AVAILABLE SOFTWARE, DOCUMENTATION, INFORMATION AND/OR OTHER MATERIALS FOR OPEN SOURCE PROJECTS
+   (COLLECTIVELY &quot;CONTENT&quot;).  USE OF THE CONTENT IS GOVERNED BY THE TERMS AND CONDITIONS OF THIS AGREEMENT AND/OR THE TERMS AND
+   CONDITIONS OF LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW.  BY USING THE CONTENT, YOU AGREE THAT YOUR USE
+   OF THE CONTENT IS GOVERNED BY THIS AGREEMENT AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR
+   NOTICES INDICATED OR REFERENCED BELOW.  IF YOU DO NOT AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND
+   CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW, THEN YOU MAY NOT USE THE CONTENT.</p>
+
+<h3>Applicable Licenses</h3>
+
+<p>Unless otherwise indicated, all Content made available by the Eclipse Foundation is provided to you under the terms and conditions of the Eclipse Public License Version 1.0
+   (&quot;EPL&quot;).  A copy of the EPL is provided with this Content and is also available at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+   For purposes of the EPL, &quot;Program&quot; will mean the Content.</p>
+
+<p>Content includes, but is not limited to, source code, object code, documentation and other files maintained in the Eclipse Foundation source code
+   repository (&quot;Repository&quot;) in software modules (&quot;Modules&quot;) and made available as downloadable archives (&quot;Downloads&quot;).</p>
+
+<ul>
+       <li>Content may be structured and packaged into modules to facilitate delivering, extending, and upgrading the Content.  Typical modules may include plug-ins (&quot;Plug-ins&quot;), plug-in fragments (&quot;Fragments&quot;), and features (&quot;Features&quot;).</li>
+       <li>Each Plug-in or Fragment may be packaged as a sub-directory or JAR (Java&trade; ARchive) in a directory named &quot;plugins&quot;.</li>
+       <li>A Feature is a bundle of one or more Plug-ins and/or Fragments and associated material.  Each Feature may be packaged as a sub-directory in a directory named &quot;features&quot;.  Within a Feature, files named &quot;feature.xml&quot; may contain a list of the names and version numbers of the Plug-ins
+      and/or Fragments associated with that Feature.</li>
+       <li>Features may also include other Features (&quot;Included Features&quot;). Within a Feature, files named &quot;feature.xml&quot; may contain a list of the names and version numbers of Included Features.</li>
+</ul>
+
+<p>The terms and conditions governing Plug-ins and Fragments should be contained in files named &quot;about.html&quot; (&quot;Abouts&quot;). The terms and conditions governing Features and
+Included Features should be contained in files named &quot;license.html&quot; (&quot;Feature Licenses&quot;).  Abouts and Feature Licenses may be located in any directory of a Download or Module
+including, but not limited to the following locations:</p>
+
+<ul>
+       <li>The top-level (root) directory</li>
+       <li>Plug-in and Fragment directories</li>
+       <li>Inside Plug-ins and Fragments packaged as JARs</li>
+       <li>Sub-directories of the directory named &quot;src&quot; of certain Plug-ins</li>
+       <li>Feature directories</li>
+</ul>
+
+<p>Note: if a Feature made available by the Eclipse Foundation is installed using the Provisioning Technology (as defined below), you must agree to a license (&quot;Feature Update License&quot;) during the
+installation process.  If the Feature contains Included Features, the Feature Update License should either provide you with the terms and conditions governing the Included Features or
+inform you where you can locate them.  Feature Update Licenses may be found in the &quot;license&quot; property of files named &quot;feature.properties&quot; found within a Feature.
+Such Abouts, Feature Licenses, and Feature Update Licenses contain the terms and conditions (or references to such terms and conditions) that govern your use of the associated Content in
+that directory.</p>
+
+<p>THE ABOUTS, FEATURE LICENSES, AND FEATURE UPDATE LICENSES MAY REFER TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS.  SOME OF THESE
+OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):</p>
+
+<ul>
+       <li>Eclipse Distribution License Version 1.0 (available at <a href="http://www.eclipse.org/licenses/edl-v10.html">http://www.eclipse.org/licenses/edl-v1.0.html</a>)</li>
+       <li>Common Public License Version 1.0 (available at <a href="http://www.eclipse.org/legal/cpl-v10.html">http://www.eclipse.org/legal/cpl-v10.html</a>)</li>
+       <li>Apache Software License 1.1 (available at <a href="http://www.apache.org/licenses/LICENSE">http://www.apache.org/licenses/LICENSE</a>)</li>
+       <li>Apache Software License 2.0 (available at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>)</li>
+       <li>Mozilla Public License Version 1.1 (available at <a href="http://www.mozilla.org/MPL/MPL-1.1.html">http://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
+</ul>
+
+<p>IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR TO USE OF THE CONTENT.  If no About, Feature License, or Feature Update License is provided, please
+contact the Eclipse Foundation to determine what terms and conditions govern that particular Content.</p>
+
+
+<h3>Use of Provisioning Technology</h3>
+
+<p>The Eclipse Foundation makes available provisioning software, examples of which include, but are not limited to, p2 and the Eclipse
+   Update Manager (&quot;Provisioning Technology&quot;) for the purpose of allowing users to install software, documentation, information and/or
+   other materials (collectively &quot;Installable Software&quot;). This capability is provided with the intent of allowing such users to
+   install, extend and update Eclipse-based products. Information about packaging Installable Software is available at <a
+       href="http://eclipse.org/equinox/p2/repository_packaging.html">http://eclipse.org/equinox/p2/repository_packaging.html</a>
+   (&quot;Specification&quot;).</p>
+
+<p>You may use Provisioning Technology to allow other parties to install Installable Software. You shall be responsible for enabling the
+   applicable license agreements relating to the Installable Software to be presented to, and accepted by, the users of the Provisioning Technology
+   in accordance with the Specification. By using Provisioning Technology in such a manner and making it available in accordance with the
+   Specification, you further acknowledge your agreement to, and the acquisition of all necessary rights to permit the following:</p>
+
+<ol>
+       <li>A series of actions may occur (&quot;Provisioning Process&quot;) in which a user may execute the Provisioning Technology
+       on a machine (&quot;Target Machine&quot;) with the intent of installing, extending or updating the functionality of an Eclipse-based
+       product.</li>
+       <li>During the Provisioning Process, the Provisioning Technology may cause third party Installable Software or a portion thereof to be
+       accessed and copied to the Target Machine.</li>
+       <li>Pursuant to the Specification, you will provide to the user the terms and conditions that govern the use of the Installable
+       Software (&quot;Installable Software Agreement&quot;) and such Installable Software Agreement shall be accessed from the Target
+       Machine in accordance with the Specification. Such Installable Software Agreement must inform the user of the terms and conditions that govern
+       the Installable Software and must solicit acceptance by the end user in the manner prescribed in such Installable Software Agreement. Upon such
+       indication of agreement by the user, the provisioning Technology will complete installation of the Installable Software.</li>
+</ol>
+
+<h3>Cryptography</h3>
+
+<p>Content may contain encryption software. The country in which you are currently may have restrictions on the import, possession, and use, and/or re-export to
+   another country, of encryption software. BEFORE using any encryption software, please check the country's laws, regulations and policies concerning the import,
+   possession, or use, and re-export of encryption software, to see if this is permitted.</p>
+
+<p><small>Java and all Java-based trademarks are trademarks of Oracle Corporation in the United States, other countries, or both.</small></p>
+</body>
+</html>

--- a/org.eclipse.buildship.dcl.provider/.classpath
+++ b/org.eclipse.buildship.dcl.provider/.classpath
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+        <attributes>
+            <attribute name="module" value="true"/>
+        </attributes>
+    </classpathentry>
+    <classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+    <classpathentry kind="src" path="src/main/java"/>
+    <classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.buildship.dcl.provider/.project
+++ b/org.eclipse.buildship.dcl.provider/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+    <name>org.eclipse.buildship.gradleprop.provider</name>
+    <comment></comment>
+    <projects>
+    </projects>
+    <buildSpec>
+        <buildCommand>
+            <name>org.eclipse.jdt.core.javabuilder</name>
+            <arguments>
+            </arguments>
+        </buildCommand>
+        <buildCommand>
+            <name>org.eclipse.pde.ManifestBuilder</name>
+            <arguments>
+            </arguments>
+        </buildCommand>
+        <buildCommand>
+            <name>org.eclipse.pde.SchemaBuilder</name>
+            <arguments>
+            </arguments>
+        </buildCommand>
+    </buildSpec>
+    <natures>
+        <nature>org.eclipse.pde.PluginNature</nature>
+        <nature>org.eclipse.jdt.core.javanature</nature>
+    </natures>
+</projectDescription>

--- a/org.eclipse.buildship.dcl.provider/META-INF/MANIFEST.MF
+++ b/org.eclipse.buildship.dcl.provider/META-INF/MANIFEST.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Provider
+Bundle-SymbolicName: org.eclipse.buildship.dcl.provider;singleton:=true
+Bundle-Version: 3.1.10.qualifier
+Require-Bundle: org.eclipse.core.runtime,
+ org.eclipse.core.contenttype,
+ org.eclipse.ui,
+ org.eclipse.ui.genericeditor,
+ org.eclipse.tm4e.registry,
+ org.eclipse.tm4e.languageconfiguration,
+ org.eclipse.lsp4e,
+ org.eclipse.jdt.launching,
+ org.eclipse.buildship.core
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Automatic-Module-Name: org.eclipse.buildship.dcl.provider

--- a/org.eclipse.buildship.dcl.provider/build.gradle
+++ b/org.eclipse.buildship.dcl.provider/build.gradle
@@ -1,0 +1,11 @@
+apply plugin: eclipsebuild.BundlePlugin
+
+dependencies {
+	api withEclipseBundle("org.eclipse.swt.${ECLIPSE_WS}.${ECLIPSE_OS}.${ECLIPSE_ARCH}")
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17) // TODO all Gradle plugins should use Java 17 for Eclipse 4.25+
+    }
+}

--- a/org.eclipse.buildship.dcl.provider/build.properties
+++ b/org.eclipse.buildship.dcl.provider/build.properties
@@ -1,0 +1,6 @@
+bin.includes = META-INF/,\
+               plugin.xml,\
+               grammar/,\
+               gradle-dcl.tmLanguage.json,\
+               language-configuration.json
+src.includes = grammar/

--- a/org.eclipse.buildship.dcl.provider/gradle-dcl.tmLanguage.json
+++ b/org.eclipse.buildship.dcl.provider/gradle-dcl.tmLanguage.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Declarative Gradle",
+  "scopeName": "source.gradle.dcl",
+  "patterns": [
+    {
+      "include": "#block"
+    },
+    {
+      "include": "#comment"
+    },
+    {
+      "include": "#constant"
+    },
+    {
+      "include": "#function"
+    },
+    {
+      "include": "#assignment"
+    }
+  ],
+  "repository": {
+    "comment": {
+      "patterns": [
+        {
+          "match": "//.*$",
+          "name": "comment.line.double-slash.gradle-dcl"
+        },
+        {
+          "begin": "/\\*",
+          "end": "\\*/",
+          "name": "comment.block.gradle-dcl"
+        }
+      ]
+    },
+    "escape": {
+      "patterns": [
+        {
+          "match": "\\\\(t|r|n|f|b|\\\"|\\\\)",
+          "name": "constant.character.escape.gradle-dcl"
+        }
+      ]
+    },
+    "numeric": {
+      "patterns": [
+        {
+          "match": "\\b([0-9]+)\\b",
+          "name": "constant.numeric.gradle-dcl"
+        }
+      ]
+    },
+    "character": {
+      "patterns": [
+        {
+          "match": "'\\\\?.'",
+          "name": "string.quoted.single.gradle-dcl",
+          "captures": {
+            "0": {
+              "patterns": [
+                {
+                  "include": "#escape",
+                  "name": "constant.character.escape.gradle-dcl"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "string": {
+      "$comment": [
+        ""
+      ],
+      "patterns": [
+        {
+          "name": "string.quoted.triple.gradle-dcl",
+          "begin": "\"\"\"",
+          "end": "\"\"\"",
+          "patterns": [
+            {
+              "include": "#escape"
+            }
+          ]
+        },
+        {
+          "match": "\".*\"",
+          "name": "string.quoted.double.gradle-dcl",
+          "captures": {
+            "0": {
+              "patterns": [
+                {
+                  "include": "#escape"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "boolean": {
+      "patterns": [
+        {
+          "match": "\\b(true|false)\\b",
+          "name": "constant.language.gradle-dcl"
+        }
+      ]
+    },
+    "constant": {
+      "patterns": [
+        {
+          "include": "#numeric"
+        },
+        {
+          "include": "#character"
+        },
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#boolean"
+        }
+      ]
+    },
+    "function": {
+      "patterns": [
+        {
+          "name": "support.function",
+          "begin": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\s*\\(",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.function.gradle-dcl"
+            }
+          },
+          "end": "\\)",
+          "patterns": [
+            {
+              "include": "#constant"
+            },
+            {
+              "include": "#function"
+            },
+            {
+              "match": "[a-zA-Z][a-zA-Z0-9]*",
+              "name": "variable.parameter.gradle-dcl"
+            },
+            {
+              "match": ",",
+              "name": "punctuation.separator.gradle-dcl"
+            }
+          ]
+        }
+      ]
+    },
+    "assignment": {
+      "name": "keyword.operator.assignment.gradle-dcl",
+      "match": "\\b([a-zA-Z][a-zA-Z0-9_]*)\\s*=\\s*([0-9]+|\\S+)",
+      "captures": {
+        "1": {
+          "name": "variable.name.gradle-dcl"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#constant"
+            },
+            {
+              "include": "#function"
+            }
+          ]
+        }
+      }
+    },
+    "block": {
+      "patterns": [
+        {
+          "name": "entity.gradle-dcl",
+          "begin": "\\b([a-zA-Z][a-zA-Z0-9]*)?\\s*\\{",
+          "beginCaptures": {
+            "1": {
+              "name": "entity.name.tag.gradle-dcl"
+            }
+          },
+          "end": "\\}",
+          "patterns": [
+            {
+              "include": "$base"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/org.eclipse.buildship.dcl.provider/language-configuration.json
+++ b/org.eclipse.buildship.dcl.provider/language-configuration.json
@@ -1,0 +1,28 @@
+{
+  "comments": {
+    "lineComment": "//",
+    "blockComment": ["/*", "*/"]
+  },
+  // symbols used as brackets
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  // symbols that are auto closed when typing
+  "autoClosingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ],
+  // symbols that can be used to surround a selection
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"],
+    ["\"", "\""],
+    ["'", "'"]
+  ]
+}

--- a/org.eclipse.buildship.dcl.provider/plugin.xml
+++ b/org.eclipse.buildship.dcl.provider/plugin.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.core.contenttype.contentTypes">
+      <content-type
+            base-type="org.eclipse.core.runtime.text"
+            file-patterns="*.gradle.dcl"
+            id="org.eclipse.buildship.dcl.content"
+            name="Declarative Gradle"
+            priority="normal">
+      </content-type>
+   </extension>
+   <extension
+         point="org.eclipse.tm4e.registry.grammars">
+      <grammar
+            path="gradle-dcl.tmLanguage.json"
+            scopeName="source.gradle.dcl">
+      </grammar>
+      <scopeNameContentTypeBinding
+            contentTypeId="org.eclipse.buildship.dcl.content"
+            scopeName="source.gradle.dcl">
+      </scopeNameContentTypeBinding>
+   </extension>
+   <extension
+         point="org.eclipse.tm4e.languageconfiguration.languageConfigurations">
+      <languageConfiguration
+            contentTypeId="org.eclipse.buildship.dcl.content"
+            path="language-configuration.json">
+      </languageConfiguration>
+   </extension>
+   <extension
+         point="org.eclipse.ui.editors">
+      <editorContentTypeBinding
+            contentTypeId="org.eclipse.buildship.dcl.content"
+            editorId="org.eclipse.ui.genericeditor.GenericEditor">
+      </editorContentTypeBinding>
+   </extension>
+   <extension
+         point="org.eclipse.lsp4e.languageServer">
+      <server
+            class="org.eclipse.buildship.dcl.provider.DeclarativeGradleConnectionProvider"
+            id="org.eclipse.buildship.dcl.provider.server"
+            label="Declarative Gradle Language Server">
+      </server>
+      <contentTypeMapping
+            contentType="org.eclipse.buildship.dcl.content"
+            id="org.eclipse.buildship.dcl.provider.server">
+      </contentTypeMapping>
+   </extension>
+</plugin>

--- a/org.eclipse.buildship.dcl.provider/src/main/java/org/eclipse/buildship/dcl/provider/DeclarativeGradleConnectionProvider.java
+++ b/org.eclipse.buildship.dcl.provider/src/main/java/org/eclipse/buildship/dcl/provider/DeclarativeGradleConnectionProvider.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Gradle Inc. and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ******************************************************************************/
+package org.eclipse.buildship.dcl.provider;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.eclipse.buildship.core.internal.CorePlugin;
+import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.JavaRuntime;
+import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
+import org.eclipse.lsp4e.server.ProcessStreamConnectionProvider;
+import org.eclipse.lsp4e.server.StreamConnectionProvider;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.PlatformUI;
+
+public class DeclarativeGradleConnectionProvider extends ProcessStreamConnectionProvider implements StreamConnectionProvider {
+
+    private static ILog log;
+
+    public static ILog getLog() {
+        if (log == null) {
+            Bundle bundle = FrameworkUtil.getBundle(DeclarativeGradleConnectionProvider.class);
+            log = Platform.getLog(bundle);
+        }
+        return log;
+    }
+
+    @SuppressWarnings("restriction")
+    public DeclarativeGradleConnectionProvider() {
+        Bundle bundle = FrameworkUtil.getBundle(DeclarativeGradleConnectionProvider.class);
+        try {
+            URL localFileURL = FileLocator.toFileURL(bundle.getEntry("/"));
+            Path pathToPlugin = Paths.get(localFileURL.toURI());
+
+            // Get the LSP JAR path
+            final String lspJarPath = CorePlugin.configurationManager().loadWorkspaceConfiguration().getLspJarPath();
+            if (lspJarPath.isBlank()) {
+                throw new RuntimeException("LSP JAR path is not set!");
+            }
+
+            IExecutionEnvironment[] executionEnvironments = JavaRuntime.getExecutionEnvironmentsManager().getExecutionEnvironments();
+            IExecutionEnvironment java11Environment = null;
+
+            for (IExecutionEnvironment environment : executionEnvironments) {
+                if (environment.getId().equals("JavaSE-11")) {
+                    java11Environment = environment;
+                    break;
+                }
+            }
+
+            ArrayList<IVMInstall> compatibleJVMs = new ArrayList<>(Arrays.asList(java11Environment.getCompatibleVMs()));
+            IVMInstall defaultVMInstall = JavaRuntime.getDefaultVMInstall();
+            IVMInstall javaExecutable = null;
+
+            if (!compatibleJVMs.isEmpty()) {
+                if (compatibleJVMs.contains(defaultVMInstall)) {
+                    javaExecutable = defaultVMInstall;
+                } else {
+                    javaExecutable = compatibleJVMs.get(0);
+                }
+
+                String pathToJavaExecutable = javaExecutable.getInstallLocation().toPath().resolve("bin").resolve("java").toString();
+
+                List<String> commands = Arrays.asList(
+                        pathToJavaExecutable,
+                        //"-agentlib:jdwp=transport=dt_socket,server=n,address=localhost:5015,suspend=y",
+                        "-jar", lspJarPath);
+
+                // add in commands path to bin application of language server
+                setCommands(commands);
+                setWorkingDirectory(pathToPlugin.toString());
+
+                // Write to the output that we are starting the server
+                System.out.println("Starting server with commands: " + commands);
+            } else {
+                PlatformUI.getWorkbench().getDisplay().syncExec(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        Shell shell = new Shell();
+                        MessageBox messageBox = new MessageBox(shell, SWT.ICON_WARNING | SWT.OK);
+                        messageBox.setText("Error");
+                        messageBox.setMessage("Compatible version of Java isn't found! Install and rerun application.");
+                        messageBox.open();
+                        shell.dispose();
+                    }
+                });
+            }
+
+        } catch (IOException | URISyntaxException e) {
+            System.err.println("[GradlePropertiesConnectionProvider]:" + e.toString());
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/org.eclipse.buildship.site/build.gradle
+++ b/org.eclipse.buildship.site/build.gradle
@@ -46,9 +46,10 @@ dependencies {
     if (findProperty('latest') == 'true') {
         localPlugin project(':org.eclipse.buildship.gradleprop.provider')
         localFeature project(':org.eclipse.buildship.gradleprop.feature')
-
         localPlugin project(':org.eclipse.buildship.kotlindsl.provider')
         localFeature project(':org.eclipse.buildship.kotlindsl.feature')
+        localPlugin project(':org.eclipse.buildship.dcl.provider')
+        localFeature project(':org.eclipse.buildship.dcl.feature')
     }
     if (findProperty('include.experimental.features') == 'true') {
         localPlugin project(':org.eclipse.buildship.kotlin')

--- a/org.eclipse.buildship.site/category.xml
+++ b/org.eclipse.buildship.site/category.xml
@@ -15,6 +15,9 @@
    <feature id="org.eclipse.buildship.kotlindsl">
       <category name="BuildshipExtrasIncubating"/>
    </feature>
+   <feature url="features/org.eclipse.buildship.dcl_0.0.0.jar" id="org.eclipse.buildship.dcl" version="0.0.0">
+      <category name="BuildshipExtrasIncubating"/>
+   </feature>
    <category-def name="Buildship" label="Buildship: Eclipse Plug-ins for Gradle"/>
    <category-def name="BuildshipExtras" label="Buildship Extras"/>
    <category-def name="BuildshipExtrasIncubating" label="Buildship Extras - Incubating"/>

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/preferences/GradleExperimentalFeaturesPreferencePage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/preferences/GradleExperimentalFeaturesPreferencePage.java
@@ -13,9 +13,13 @@ import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.preference.PreferencePage;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
@@ -34,6 +38,13 @@ public final class GradleExperimentalFeaturesPreferencePage extends PreferencePa
     public static final String PAGE_ID = "org.eclipse.buildship.ui.preferences.experimental";
     private Button enableModuleSuppotCheckbox;
     private Button enableProblemApiCheckbox;
+    // Horizontal container for the text field and the browse button
+    private Composite lspPathContainer;
+    // Label for the text field
+    private Text lspJarPathLabel;
+    private Text lspJarPath;
+    private Button lspJarPathBrowseButton;
+
 
     @Override
     public void init(IWorkbench workbench) {
@@ -43,6 +54,7 @@ public final class GradleExperimentalFeaturesPreferencePage extends PreferencePa
     protected Control createContents(Composite parent) {
         Composite composite = new Composite(parent, SWT.NONE);
         GridLayoutFactory.swtDefaults().numColumns(1).applyTo(composite);
+        GridDataFactory.swtDefaults().align(SWT.FILL, SWT.FILL).grab(true, true).applyTo(composite);
 
         this.enableModuleSuppotCheckbox = new Button(composite, SWT.CHECK);
         this.enableModuleSuppotCheckbox.setText(CoreMessages.Preference_Label_ModulePath);
@@ -56,6 +68,35 @@ public final class GradleExperimentalFeaturesPreferencePage extends PreferencePa
         GridDataFactory.swtDefaults().align(SWT.FILL, SWT.TOP).grab(true, false).applyTo(this.enableProblemApiCheckbox);
         HoverText.createAndAttach(this.enableProblemApiCheckbox, CoreMessages.Preference_Label_ProblemsApiSupportHover);
 
+        this.lspPathContainer = new Composite(composite, SWT.NONE);
+        GridLayoutFactory.swtDefaults().numColumns(3).applyTo(this.lspPathContainer);
+        GridDataFactory.swtDefaults().align(SWT.FILL, SWT.TOP).grab(true, false).applyTo(this.lspPathContainer);
+
+        this.lspJarPathLabel = new Text(this.lspPathContainer, SWT.READ_ONLY);
+        this.lspJarPathLabel.setText(CoreMessages.Preference_Label_LspJarPath);
+        GridDataFactory.swtDefaults().align(SWT.LEFT, SWT.CENTER).grab(false, false).applyTo(this.lspJarPathLabel);
+
+        this.lspJarPath = new Text(this.lspPathContainer, SWT.BORDER);
+        this.lspJarPath.setText(CorePlugin.configurationManager().loadWorkspaceConfiguration().getLspJarPath());
+        GridDataFactory.swtDefaults().align(SWT.FILL, SWT.CENTER).grab(true, false).applyTo(this.lspJarPath);
+
+        this.lspJarPathBrowseButton = new Button(this.lspPathContainer, SWT.PUSH);
+        this.lspJarPathBrowseButton.setText(CoreMessages.Preference_Label_LspJarBrowse);
+        GridDataFactory.swtDefaults().align(SWT.RIGHT, SWT.CENTER).grab(false, false).applyTo(this.lspJarPathBrowseButton);
+
+        this.lspJarPathBrowseButton.addSelectionListener(new SelectionAdapter() {
+
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                FileDialog dialog = new FileDialog(getShell(), SWT.OPEN);
+                dialog.setFilterExtensions(new String[] { "lsp-all.jar" });
+                String path = dialog.open();
+                if (path != null) {
+                    GradleExperimentalFeaturesPreferencePage.this.lspJarPath.setText(path);
+                }
+            }
+        });
+
         return composite;
     }
 
@@ -64,7 +105,7 @@ public final class GradleExperimentalFeaturesPreferencePage extends PreferencePa
         ConfigurationManager manager = CorePlugin.configurationManager();
         WorkspaceConfiguration c = manager.loadWorkspaceConfiguration();
         manager.saveWorkspaceConfiguration(new WorkspaceConfiguration(c.getGradleDistribution(), c.getGradleUserHome(), c.getJavaHome(), c.isOffline(), c.isBuildScansEnabled(),
-                c.isAutoSync(), c.getArguments(), c.getJvmArguments(), c.isShowConsoleView(), c.isShowExecutionsView(), this.enableModuleSuppotCheckbox.getSelection(), this.enableProblemApiCheckbox.getSelection()));
+                c.isAutoSync(), c.getArguments(), c.getJvmArguments(), c.isShowConsoleView(), c.isShowExecutionsView(), this.enableModuleSuppotCheckbox.getSelection(), this.enableProblemApiCheckbox.getSelection(), this.lspJarPath.getText()));
         return true;
     }
 }

--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/preferences/GradleWorkbenchPreferencePage.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/preferences/GradleWorkbenchPreferencePage.java
@@ -43,6 +43,7 @@ public final class GradleWorkbenchPreferencePage extends PreferencePage implemen
     private GradleProjectSettingsComposite gradleProjectSettingsComposite;
     private boolean experimentalModuleSupportEnabled;
     private boolean problemsApiSupportEnabled;
+    private String lspJarPath;
 
 
     public GradleWorkbenchPreferencePage() {
@@ -78,6 +79,7 @@ public final class GradleWorkbenchPreferencePage extends PreferencePage implemen
         this.gradleProjectSettingsComposite.getShowExecutionsViewCheckbox().setSelection(config.isShowExecutionsView());
         this.experimentalModuleSupportEnabled = config.isExperimentalModuleSupportEnabled();
         this.problemsApiSupportEnabled = config.isProblemsApiSupportEnabled();
+        this.lspJarPath = config.getLspJarPath();
     }
 
     private void addListeners() {
@@ -101,7 +103,7 @@ public final class GradleWorkbenchPreferencePage extends PreferencePage implemen
         List<String> jvmArguments = this.gradleProjectSettingsComposite.getAdvancedOptionsGroup().getJvmArguments();
         boolean showConsoleView = this.gradleProjectSettingsComposite.getShowConsoleViewCheckbox().getSelection();
         boolean showExecutionsView = this.gradleProjectSettingsComposite.getShowExecutionsViewCheckbox().getSelection();
-        WorkspaceConfiguration workspaceConfig = new WorkspaceConfiguration(distribution, gradleUserHome, javaHome, offlineMode, buildScansEnabled, autoSync, arguments, jvmArguments, showConsoleView, showExecutionsView, this.experimentalModuleSupportEnabled, this.problemsApiSupportEnabled);
+        WorkspaceConfiguration workspaceConfig = new WorkspaceConfiguration(distribution, gradleUserHome, javaHome, offlineMode, buildScansEnabled, autoSync, arguments, jvmArguments, showConsoleView, showExecutionsView, this.experimentalModuleSupportEnabled, this.problemsApiSupportEnabled, this.lspJarPath);
         CorePlugin.configurationManager().saveWorkspaceConfiguration(workspaceConfig);
         return super.performOk();
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,6 @@
 // publish build scans from CI builds
 plugins {
-    id "com.gradle.develocity" version "3.17.6"
+    id "com.gradle.develocity" version "3.18.1"
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
@@ -8,9 +8,16 @@ plugins {
 def isCI = System.getenv('CI') != null
 
 develocity {
-    server = "https://ge.gradle.org"
+    server = "https://develocity-staging.eclipse.org"
     buildScan {
-        publishing.onlyIf { isCI }
+        publishing.onlyIf { true }
+        obfuscation {
+            username { name -> isCI ? 'ci' : 'local' }
+            ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0" } }
+            externalProcessName { processName -> "non-build-process" }
+            hostname { host -> isCI ? 'ci' : 'local' }
+
+        }
         uploadInBackground = !isCI
     }
 }
@@ -33,6 +40,8 @@ if (properties['latest'] == 'true') {
     include ':org.eclipse.buildship.gradleprop.feature'
     include ':org.eclipse.buildship.kotlindsl.provider'
     include ':org.eclipse.buildship.kotlindsl.feature'
+    include ':org.eclipse.buildship.dcl.feature'
+    include ':org.eclipse.buildship.dcl.provider'
     include ':org.eclipse.buildship.gradleprop.test'
 }
 


### PR DESCRIPTION
### Context

Declarative Gradle introduces a new file format `dcl`.
As this file is based on our DCL language, we need extra tooling to support it.

Currently, we are developing an [LSP](https://github.com/gradle/declarative-lsp) to handle the file, and this PR introduces a new plugin using this server.