### PR TITLE
Adapt Build Scan publication message parsing

### DIFF
--- a/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/console/BuildScanPatternMatchListener.java
+++ b/org.eclipse.buildship.ui/src/main/java/org/eclipse/buildship/ui/internal/console/BuildScanPatternMatchListener.java
@@ -59,7 +59,7 @@ public final class BuildScanPatternMatchListener implements IPatternMatchListene
 
     @Override
     public String getPattern() {
-        return "Publishing build [information|scan].*\\s+" + PatternUtils.WEB_URL_PATTERN;
+        return "Publishing (Build Scan|build scan|build information)(?: to Develocity)?\\.\\.\\." + PatternUtils.WEB_URL_PATTERN;
     }
 
     @Override


### PR DESCRIPTION
(updated version of this Draft PR - https://github.com/eclipse-buildship/buildship/pull/1346)

Fixes https://github.com/eclipse-buildship/buildship/issues/1347

Context
Recent Develocity Gradle plugin versions log a slightly different text:
"Publishing Build Scan to Develocity..."

I'm not sure if it's covered already by tests...