### PR TITLE
Adapt Build Scan publication message parsing

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/console/BuildScanPatternMatchListener.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/console/BuildScanPatternMatchListener.java
@@ -59,7 +59,7 @@ public final class BuildScanPatternMatchListener implements IPatternMatchListene
 
     @Override
     public String getPattern() {
-        return "Publishing build [information|scan].*\\s+" + PatternUtils.WEB_URL_PATTERN;
+        return "Publishing (?:build information|build scan|Build Scan).*\\s+" + PatternUtils.WEB_URL_PATTERN;
     }
 
     @Override


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes https://github.com/eclipse-buildship/buildship/issues/1347


### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Recent Develocity Gradle plugin versions log a slightly different text:
"Publishing Build Scan..." 

I'm not sure if it's covered already by tests...
