### PR TITLE
Remove Develocity configuration

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,8 +18,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Sanity check"
@@ -54,8 +52,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Basic test coverage"
@@ -83,8 +79,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Full test coverage"
@@ -107,8 +101,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Cross-version test coverage"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Sanity check"
@@ -45,8 +43,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Basic test coverage"
@@ -73,8 +69,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          develocity-access-key: ${{ secrets.DEVELOCITY_API_TOKEN }}
       - uses: ./.github/actions/run-build
         with:
           name: "Full test coverage"

--- a/build.gradle
+++ b/build.gradle
@@ -71,15 +71,6 @@ eclipseBuild {
     commitId = currentCommitId()
 }
 
-def develocityApi = project.extensions.findByName('develocity')
-if (develocityApi) {
-    def eclipseVersion = Config.on(project).getTargetPlatform().getEclipseVersion()
-    develocityApi.getBuildScan().tag("eclipse_${eclipseVersion}")
-    if (project.hasProperty('eclipse.test.java.version')) {
-        develocityApi.getBuildScan().tag("eclipseTestJdk_${project.getProperty('eclipse.test.java.version')}")
-    }
-}
-
 // read the current version from an external file and add a timestamp suffix if requested by the caller
 ext.baseVersion = file('version.txt').text.trim()
 ext.versionQualifier = getVersionQualifier()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,27 +1,3 @@
-// publish build scans from CI builds
-plugins {
-    id "com.gradle.develocity" version "3.19.2"
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.1'
-}
-
-
-def isCI = System.getenv('CI') != null
-
-develocity {
-    server = "https://develocity-staging.eclipse.org"
-    allowUntrustedServer = false // ensure a trusted certificate is configured
-    buildScan {
-        publishing.onlyIf { it.isAuthenticated() }
-        obfuscation {
-            username { name -> isCI ? 'ci' : 'local' }
-            ipAddresses { addresses -> addresses.collect { address -> "0.0.0.0" } }
-            externalProcessName { processName -> "non-build-process" }
-            hostname { host -> isCI ? 'ci' : 'local' }
-        }
-        uploadInBackground = !isCI
-    }
-}
-
 rootProject.name = 'buildship'
 
 include ':org.gradle.toolingapi'
@@ -49,14 +25,3 @@ include ':org.eclipse.buildship.oomph.edit'
 include ':org.eclipse.buildship.oomph.feature'
 include ':org.eclipse.buildship.oomph.test'
 
-buildCache {
-    local {
-        enabled = !isCI
-    }
-
-    remote(develocity.buildCache) {
-        enabled = true
-        push = isCI
-    }
-
-}


### PR DESCRIPTION
The Eclipse Foundation has announced the discontinuation of the Develocity service offering (see [announcement](https://www.eclipse.org/lists/eclipse.org-committers/msg01557.html)).

This PR removes the Develocity configuration that was added in #1328.