### PR TITLE
remove project search on isNeeded in customGradleImport

### DIFF
--- a/org.eclipse.buildship.oomph/src/main/java/org/eclipse/buildship/oomph/impl/CustomGradleImportTaskImpl.java
+++ b/org.eclipse.buildship.oomph/src/main/java/org/eclipse/buildship/oomph/impl/CustomGradleImportTaskImpl.java
@@ -50,9 +50,6 @@ public class CustomGradleImportTaskImpl extends GradleImportTaskImpl {
         if (sourceLocators.isEmpty()) {
             return false;
         }
-        if (context.getTrigger() != Trigger.MANUAL) {
-            return !calculateProjectsToImport().isEmpty();
-        }
         return true;
     }
 


### PR DESCRIPTION
<!--- The issue this PR addresses -->
Fixes #1319 

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

When installing a fresh Eclipse install via Oomph, users will likely "git clone" then afterwards "gradle import" as part of the `STARTUP` stage of the install.

`isNeeded()` is called as part of a preliminary check before running any `STARTUP` tasks. The `isNeeded` for the Gradle Import task is looking for projects to import on the filesystem before continuing, however, this is always going to fail when its a fresh install, because the repository containing the projects hasn't been cloned yet - oomph will clone as part of the STARTUP tasks, then it gradle imports directly afterwards.

Is there any need to even do this check in `isNeeded`? I don't think so. If this task is configured to be part of a STARTUP task, then its almost always needed, we don't need to check.
the `perform` task re-runs `calculateProjectsToImport` so it will either fail as it currently does at this point later if it cannot still find the project post-clone, or an empty list is returned, meaning it gracefully doesn't import anything
